### PR TITLE
Convert synonyms to GovUK [5 / 7]

### DIFF
--- a/app/views/synonyms/_shared_actions.html+govuk.erb
+++ b/app/views/synonyms/_shared_actions.html+govuk.erb
@@ -1,5 +1,5 @@
-<div id="import-synonyms">
-  <h3>Import synonyms</h3>
+<div id="import-export-synonyms">
+  <h3>Import and Export synonyms</h3>
 
   <p>
     Import multiple synonyms from a CSV file
@@ -8,10 +8,6 @@
   <%= link_to synonyms_import_path, class: 'govuk-button' do %>
     Import synonyms CSV
   <% end %>
-</div>
-
-<div id="export-synonyms">
-  <h3>Export synonyms</h3>
 
   <p>
     Export all synonyms as a CSV file

--- a/app/views/synonyms/chapters/headings/index.html+govuk.erb
+++ b/app/views/synonyms/chapters/headings/index.html+govuk.erb
@@ -1,0 +1,37 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Chapters': synonyms_section_chapters_path(section_id: chapter.section.id) %>
+
+<h2>Headings search synonyms of chapter <%= chapter.description.titleize %></h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Heading</th>
+      <th>Commodities</th>
+      <th>Title</th>
+      <th class="hott-actions-col">Synonyms</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @headings.each do |heading| %>
+      <tr id="<%= dom_id(heading) %>">
+        <td><%= heading.heading_id %></td>
+        <td>
+          <%= link_to "Commodities in #{heading.to_param}", synonyms_heading_commodities_path(heading) %>
+        </td>
+        <td><%= heading.description.titleize %></td>
+        <td class="hott-link-group">
+          <div>
+            <%= pluralize heading.search_references_count, "synonym" %>
+          </div>
+          <%= link_to 'Edit', synonyms_heading_search_references_path(heading) %>
+          <% if heading.search_references_count > 0 %>
+            <%= link_to 'Export', export_synonyms_heading_search_references_path(heading), method: :post %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render "synonyms/shared_actions" %>

--- a/app/views/synonyms/chapters/search_references/edit.html+govuk.erb
+++ b/app/views/synonyms/chapters/search_references/edit.html+govuk.erb
@@ -1,0 +1,12 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Chapters': synonyms_section_chapters_path(section_id: chapter.section.id),
+                      'Search Synonyms': synonyms_chapter_search_references_path(chapter) %>
+
+<h2>Edit Search Synonym</h2>
+
+<%= govuk_form_for search_reference, url: synonyms_chapter_search_reference_path(chapter, search_reference), as: :search_reference do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= submit_and_back_buttons f, synonyms_chapter_search_references_path(chapter) %>
+<% end %>
+

--- a/app/views/synonyms/chapters/search_references/index.html+govuk.erb
+++ b/app/views/synonyms/chapters/search_references/index.html+govuk.erb
@@ -1,0 +1,30 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Chapters': synonyms_section_chapters_path(section_id: chapter.section.id) %>
+
+<h2>Search synonyms for <%= chapter.reference_title %></h2>
+
+<%= link_to 'New Search Synonym', new_synonyms_chapter_search_reference_path(chapter), class: 'govuk-button' %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th class="hott-actions-col">
+        Actions
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @search_references.each do |search_reference| %>
+      <tr id="<%= dom_id(search_reference) %>">
+        <td><%= search_reference.title %></td>
+        <td class="hott-link-group">
+          <%= link_to "Edit", edit_synonyms_chapter_search_reference_path(chapter, search_reference), class: 'btn btn-small btn-warning' %>
+          <%= link_to "Remove", synonyms_chapter_search_reference_path(chapter, search_reference), method: :delete, data: { confirm: 'Are you sure?', disable: 'Working'}, class: 'btn btn-small btn-danger' %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @search_references %>

--- a/app/views/synonyms/chapters/search_references/new.html+govuk.erb
+++ b/app/views/synonyms/chapters/search_references/new.html+govuk.erb
@@ -1,0 +1,12 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Chapters': synonyms_section_chapters_path(section_id: chapter.section.id),
+                      'Search Synonyms': synonyms_chapter_search_references_path(chapter) %>
+
+<h2>New Search Synonym</h2>
+
+<%= govuk_form_for search_reference, url: synonyms_chapter_search_references_path(chapter), as: :search_reference do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= submit_and_back_buttons f, synonyms_chapter_search_references_path(chapter) %>
+<% end %>
+

