### PR TITLE
HOTT-1038: Fixed pagination in synonym search references

### DIFF
--- a/app/controllers/synonyms/search_references_controller.rb
+++ b/app/controllers/synonyms/search_references_controller.rb
@@ -3,7 +3,7 @@ module Synonyms
     before_action :authorize_user
 
     def index
-      @search_references = search_reference_parent.search_references.all(page: page, per_page: per_page).reload
+      @search_references = search_reference_parent.search_references.all(page: page, per_page: per_page)
       @search_references = Kaminari.paginate_array(@search_references, total_count: @search_references.metadata[:pagination][:total]).page(page).per(per_page)
     end
 
@@ -72,7 +72,7 @@ module Synonyms
     end
 
     def per_page
-      params.fetch(:per_page, 25)
+      params.fetch(:per_page, 200)
     end
 
     def search_reference_parent


### PR DESCRIPTION
### Jira link

[HOTT-1038](https://transformuk.atlassian.net/browse/HOTT-1038)

### What?

I have added/removed/altered:

- [x] Fixed the pagination in Synonym search references
- [x] Raised the pagination limit to 200

### Why?

I am doing this because:

- The pagination was broken, and the current pagination threshold is too low.
