### PR TITLE
Handle invalid responses from the API

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -30,5 +30,9 @@ module TradeTariffAdmin
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de
     config.active_job.queue_adapter = :sidekiq
+
+    config.action_dispatch.rescue_responses.merge!(
+      'Faraday::ResourceNotFound' => :not_found,
+    )
   end
 end

--- a/config/initializers/her.rb
+++ b/config/initializers/her.rb
@@ -10,6 +10,7 @@ Her::API.setup url: Rails.application.config.api_host do |c|
   # Response
   c.use Her::Middleware::HeaderMetadataParse
   c.use Her::Middleware::TariffJsonapiParser
+  c.use Faraday::Response::RaiseError
 
   # Adapter
   c.adapter Faraday::Adapter::NetHttp


### PR DESCRIPTION
### Jira link

[HOTT-853](https://transformuk.atlassian.net/browse/HOTT-853)

### What?

I have added/removed/altered:

- [x] Added Faraday's RaiseError middlewhere to the default api client

### Why?

I am doing this because:

- Previously 404s, 500s, any other failure were being treated as legitimate responses and processed incorrectly by the api client - resulting in every error returning an 500 screen
