### PR TITLE
Adds routing filter mechanism

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,4 @@
+API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3018","xi":"http://localhost:3019" }
+SERVICE_DEFAULT=uk
+PORT=3003
+ADMIN_HOST='http://localhost:3018'

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,3 @@
+API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3018","xi":"http://localhost:3019" }
+SERVICE_DEFAULT=uk
+ADMIN_HOST='http://test.host'

--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,6 @@ REVISION
 public/uploads/*
 .nvimlog
 vendor
-.env.*
+.env
+.env.*.local
 /node_modules

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ ruby File.read('.ruby-version').chomp
 # Server
 gem 'puma'
 gem 'rails', '~> 6'
+gem 'routing-filter', github: 'svenfuchs/routing-filter'
 
 # DB
 gem 'pg'

--- a/Gemfile
+++ b/Gemfile
@@ -62,6 +62,7 @@ gem 'nokogiri', '>= 1.10.10'
 group :development, :test do
   gem 'brakeman'
   gem 'dotenv-rails'
+  gem 'pry-byebug'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
       sassc (>= 2.0.0)
     brakeman (5.0.1)
     builder (3.2.4)
+    byebug (11.1.3)
     capybara (3.35.3)
       addressable
       mini_mime (>= 0.1.3)
@@ -95,6 +96,7 @@ GEM
     ci_reporter_rspec (1.0.0)
       ci_reporter (~> 2.0)
       rspec (>= 2.14, < 4)
+    coderay (1.1.3)
     coffee-rails (5.0.0)
       coffee-script (>= 2.2.0)
       railties (>= 5.2.0)
@@ -265,6 +267,12 @@ GEM
       ast (~> 2.4.1)
     pg (1.2.3)
     plek (4.0.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-byebug (3.9.0)
+      byebug (~> 11.0)
+      pry (~> 0.13.0)
     public_suffix (4.0.6)
     puma (5.3.1)
       nio4r (~> 2.0)
@@ -478,6 +486,7 @@ DEPENDENCIES
   oj
   pg
   plek
+  pry-byebug
   puma
   pundit
   rails (~> 6)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+GIT
+  remote: https://github.com/svenfuchs/routing-filter.git
+  revision: 8d1f1da79c4db786e8baeda586a8d790e23712bf
+  specs:
+    routing-filter (0.6.3)
+      actionpack (>= 6.1)
+      activesupport (>= 6.1)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -476,6 +484,7 @@ DEPENDENCIES
   redis
   redis-activesupport
   responders
+  routing-filter!
   rspec-rails
   rspec_junit_formatter
   rubocop-govuk

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,0 +1,13 @@
+module ServiceHelper
+  def switch_service_link
+    return link_to('Switch to XI service', "/xi#{current_path}") if TradeTariffAdmin::ServiceChooser.uk?
+
+    link_to('Switch to UK service', current_path)
+  end
+
+  private
+
+  def current_path
+    request.filtered_path.sub("/#{TradeTariffAdmin::ServiceChooser.service_choice}", '')
+  end
+end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -8,6 +8,6 @@ module ServiceHelper
   private
 
   def current_path
-    request.filtered_path.sub("/#{TradeTariffAdmin::ServiceChooser.service_choice}", '')
+    request.filtered_path.sub(TradeTariffAdmin::ServiceChooser.service_choice.to_s, '').sub('//', '/')
   end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,6 +25,7 @@
       </span>
       <ul class="dropdown-menu">
         <li><%= link_to 'Sign out', gds_sign_out_path %></li>
+        <li><%= switch_service_link %></li>
       </ul>
     </li>
   </ul>

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,6 @@ module TradeTariffAdmin
     config.autoloader = :classic
 
     require 'trade_tariff_admin'
-    require 'faraday_middleware/service_urls'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,9 +8,6 @@ Bundler.require(*Rails.groups)
 
 APP_SLUG = 'trade-tariff-admin'.freeze
 
-require 'trade_tariff_admin'
-require 'trade_tariff_admin/service_chooser'
-
 module TradeTariffAdmin
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -18,6 +15,8 @@ module TradeTariffAdmin
 
     config.autoloader = :classic
 
+    require 'trade_tariff_admin'
+    require 'trade_tariff_admin/service_chooser'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,7 @@ module TradeTariffAdmin
     config.autoloader = :classic
 
     require 'trade_tariff_admin'
+    require 'faraday_middleware/service_urls'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/application.rb
+++ b/config/application.rb
@@ -8,6 +8,9 @@ Bundler.require(*Rails.groups)
 
 APP_SLUG = 'trade-tariff-admin'.freeze
 
+require 'trade_tariff_admin'
+require 'trade_tariff_admin/service_chooser'
+
 module TradeTariffAdmin
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
@@ -15,7 +18,6 @@ module TradeTariffAdmin
 
     config.autoloader = :classic
 
-    require 'trade_tariff_admin'
 
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers

--- a/config/initializers/her.rb
+++ b/config/initializers/her.rb
@@ -1,12 +1,13 @@
-# order of included modules does matter: first included last executed
+# order of used middleware matters: first used last executed
 Her::API.setup url: Rails.application.config.api_host do |c|
   # Request
+  c.use FaradayMiddleware::ServiceUrls
   c.use Faraday::Request::UrlEncoded
-  c.use Her::Middleware::BearerTokenAuthentication, ENV['BEARER_TOKEN'] || 'tariff-api-test-token' # lib/her/middleware/bearer_token_authentication.rb
+  c.use Her::Middleware::BearerTokenAuthentication, ENV['BEARER_TOKEN'] || 'tariff-api-test-token'
 
   # Response
-  c.use Her::Middleware::HeaderMetadataParse  # lib/her/middleware/header_metadata_parse.rb
-  c.use Her::Middleware::TariffJsonapiParser  # lib/her/middleware/tariff_jsonapi_parser.rb
+  c.use Her::Middleware::HeaderMetadataParse
+  c.use Her::Middleware::TariffJsonapiParser
 
   # Adapter
   c.adapter Faraday::Adapter::NetHttp

--- a/config/initializers/her.rb
+++ b/config/initializers/her.rb
@@ -1,3 +1,5 @@
+require 'faraday_middleware/service_urls'
+
 # order of used middleware matters: first used last executed
 Her::API.setup url: Rails.application.config.api_host do |c|
   # Request

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,12 @@
 require 'sidekiq/web'
 require 'sidekiq-scheduler/web'
 require 'gds_editor_constraint'
+require 'routing_filter/service_path_prefix_handler'
 
 Rails.application.routes.draw do
+  filter :service_path_prefix_handler
+  default_url_options(host: TradeTariffAdmin.host)
+
   namespace :notes, module: :notes do
     resources :sections, only: %i[index show] do
       scope module: 'sections' do

--- a/lib/faraday_middleware/service_urls.rb
+++ b/lib/faraday_middleware/service_urls.rb
@@ -3,15 +3,10 @@ require 'faraday'
 module FaradayMiddleware
   class ServiceUrls < Faraday::Middleware
     def call(env)
+      service_uri = URI(TradeTariffAdmin::ServiceChooser.api_host)
       env.url.host = service_uri.host
       env.url.port = service_uri.port
       @app.call(env)
-    end
-
-    private
-
-    def service_uri
-      @service_uri ||= URI(TradeTariffAdmin::ServiceChooser.api_host)
     end
   end
 end

--- a/lib/faraday_middleware/service_urls.rb
+++ b/lib/faraday_middleware/service_urls.rb
@@ -1,0 +1,17 @@
+require 'faraday'
+
+module FaradayMiddleware
+  class ServiceUrls < Faraday::Middleware
+    def call(env)
+      env.url.host = service_uri.host
+      env.url.port = service_uri.port
+      @app.call(env)
+    end
+
+    private
+
+    def service_uri
+      @service_uri ||= URI(TradeTariffAdmin::ServiceChooser.api_host)
+    end
+  end
+end

--- a/lib/routing_filter/service_path_prefix_handler.rb
+++ b/lib/routing_filter/service_path_prefix_handler.rb
@@ -1,0 +1,42 @@
+require 'trade_tariff_admin'
+
+module RoutingFilter
+  class ServicePathPrefixHandler < Filter
+    SERVICE_CHOICE_PREFIXES =
+      ::TradeTariffAdmin::ServiceChooser.service_choices
+                                           .keys
+                                           .map { |prefix| Regexp.escape(prefix) }
+                                           .join('|')
+                                           .freeze
+
+    SERVICE_CHOICE_PREFIXES_REGEX = %r{^/(#{SERVICE_CHOICE_PREFIXES})(?=/|$)}.freeze
+
+    # Recognising paths
+    def around_recognize(path, _env)
+      service_choice = extract_segment!(SERVICE_CHOICE_PREFIXES_REGEX, path)
+
+      ::TradeTariffAdmin::ServiceChooser.service_choice = service_choice
+
+      yield
+    end
+
+    # Rendering links
+    def around_generate(_params)
+      yield.tap do |result, _params|
+        service_choice = ::TradeTariffAdmin::ServiceChooser.service_choice
+
+        if service_choice.present? && service_choice != service_choice_default
+          prepended_url = prepend_segment(result.url, service_choice)
+
+          result.update(prepended_url)
+        end
+      end
+    end
+
+    private
+
+    def service_choice_default
+      ::TradeTariffAdmin::ServiceChooser.service_default
+    end
+  end
+end

--- a/lib/trade_tariff_admin.rb
+++ b/lib/trade_tariff_admin.rb
@@ -4,6 +4,7 @@ require 'her/middleware/accept_api_v2'
 require 'her/middleware/tariff_jsonapi_parser'
 require 'redis_resolver'
 
+
 module TradeTariffAdmin
   class << self
     def host
@@ -12,42 +13,6 @@ module TradeTariffAdmin
 
     def production?
       ENV['GOVUK_APP_DOMAIN'] == 'tariff-admin-production.cloudapps.digital'
-    end
-  end
-
-  module ServiceChooser
-    class << self
-      def service_default
-        ENV.fetch('SERVICE_DEFAULT', 'uk')
-      end
-
-      def service_choices
-        @service_choices ||= JSON.parse(ENV['API_SERVICE_BACKEND_URL_OPTIONS'])
-      end
-
-      def service_choice=(service_choice)
-        Thread.current[:service_choice] = service_choice
-      end
-
-      def service_choice
-        Thread.current[:service_choice]
-      end
-
-      def api_host
-        host = service_choices[service_choice]
-
-        return service_choices[service_default] if host.blank?
-
-        host
-      end
-
-      def uk?
-        (service_choice || service_default) == 'uk'
-      end
-
-      def xi?
-        service_choice == 'xi'
-      end
     end
   end
 end

--- a/lib/trade_tariff_admin/service_chooser.rb
+++ b/lib/trade_tariff_admin/service_chooser.rb
@@ -1,20 +1,4 @@
-require 'her/middleware/bearer_token_authentication'
-require 'her/middleware/header_metadata_parse'
-require 'her/middleware/accept_api_v2'
-require 'her/middleware/tariff_jsonapi_parser'
-require 'redis_resolver'
-
 module TradeTariffAdmin
-  class << self
-    def host
-      ENV.fetch('ADMIN_HOST', 'http://localhost')
-    end
-
-    def production?
-      ENV['GOVUK_APP_DOMAIN'] == 'tariff-admin-production.cloudapps.digital'
-    end
-  end
-
   module ServiceChooser
     class << self
       def service_default

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -37,6 +37,15 @@ describe ServiceHelper, type: :helper do
       it 'returns the link to the current UK service' do
         expect(switch_service_link).to eq(link_to('Switch to UK service', '/rollbacks/new'))
       end
+
+      context 'when using the root path' do
+        let(:path) { '/xi' }
+        let(:choice) { 'xi' }
+
+        it 'returns the link to the current UK service' do
+          expect(switch_service_link).to eq(link_to('Switch to UK service', '/'))
+        end
+      end
     end
   end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -12,6 +12,15 @@ describe ServiceHelper, type: :helper do
       allow(helper).to receive(:request).and_return(request)
     end
 
+    context 'when the selected service choice is nil' do
+      let(:path) { '/rollbacks/new' }
+      let(:choice) { nil }
+
+      it 'returns the link to the XI service' do
+        expect(switch_service_link).to eq(link_to('Switch to XI service', '/xi/rollbacks/new'))
+      end
+    end
+
     context 'when the selected service choice is uk' do
       let(:path) { '/uk/rollbacks/new' }
       let(:choice) { 'uk' }

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+describe ServiceHelper, type: :helper do
+  before do
+    allow(TradeTariffAdmin::ServiceChooser).to receive(:service_choice).and_return(choice)
+  end
+
+  describe '.switch_service_link' do
+    let(:request) { double('request', filtered_path: path) }
+
+    before do
+      allow(helper).to receive(:request).and_return(request)
+    end
+
+    context 'when the selected service choice is uk' do
+      let(:path) { '/uk/rollbacks/new' }
+      let(:choice) { 'uk' }
+
+      it 'returns the link to the XI service' do
+        expect(switch_service_link).to eq(link_to('Switch to XI service', '/xi/rollbacks/new'))
+      end
+    end
+
+    context 'when the selected service choice is xi' do
+      let(:path) { '/xi/rollbacks/new' }
+      let(:choice) { 'xi' }
+
+      it 'returns the link to the current UK service' do
+        expect(switch_service_link).to eq(link_to('Switch to UK service', '/rollbacks/new'))
+      end
+    end
+  end
+end

--- a/spec/lib/faraday_middleware/service_urls_spec.rb
+++ b/spec/lib/faraday_middleware/service_urls_spec.rb
@@ -1,0 +1,43 @@
+require 'rails_helper'
+
+describe FaradayMiddleware::ServiceUrls do
+  subject(:response) { connection.get('http://foo') }
+
+  before do
+    stub_request(:get, expected_url)
+
+    Thread.current[:service_choice] = choice
+  end
+
+  after do
+    Thread.current[:service_choice] = nil
+  end
+
+  let(:connection) do
+    Faraday.new do |conn|
+      conn.use described_class
+      conn.adapter Faraday.default_adapter
+    end
+  end
+
+  context 'when the service choice is xi' do
+    let(:choice) { 'xi' }
+    let(:expected_url) { 'http://localhost:3019' }
+
+    it { expect(response.env[:url].to_s).to eq(expected_url) }
+  end
+
+  context 'when the service choice is uk' do
+    let(:choice) { 'uk' }
+    let(:expected_url) { 'http://localhost:3018' }
+
+    it { expect(response.env[:url].to_s).to eq(expected_url) }
+  end
+
+  context 'when the service choice is not set' do
+    let(:choice) { nil }
+    let(:expected_url) { 'http://localhost:3018' }
+
+    it { expect(response.env[:url].to_s).to eq(expected_url) }
+  end
+end

--- a/spec/lib/service_chooser_spec.rb
+++ b/spec/lib/service_chooser_spec.rb
@@ -1,0 +1,95 @@
+require 'rails_helper'
+
+describe TradeTariffAdmin::ServiceChooser do
+  after do
+    Thread.current[:service_choice] = nil
+  end
+
+  describe '.service_choices' do
+    it 'returns a Hash of url options for the services' do
+      expect(described_class.service_choices).to eq(
+        'uk' => 'http://localhost:3018',
+        'xi' => 'http://localhost:3019',
+      )
+    end
+  end
+
+  describe '.service_choice=' do
+    it 'assigns the service choice to the current Thread' do
+      expect { described_class.service_choice = 'xi' }
+        .to change { Thread.current[:service_choice] }
+        .from(nil)
+        .to('xi')
+    end
+  end
+
+  describe '.api_host' do
+    before do
+      Thread.current[:service_choice] = choice
+    end
+
+    context 'when the service choice does not have a corresponding url' do
+      let(:choice) { 'foo' }
+
+      it 'returns the default service choice url' do
+        expect(described_class.api_host).to eq('http://localhost:3018')
+      end
+    end
+
+    context 'when the service choice has a corresponding url' do
+      let(:choice) { 'xi' }
+
+      it 'returns the service choice url' do
+        expect(described_class.api_host).to eq('http://localhost:3019')
+      end
+    end
+  end
+
+  describe '.uk?' do
+    before do
+      Thread.current[:service_choice] = choice
+    end
+
+    context 'when the service choice is not set' do
+      let(:choice) { nil }
+
+      it { expect(described_class).to be_uk }
+    end
+
+    context 'when the service choice is uk' do
+      let(:choice) { 'uk' }
+
+      it { expect(described_class).to be_uk }
+    end
+
+    context 'when the service choice is xi' do
+      let(:choice) { 'xi' }
+
+      it { expect(described_class).not_to be_uk }
+    end
+  end
+
+  describe '.xi?' do
+    before do
+      Thread.current[:service_choice] = choice
+    end
+
+    context 'when the service choice is not set' do
+      let(:choice) { nil }
+
+      it { expect(described_class).not_to be_xi }
+    end
+
+    context 'when the service choice is xi' do
+      let(:choice) { 'xi' }
+
+      it { expect(described_class).to be_xi }
+    end
+
+    context 'when the service choice is uk' do
+      let(:choice) { 'uk' }
+
+      it { expect(described_class).not_to be_xi }
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -11,7 +11,7 @@ require 'rspec/rails'
 require 'pundit/rspec'
 require 'webmock/rspec'
 
-Dir[Rails.root.join('spec/support/**/*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec/support/**/*.rb')].sort.each { |f| require f }
 
 RSpec.configure do |config|
   config.raise_errors_for_deprecations!

