### PR TITLE
Support for `main` branch in CI scripts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,12 +191,14 @@ workflows:
             branches:
               ignore:
                 - master
+                - main
       - deploy_dev:
           context: trade-tariff
           filters:
             branches:
               ignore:
                 - master
+                - main
           requires:
             - test
       - deploy_staging:
@@ -205,12 +207,14 @@ workflows:
             branches:
               only:
                 - master
+                - main
       - deploy_prod:
           context: trade-tariff
           filters:
             branches:
               only:
                 - master
+                - main
           requires:
             - deploy_staging
 


### PR DESCRIPTION
### Jira link

[HOTT-1071](https://transformuk.atlassian.net/browse/HOTT-1071)

### What?

I have added/removed/altered:

- [x] Added `main` to the list of branches treated as the 'trunk' by the CI scripts

### Why?

I am doing this because:

- It is a trivial change and will allow us to rename the `master` branch to `main`

### Deployment risks (optional)

- This is a lower risk project to perform this change on as a first step
- if this breaks something it will be the deployment ability rather then the running service
- this separates the branch rename from the CI script changes so it can be verified that the script changes continue to work with the existing 'trunk' branch
