### PR TITLE
Convert news to GovUK [6 / 7]

### DIFF
--- a/app/views/layouts/application.html+govuk.erb
+++ b/app/views/layouts/application.html+govuk.erb
@@ -31,6 +31,9 @@
       <%= header.navigation_item text: "Search Synonyms",
                                  href: synonyms_sections_path,
                                  active: active_nav_link?(/\/synonyms/) %>
+      <%= header.navigation_item text: "News",
+                                 href: news_items_path,
+                                 active: active_nav_link?(/\/news_items/) %>
       <%= header.navigation_item text: "Tariff Updates",
                                  href: tariff_updates_path,
                                  active: active_nav_link?(/\/tariff_updates/) %>

--- a/app/views/news_items/_form.html+govuk.erb
+++ b/app/views/news_items/_form.html+govuk.erb
@@ -1,0 +1,30 @@
+<%= govuk_form_for news_item do |f| %>
+  <%= f.govuk_text_field :title, width: 'one-half' %>
+
+  <%= govuk_markdown_area f, :content, rows: 12 %>
+
+  <%= f.govuk_text_field :start_date, width: 'one-third' %>
+  <%= f.govuk_text_field :end_date, width: 'one-third' %>
+
+  <%= f.govuk_check_box :show_on_uk, 1, 0,
+                        label: { text: 'Show on UK service' },
+                        multiple: false,
+                        link_errors: true %>
+
+  <%= f.govuk_check_box :show_on_xi, 1, 0,
+                        label: { text: 'Show on XI service' },
+                        multiple: false,
+                        link_errors: true %>
+
+  <%= f.govuk_check_box :show_on_home_page, 1, 0,
+                        label: { text: 'Show News story on the Home page' },
+                        multiple: false,
+                        link_errors: true %>
+
+  <%= f.govuk_check_box :show_on_updates_page, 1, 0,
+                        label: { text: 'Show News story on the Updates page' },
+                        multiple: false,
+                        link_errors: true %>
+
+  <%= submit_and_back_buttons f, news_items_path %>
+<% end %>

--- a/app/views/news_items/edit.html+govuk.erb
+++ b/app/views/news_items/edit.html+govuk.erb
@@ -1,0 +1,21 @@
+<%= govuk_breadcrumbs 'News': news_items_path %>
+
+<h2>Edit News story</h2>
+
+<%= render 'form', news_item: @news_item %>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<h3>
+  Remove News item
+</h3>
+
+<p>
+  Remove this News item
+</p>
+
+<%= link_to 'Remove',
+                news_item_path(@news_item),
+                method: :delete,
+                class: 'govuk-button govuk-button--warning',
+                data: { confirm: "Are you sure?", disable: 'Working ...' } %>

--- a/app/views/news_items/index.html+govuk.erb
+++ b/app/views/news_items/index.html+govuk.erb
@@ -1,0 +1,45 @@
+<h2>
+  News stories
+</h2>
+
+<%= link_to 'Add News story', new_news_item_path, class: 'govuk-button' %>
+
+<% if @news_items.any? %>
+  <table>
+    <thead>
+      <tr>
+        <th>ID</th>
+        <th>Title</th>
+        <th>Start date</th>
+        <th>End date</th>
+        <th>UK</th>
+        <th>XI</th>
+        <th>Home page</th>
+        <th>Updates page</th>
+        <th>Actions</th>
+      </tr>
+    </thead>
+    <tbody>
+      <% @news_items.each do |news_item| %>
+        <tr id="<%= dom_id(news_item) %>">
+          <td><%= news_item.id %></td>
+          <td><%= truncate news_item.title %></td>
+          <td><%= news_item_date news_item.start_date %></td>
+          <td><%= news_item_date news_item.end_date %></td>
+          <td><%= news_item_bool news_item.show_on_uk %></td>
+          <td><%= news_item_bool news_item.show_on_xi %></td>
+          <td><%= news_item_bool news_item.show_on_home_page %></td>
+          <td><%= news_item_bool news_item.show_on_updates_page %></td>
+          <td>
+            <%= link_to 'Edit',
+                        edit_news_item_path(news_item) %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% else %>
+  <div class="govuk-inset-text">
+    <p>No News stories</p>
+  </div>
+<% end %>

--- a/app/views/news_items/new.html+govuk.erb
+++ b/app/views/news_items/new.html+govuk.erb
@@ -1,0 +1,5 @@
+<%= govuk_breadcrumbs 'News': news_items_path %>
+
+<h2>New News story</h2>
+
+<%= render 'form', news_item: @news_item %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -51,3 +51,7 @@ en:
       rollback:
         keep: Keeps update files and records since specified date and just mark them pending
         date: Should be in 'YYYY-MM-DD' format
+
+      news_item:
+        start_date: 'YYYY/MM/DD'
+        end_date: 'YYYY/MM/DD or leave blank for no end date'


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Converted the news section to use the GovUK design system

### Why?

I am doing this because:

- The existing UI framework is hard to maintain
- We can get more value for money investing in the new govuk framework
- Its one less tool for the developers to need to understand
- We will be expanding the admin area in the coming months

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- currently it needs GOVUK_FRONTEND=true so it can be booted in either UI

### Screenshots

![Screenshot from 2021-11-15 15-30-19](https://user-images.githubusercontent.com/10818/141811761-00f45498-5b18-4a70-be83-c3923039e001.png)
![Screenshot from 2021-11-15 15-24-17](https://user-images.githubusercontent.com/10818/141811768-ed6e352d-9675-46a0-9835-9b1af0557885.png)
![Screenshot from 2021-11-15 15-23-55](https://user-images.githubusercontent.com/10818/141811771-853f373c-46f8-4091-ad52-1860c0d8c987.png)
![Screenshot from 2021-11-15 15-23-21](https://user-images.githubusercontent.com/10818/141811773-58873f85-044c-4a9c-bc33-0d8ca92f557c.png)
