### PR TITLE
Avoid specs relying on element ids

### DIFF
--- a/spec/features/chapter_notes_spec.rb
+++ b/spec/features/chapter_notes_spec.rb
@@ -48,7 +48,7 @@ RSpec.describe 'Chapter Note management' do
         end
       end
 
-      create_note_for chapter, content: chapter_note.content
+      create_note_for chapter, 'Content' => chapter_note.content
 
       verify note_created_for(chapter)
     end
@@ -88,7 +88,7 @@ RSpec.describe 'Chapter Note management' do
 
       verify note_created_for(chapter)
 
-      update_note_for chapter, content: new_content
+      update_note_for chapter, 'Content' => new_content
 
       stub_api_for(ChapterNote) do |stub|
         stub.get("/admin/chapters/#{chapter.to_param}/chapter_note") do |_env|
@@ -149,7 +149,7 @@ RSpec.describe 'Chapter Note management' do
     ensure_on new_notes_chapter_chapter_note_path(chapter)
 
     fields_and_values.each do |field, value|
-      fill_in "chapter_note_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -161,7 +161,7 @@ RSpec.describe 'Chapter Note management' do
     ensure_on edit_notes_chapter_chapter_note_path(chapter)
 
     fields_and_values.each do |field, value|
-      fill_in "chapter_note_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -172,7 +172,7 @@ RSpec.describe 'Chapter Note management' do
   def note_updated_for(chapter, args = {})
     ensure_on edit_notes_chapter_chapter_note_path(chapter)
 
-    page.has_field?('chapter_note_content', with: args[:content])
+    page.has_field?('Content', with: args[:content])
   end
 
   def note_created_for(chapter)

--- a/spec/features/chapter_search_reference_spec.rb
+++ b/spec/features/chapter_search_reference_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Chapter Search Reference management' do
           jsonapi_success_response('search_reference', [chapter_search_reference.attributes], 'x-meta' => { pagination: { total: 1 } }.to_json)
         end
       end
-      create_search_reference_for chapter, title: title
+      create_search_reference_for chapter, 'Synonym' => title
 
       verify search_reference_created_for(chapter, title: title)
     end
@@ -111,7 +111,7 @@ RSpec.describe 'Chapter Search Reference management' do
         end
       end
 
-      update_chapter_search_reference_for(chapter, chapter_search_reference, title: new_title)
+      update_chapter_search_reference_for(chapter, chapter_search_reference, 'Synonym' => new_title)
 
       stub_api_for(Chapter::SearchReference) do |stub|
         stub.get("/admin/chapters/#{chapter.to_param}/search_references/#{chapter_search_reference.to_param}") do |_env|
@@ -129,7 +129,7 @@ RSpec.describe 'Chapter Search Reference management' do
     ensure_on new_synonyms_chapter_search_reference_path(chapter)
 
     fields_and_values.each do |field, value|
-      fill_in "search_reference_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -141,7 +141,7 @@ RSpec.describe 'Chapter Search Reference management' do
     ensure_on edit_synonyms_chapter_search_reference_path(chapter, search_reference)
 
     fields_and_values.each do |field, value|
-      fill_in "search_reference_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -160,7 +160,7 @@ RSpec.describe 'Chapter Search Reference management' do
   def chapter_search_reference_updated_for(chapter, search_reference, args = {})
     ensure_on edit_synonyms_chapter_search_reference_path(chapter, search_reference)
 
-    page.has_field?('search_reference_title', with: args[:title])
+    page.has_field?('Synonym', with: args[:title])
   end
 
   def search_reference_created_for(chapter, attributes = {})

--- a/spec/features/commodity_search_reference_spec.rb
+++ b/spec/features/commodity_search_reference_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Commodity Search Reference management' do
         end
       end
 
-      create_search_reference_for commodity, title: title
+      create_search_reference_for commodity, 'Synonym' => title
 
       verify search_reference_created_for(commodity, title: title)
     end
@@ -110,7 +110,7 @@ RSpec.describe 'Commodity Search Reference management' do
         end
       end
 
-      update_commodity_search_reference_for(commodity, commodity_search_reference, title: new_title)
+      update_commodity_search_reference_for(commodity, commodity_search_reference, 'Synonym' => new_title)
 
       stub_api_for(Commodity::SearchReference) do |stub|
         stub.get("/admin/commodities/#{commodity.to_param}/search_references/#{commodity_search_reference.to_param}") do |_env|
@@ -128,7 +128,7 @@ RSpec.describe 'Commodity Search Reference management' do
     ensure_on new_synonyms_commodity_search_reference_path(commodity)
 
     fields_and_values.each do |field, value|
-      fill_in "search_reference_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -140,7 +140,7 @@ RSpec.describe 'Commodity Search Reference management' do
     ensure_on edit_synonyms_commodity_search_reference_path(commodity, search_reference)
 
     fields_and_values.each do |field, value|
-      fill_in "search_reference_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -159,7 +159,7 @@ RSpec.describe 'Commodity Search Reference management' do
   def commodity_search_reference_updated_for(commodity, search_reference, args = {})
     ensure_on edit_synonyms_commodity_search_reference_path(commodity, search_reference)
 
-    page.has_field?('search_reference_title', with: args[:title])
+    page.has_field?('Synonym', with: args[:title])
   end
 
   def search_reference_created_for(commodity, attributes = {})

--- a/spec/features/heading_search_reference_spec.rb
+++ b/spec/features/heading_search_reference_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe 'Heading Search Reference management' do
         end
       end
 
