### PR TITLE
HOTT-1112 Fix for rollbacks without users

### DIFF
--- a/app/models/rollback.rb
+++ b/app/models/rollback.rb
@@ -19,7 +19,7 @@ class Rollback
   end
 
   def user
-    @user ||= User.find(user_id)
+    @user ||= User.find_by(id: user_id)
   end
 
   def initialize_errors

--- a/app/views/rollbacks/index.html.erb
+++ b/app/views/rollbacks/index.html.erb
@@ -20,7 +20,7 @@
       <% @rollbacks.each do |rollback| %>
         <tr id='<%= dom_id(rollback) %>'>
           <td><%= rollback.id %></td>
-          <td><%= rollback.user %></td>
+          <td><%= rollback.user || tag.em('unknown user')%></td>
           <td><%= rollback.reason %></td>
           <td><%= rollback.date %></td>
           <td><%= rollback.keep %></td>


### PR DESCRIPTION
### Jira link

[HOTT-1112](https://transformuk.atlassian.net/browse/HOTT-1112)

### What?

I have added/removed/altered:

- [x] Fixed showing Rollbacks without users

### Why?

I am doing this because:

- We currently have rollbacks on Dev and Staging which are assigned to user accounts which no longer exist