--- a/spec/routing/service_path_prefix_handler_spec.rb
+++ b/spec/routing/service_path_prefix_handler_spec.rb
@@ -56,9 +56,6 @@ describe RoutingFilter::ServicePathPrefixHandler, type: :routing do
   end
 
   describe 'path generation' do
-    let(:commodity_id) { '0101210000' }
-    let(:service_default) { 'uk' }
-
     before do
       TradeTariffAdmin::ServiceChooser.service_choice = choice
     end

--- a/spec/routing/service_path_prefix_handler_spec.rb
+++ b/spec/routing/service_path_prefix_handler_spec.rb
@@ -1,0 +1,99 @@
+require 'rails_helper'
+
+# rubocop:disable RSpec/MultipleExpectations
+describe RoutingFilter::ServicePathPrefixHandler, type: :routing do
+  let(:path) { "#{prefix}/rollbacks" }
+
+  after do
+    Thread.current[:service_choice] = nil
+  end
+
+  describe 'matching routes' do
+    context 'when the service choice prefix is xi' do
+      let(:prefix) { '/xi' }
+
+      it 'sets the request params service choice to the xi backend' do
+        expect(get: path).to route_to(
+          controller: 'rollbacks',
+          action: 'index',
+        )
+        expect(Thread.current[:service_choice]).to eq('xi')
+      end
+    end
+
+    context 'when the service choice prefix is not present' do
+      let(:prefix) { nil }
+
+      it 'does not specify the service backend' do
+        expect(get: path).to route_to(
+          controller: 'rollbacks',
+          action: 'index',
+        )
+        expect(Thread.current[:service_choice]).to be_nil
+      end
+    end
+
+    context 'when the service choice prefix is the same as the default' do
+      let(:prefix) { '/uk' }
+
+      it 'does not set the request params service choice' do
+        expect(get: path).to route_to(
+          controller: 'rollbacks',
+          action: 'index',
+        )
+        expect(Thread.current[:service_choice]).to eq('uk')
+      end
+    end
+
+    context 'when the service choice prefix is set to an unsupported service choice' do
+      let(:prefix) { '/xixi' }
+
+      it 'routes to a not_found action in the errors controller' do
+        expect(get: path).not_to be_routable
+        expect(Thread.current[:service_choice]).to eq(nil)
+      end
+    end
+  end
+
+  describe 'path generation' do
+    let(:commodity_id) { '0101210000' }
+    let(:service_default) { 'uk' }
+
+    before do
+      TradeTariffAdmin::ServiceChooser.service_choice = choice
+    end
+
+    context 'when the service choice is not the default' do
+      let(:choice) { 'xi' }
+
+      it 'prepends the choice to the url' do
+        result = new_rollback_url(page: '1')
+
+        expect(result).to eq('http://test.host/xi/rollbacks/new?page=1')
+      end
+
+      it 'prepends the choice to the path' do
+        result = new_rollback_path(page: '1')
+
+        expect(result).to eq('/xi/rollbacks/new?page=1')
+      end
+    end
+
+    context 'when the service choice is the default' do
+      let(:choice) { 'uk' }
+
+      it 'does not prepend the choice to the url' do
+        result = new_rollback_url(page: '1')
+
+        expect(result).to eq('http://test.host/rollbacks/new?page=1')
+      end
+
+      it 'does not prepend the choice to the path' do
+        result = new_rollback_path(page: '1')
+
+        expect(result).to eq('/rollbacks/new?page=1')
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleExpectations


### PR DESCRIPTION

### Jira link

https://transformuk.atlassian.net/browse/HOTT-579

### What?

I have added/removed/altered:

- [x] Adds a routing prefix filtering mechanism for switching between tariff backends
- [x] Updates api calls to the admin api with new host choice from filtering mechanism
- [x] Adds ui component for driving change to service

### Why?

I am doing this because:

- This mechanism enables us to choose between different backends based on
on the path prefix. This is consistent with the approach to routing
taken in the frontend application previously.
- It's needed to make sure we can provide access to the HMRC team to update various aspects of the tariff on both services