-      create_search_reference_for heading, title: title
+      create_search_reference_for heading, 'Synonym' => title
 
       verify search_reference_created_for(heading, title: title)
     end
@@ -110,7 +110,7 @@ RSpec.describe 'Heading Search Reference management' do
         end
       end
 
-      update_heading_search_reference_for(heading, heading_search_reference, title: new_title)
+      update_heading_search_reference_for(heading, heading_search_reference, 'Synonym' => new_title)
 
       stub_api_for(Heading::SearchReference) do |stub|
         stub.get("/admin/headings/#{heading.to_param}/search_references/#{heading_search_reference.to_param}") do |_env|
@@ -128,7 +128,7 @@ RSpec.describe 'Heading Search Reference management' do
     ensure_on new_synonyms_heading_search_reference_path(heading)
 
     fields_and_values.each do |field, value|
-      fill_in "search_reference_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -140,7 +140,7 @@ RSpec.describe 'Heading Search Reference management' do
     ensure_on edit_synonyms_heading_search_reference_path(heading, search_reference)
 
     fields_and_values.each do |field, value|
-      fill_in "search_reference_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -159,7 +159,7 @@ RSpec.describe 'Heading Search Reference management' do
   def heading_search_reference_updated_for(heading, search_reference, args = {})
     ensure_on edit_synonyms_heading_search_reference_path(heading, search_reference)
 
-    page.has_field?('search_reference_title', with: args[:title])
+    page.has_field?('Synonym', with: args[:title])
   end
 
   def search_reference_created_for(heading, attributes = {})

--- a/spec/features/rollbacks_spec.rb
+++ b/spec/features/rollbacks_spec.rb
@@ -46,8 +46,8 @@ RSpec.describe 'Rollbacks management' do
   def create_rollback(rollback)
     ensure_on new_rollback_path
 
-    fill_in 'rollback_reason', with: 'a reason'
-    fill_in 'rollback_date', with: rollback.date
+    fill_in 'Reason', with: 'a reason'
+    fill_in 'Rollback to', with: rollback.date
 
     click_button 'Create Rollback'
   end

--- a/spec/features/section_notes_spec.rb
+++ b/spec/features/section_notes_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe 'Section Note management' do
         end
       end
 
-      create_note_for section, content: section_note.content
+      create_note_for section, 'Content' => section_note.content
 
       verify note_created_for(section)
     end
@@ -63,7 +63,7 @@ RSpec.describe 'Section Note management' do
         stub.patch("/admin/sections/#{section.id}/section_note") { |_env| api_no_content_response }
       end
 
-      update_note_for section, content: new_content
+      update_note_for section, 'Content' => new_content
 
       stub_api_for(SectionNote) do |stub|
         stub.get("/admin/sections/#{section.id}/section_note") { |_env| jsonapi_success_response('section_note', section_note.attributes.merge(content: new_content)) }
@@ -107,7 +107,7 @@ RSpec.describe 'Section Note management' do
     ensure_on new_notes_section_section_note_path(section)
 
     fields_and_values.each do |field, value|
-      fill_in "section_note_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -119,7 +119,7 @@ RSpec.describe 'Section Note management' do
     ensure_on edit_notes_section_section_note_path(section)
 
     fields_and_values.each do |field, value|
-      fill_in "section_note_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -130,7 +130,7 @@ RSpec.describe 'Section Note management' do
   def note_updated_for(section, args = {})
     ensure_on edit_notes_section_section_note_path(section)
 
-    page.has_field?('section_note_content', with: args[:content])
+    page.has_field?('Content', with: args[:content])
   end
 
   def note_created_for(section)

--- a/spec/features/section_search_reference_spec.rb
+++ b/spec/features/section_search_reference_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe 'Section Search Reference management' do
         end
       end
 
-      create_search_reference_for section, title: title
+      create_search_reference_for section, 'Synonym' => title
 
       verify search_reference_created_for(section, title: title)
     end
@@ -118,7 +118,7 @@ RSpec.describe 'Section Search Reference management' do
         end
       end
 
-      update_section_search_reference_for(section, section_search_reference, title: new_title)
+      update_section_search_reference_for(section, section_search_reference, 'Synonym' => new_title)
 
       stub_api_for(Section::SearchReference) do |stub|
         stub.get("/admin/sections/#{section.to_param}/search_references/#{section_search_reference.to_param}") do |_env|
@@ -136,7 +136,7 @@ RSpec.describe 'Section Search Reference management' do
     ensure_on new_synonyms_section_search_reference_path(section)
 
     fields_and_values.each do |field, value|
-      fill_in "search_reference_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -148,7 +148,7 @@ RSpec.describe 'Section Search Reference management' do
     ensure_on edit_synonyms_section_search_reference_path(section, search_reference)
 
     fields_and_values.each do |field, value|
-      fill_in "search_reference_#{field}", with: value
+      fill_in field, with: value
     end
 
     yield if block_given?
@@ -167,7 +167,7 @@ RSpec.describe 'Section Search Reference management' do
   def section_search_reference_updated_for(section, search_reference, args = {})
     ensure_on edit_synonyms_section_search_reference_path(section, search_reference)
 
-    page.has_field?('search_reference_title', with: args[:title])
+    page.has_field?('Synonym', with: args[:title])
   end
 
   def search_reference_created_for(section, attributes = {})


### PR DESCRIPTION
### Jira link

???

### What?

I have added/removed/altered:

- [x] Changed the feature specs to not reference element ids 

### Why?

I am doing this because:

- Drive by fix because I ran into this looking at why one of the synonyms forms didn't work