--- a/app/views/synonyms/commodities/search_references/edit.html+govuk.erb
+++ b/app/views/synonyms/commodities/search_references/edit.html+govuk.erb
@@ -1,0 +1,12 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Commodities': synonyms_heading_commodities_path(heading_id: commodity.heading_id),
+                      'Search Synonyms': synonyms_commodity_search_references_path(commodity) %>
+
+<h2>Edit Search Synonym</h2>
+
+<%= govuk_form_for search_reference, url: synonyms_commodity_search_reference_path(commodity, search_reference), as: :search_reference do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= submit_and_back_buttons f, synonyms_commodity_search_references_path(commodity) %>
+<% end %>
+

--- a/app/views/synonyms/commodities/search_references/index.html+govuk.erb
+++ b/app/views/synonyms/commodities/search_references/index.html+govuk.erb
@@ -1,0 +1,30 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Commodities': synonyms_heading_commodities_path(heading_id: commodity.heading_id) %>
+
+<h2>Search synonyms <%= commodity.reference_title %></h2>
+
+<%= link_to 'New Search Synonym', new_synonyms_commodity_search_reference_path(commodity), class: 'govuk-button' %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th class="hott-actions-col">
+        Actions
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @search_references.each do |search_reference| %>
+      <tr id="<%= dom_id(search_reference) %>">
+        <td><%= search_reference.title %></td>
+        <td class="hott-link-group">
+          <%= link_to "Edit", edit_synonyms_commodity_search_reference_path(commodity, search_reference) %>
+          <%= link_to "Remove", synonyms_commodity_search_reference_path(commodity, search_reference), method: :delete, data: { confirm: 'Are you sure?', disable: 'Working'} %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @search_references %>

--- a/app/views/synonyms/commodities/search_references/new.html+govuk.erb
+++ b/app/views/synonyms/commodities/search_references/new.html+govuk.erb
@@ -1,0 +1,12 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Commodities': synonyms_heading_commodities_path(heading_id: commodity.heading_id),
+                      'Search Synonyms': synonyms_commodity_search_references_path(commodity) %>
+
+<h2>New Search Synonym</h2>
+
+<%= govuk_form_for search_reference, url: synonyms_commodity_search_references_path(commodity), as: :search_reference do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= submit_and_back_buttons f, synonyms_commodity_search_references_path(commodity) %>
+<% end %>
+

--- a/app/views/synonyms/headings/commodities/index.html+govuk.erb
+++ b/app/views/synonyms/headings/commodities/index.html+govuk.erb
@@ -1,0 +1,37 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Headings': synonyms_chapter_headings_path(chapter_id: heading.chapter_id) %>
+
+<h2>Commodities search synonyms of heading <%= heading.to_param %>:<%= heading.description.titleize %></h2>
+
+<table class='table table-bordered table-striped table-condensed table-headings'>
+  <thead>
+    <tr>
+      <th>Commodity</th>
+      <th>Title</th>
+      <th class="actions_col">Synonyms</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @commodities.each do |commodity| %>
+      <tr id="<%= dom_id(commodity) %>">
+        <td><%= commodity.goods_nomenclature_item_id %></td>
+        <td><%= commodity.description.titleize %></td>
+        <td class="hott-link-group">
+          <% if commodity.leaf %>
+            <div>
+              <%= pluralize commodity.search_references_count, "synonym" %>
+            </div>
+            <%= link_to 'Edit', synonyms_commodity_search_references_path(commodity) %>
+            <% if commodity.search_references_count > 0 %>
+              <%= link_to 'Export', export_synonyms_commodity_search_references_path(commodity), method: :post %>
+            <% end %>
+          <% else %>
+            <em>Intermediate code</em>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render "synonyms/shared_actions" %>

--- a/app/views/synonyms/headings/search_references/edit.html+govuk.erb
+++ b/app/views/synonyms/headings/search_references/edit.html+govuk.erb
@@ -1,0 +1,12 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Headings': synonyms_chapter_headings_path(chapter_id: heading.chapter.id),
+                      'Search Synonyms': synonyms_heading_search_references_path(heading) %>
+
+<h2>Edit Search Synonym</h2>
+
+<%= govuk_form_for search_reference, url: synonyms_heading_search_reference_path(heading, search_reference), as: :search_reference do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= submit_and_back_buttons f, synonyms_heading_search_references_path(heading) %>
+<% end %>
+

