### PR TITLE
Adds staging deploy to circle ci workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ commands:
         type: string
       environment_key:
         type: string
-      app_domain_prefix:
-        type: string
       buildpack_version:
         type: string
         default: "v1.8.39"
@@ -152,7 +150,18 @@ jobs:
       - cf_deploy:
           space: "development"
           environment_key: "dev"
-          app_domain_prefix: "dev"
+      - sentry-release
+
+  deploy_staging:
+    docker:
+      - image: cimg/ruby:2.7.3-node
+    environment:
+      SENTRY_ENVIRONMENT: staging
+    steps:
+      - checkout
+      - cf_deploy:
+          space: "staging"
+          environment_key: "staging"
       - sentry-release
 
   deploy_prod:
@@ -164,7 +173,6 @@ jobs:
       - cf_deploy:
           space: "production"
           environment_key: "production"
-          app_domain_prefix: "production"
       - sentry-release
 
 workflows:
@@ -187,10 +195,18 @@ workflows:
                 - master
           requires:
             - test
+      - deploy_staging:
+          context: trade-tariff
+          filters:
+            branches:
+              only:
+                - master
       - deploy_prod:
           context: trade-tariff
           filters:
             branches:
               only:
                 - master
+          requires:
+            - deploy_staging
 

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,3 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.action_dispatch.cookies_serializer = :marshal
+Rails.application.config.action_dispatch.cookies_serializer = :json


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Adds staging deploy to admin
- [x] Migrate to json cookie serialization (this is already the standard but we also support dumped ruby objects - this is repeating what we've safely done elsewhere)

### Why?

I am doing this because:

- We want to be able to update the admin app in staging to manage updates/rollbacks
