### PR TITLE
HOTT-1034: Upgraded to puma 5.5.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -290,7 +290,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     public_suffix (4.0.6)
-    puma (5.5.0)
+    puma (5.5.2)
       nio4r (~> 2.0)
     pundit (2.1.1)
       activesupport (>= 3.0.0)


### PR DESCRIPTION
### Jira link

[HOTT-1034](https://transformuk.atlassian.net/browse/HOTT-1034)

### What?

I have added/removed/altered:

- [x] Upgraded the puma gem to 5.5.2

### Why?

I am doing this because:

- we currently have 5.5.0 which has a minor security issue in it