--- a/app/views/synonyms/headings/search_references/index.html+govuk.erb
+++ b/app/views/synonyms/headings/search_references/index.html+govuk.erb
@@ -1,0 +1,30 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Headings': synonyms_chapter_headings_path(chapter_id: heading.chapter.id) %>
+
+<h2>Search synonyms <%= heading.reference_title %></h2>
+
+<%= link_to 'New Search Synonym', new_synonyms_heading_search_reference_path(heading), class: 'govuk-button' %>
+
+<table class='table table-bordered table-striped table-condensed table-search-references'>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th class="hott-actions-col">
+        Actions
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @search_references.each do |search_reference| %>
+      <tr id="<%= dom_id(search_reference) %>">
+        <td><%= search_reference.title %></td>
+        <td class="hott-link-group">
+          <%= link_to "Edit", edit_synonyms_heading_search_reference_path(heading, search_reference) %>
+          <%= link_to "Remove", synonyms_heading_search_reference_path(heading, search_reference), method: :delete, data: { confirm: 'Are you sure?', disable: 'Working'} %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @search_references %>

--- a/app/views/synonyms/headings/search_references/new.html+govuk.erb
+++ b/app/views/synonyms/headings/search_references/new.html+govuk.erb
@@ -1,0 +1,12 @@
+<%= govuk_breadcrumbs 'Sections': synonyms_sections_path,
+                      'Headings': synonyms_chapter_headings_path(chapter_id: heading.chapter.id),
+                      'Search Synonyms': synonyms_heading_search_references_path(heading) %>
+
+<h2>New Search Synonym</h2>
+
+<%= govuk_form_for search_reference, url: synonyms_heading_search_references_path(heading), as: :search_reference do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= submit_and_back_buttons f, synonyms_heading_search_references_path(heading) %>
+<% end %>
+

--- a/app/views/synonyms/imports/show.html+govuk.erb
+++ b/app/views/synonyms/imports/show.html+govuk.erb
@@ -1,0 +1,48 @@
+<h2>Import search synonyms</h2>
+
+<%= govuk_form_for :synonyms_import, url: synonyms_import_path do |f| %>
+  <div class="govuk-inset-text">
+    <p>Sample CSV file:</p>
+
+    <table>
+      <thead>
+        <tr>
+          <th>goods_nomenclature_item_id</th>
+          <th>title</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>8402000000</td>
+          <td>machine tools</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <p>Upload CSV with synonyms. Synonyms are overriden if ID is provided</p>
+
+  <%= f.govuk_file_field :file, accept: 'text/csv' %>
+
+  <div class="govuk-button-group">
+    <%= f.govuk_submit 'Import synonyms from CSV' %>
+    <%= link_to 'Back', :back, class: 'govuk-button govuk-button--secondary' %>
+  </div>
+<% end %>
+
+<hr class="govuk-section-break govuk-section-break--l govuk-section-break--visible">
+
+<h3>Import Tasks:</h3>
+
+<table>
+  <thead>
+    <tr>
+      <th>Task</th>
+      <th>Created</th>
+      <th>Status</th>
+    </tr>
+  </thead>
+  <tbody>
+    <%= render @import_tasks %>
+  </tbody>
+</table>

--- a/app/views/synonyms/sections/chapters/index.html+govuk.erb
+++ b/app/views/synonyms/sections/chapters/index.html+govuk.erb
@@ -1,6 +1,6 @@
 <%= govuk_breadcrumbs 'Sections': synonyms_sections_path %>
 
-<h3>Chapter search synonyms of section: <%= section.title %></h3>
+<h2>Chapter search synonyms of section: <%= section.title %></h2>
 
 <table>
   <thead>

--- a/app/views/synonyms/sections/index.html+govuk.erb
+++ b/app/views/synonyms/sections/index.html+govuk.erb
@@ -1,0 +1,32 @@
+<h2>Section search synonyms</h2>
+
+<table>
+  <thead>
+    <tr>
+      <th>Section</th>
+      <th>Chapters</th>
+      <th>Title</th>
+      <th class="hott-actions-col">Synonyms</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @sections.each do |section| %>
+      <tr id='<%= dom_id(section) %>'>
+        <td><%= section.position %></td>
+        <td><%= link_to section.chapters_range, synonyms_section_chapters_path(section) %></td>
+        <td><%= section.title %></td>
+        <td class="hott-link-group">
+          <div>
+            <%= pluralize section.search_references_count, "synonym" %>
+          </div>
+          <%= link_to 'Edit', synonyms_section_search_references_path(section) %>
+          <% if section.search_references_count > 0 %>
+            <%= link_to 'Export', export_synonyms_section_search_references_path(section), method: :post %>
+          <% end %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= render "synonyms/shared_actions" %>

--- a/app/views/synonyms/sections/search_references/edit.html+govuk.erb
+++ b/app/views/synonyms/sections/search_references/edit.html+govuk.erb
@@ -1,0 +1,10 @@
+<%= govuk_breadcrumbs 'Sections' => synonyms_sections_path,
+                      'Search Synonyms' => synonyms_section_search_references_path(section) %>
+
+<h2>Edit Search Synonym</h2>
+
+<%= govuk_form_for search_reference, url: synonyms_section_search_reference_path(section, search_reference), as: :search_reference do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= submit_and_back_buttons f, synonyms_section_search_references_path(section) %>
+<% end %>

--- a/app/views/synonyms/sections/search_references/index.html+govuk.erb
+++ b/app/views/synonyms/sections/search_references/index.html+govuk.erb
@@ -1,0 +1,29 @@
+<%= govuk_breadcrumbs 'Sections' => synonyms_sections_path %>
+
+<h2>Search synonyms for <%= section.reference_title %></h2>
+
+<%= link_to 'New Search Synonym', new_synonyms_section_search_reference_path(section), class: 'govuk-button' %>
+
+<table>
+  <thead>
+    <tr>
+      <th>Title</th>
+      <th class="hott-actions-col">
+        Actions
+      </th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @search_references.each do |search_reference| %>
+      <tr id="<%= dom_id(search_reference) %>">
+        <td><%= search_reference.title %></td>
+        <td class="hott-link-group">
+          <%= link_to "Edit", edit_synonyms_section_search_reference_path(section, search_reference) %>
+          <%= link_to "Remove", synonyms_section_search_reference_path(section, search_reference), method: :delete, data: { confirm: 'Are you sure?', disable: 'Working'}, class: 'btn btn-small btn-danger' %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= paginate @search_references %>

--- a/app/views/synonyms/sections/search_references/new.html+govuk.erb
+++ b/app/views/synonyms/sections/search_references/new.html+govuk.erb
@@ -1,0 +1,12 @@
+<%= govuk_breadcrumbs 'Sections' => synonyms_sections_path,
+                      'Search Synonyms' => synonyms_section_search_references_path(section) %>
+
+<h2>New Search Synonym</h2>
+
+<%= govuk_form_for @search_reference,
+                  url: synonyms_section_search_references_path(section),
+                  as: :search_reference do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= submit_and_back_buttons f, synonyms_section_search_references_path(section) %>
+<% end %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -40,6 +40,8 @@ en:
         section_title: Section title
       chapter_note:
         chapter_title: Chapter
+      search_reference:
+        title: Synonym
 
     legend:
       rollback:


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Converted Chapter synonyms section to GovUK
- [x] Converted Sections synonyms section to GovUK
- [x] Converted Headings synonyms section to GovUK
- [x] Converted Chapters synonyms section to GovUK

### Why?

I am doing this because:

- The existing UI framework is hard to maintain
- We can get more value for money investing in the new govuk framework
- Its one less tool for the developers to need to understand
- We will be expanding the admin area in the coming months

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- currently it needs GOVUK_FRONTEND=true so it can be booted in either UI

### Screenshots

![Screenshot from 2021-11-15 15-30-19](https://user-images.githubusercontent.com/10818/141811761-00f45498-5b18-4a70-be83-c3923039e001.png)
![Screenshot from 2021-11-15 15-24-17](https://user-images.githubusercontent.com/10818/141811768-ed6e352d-9675-46a0-9835-9b1af0557885.png)
![Screenshot from 2021-11-15 15-23-55](https://user-images.githubusercontent.com/10818/141811771-853f373c-46f8-4091-ad52-1860c0d8c987.png)
![Screenshot from 2021-11-15 15-23-21](https://user-images.githubusercontent.com/10818/141811773-58873f85-044c-4a9c-bc33-0d8ca92f557c.png)
