### PR TITLE
Adds a live preview markdown editor field [7 / 7]

### DIFF
--- a/app/helpers/govuk_helper.rb
+++ b/app/helpers/govuk_helper.rb
@@ -31,12 +31,9 @@ module GovukHelper
   end
 
   def govuk_markdown_area(form, field_name, **options)
-    form.govuk_text_area(field_name, **options) +
-      tag.p do
-        link_to 'Markdown guide',
-                'http://govspeak-preview.herokuapp.com/guide',
-                rel: 'noopener',
-                target: '_blank'
-      end
+    render 'application/markdown_field',
+           form: form,
+           field_name: field_name,
+           field_options: options
   end
 end

--- a/app/views/application/_markdown_field.html.erb
+++ b/app/views/application/_markdown_field.html.erb
@@ -13,7 +13,9 @@
     <div class="govuk-form-group">
       <label class="govuk-label">Preview</label>
 
-      <div class="hott-markdown-preview">
+      <div class="hott-markdown-preview"
+        data-preview="govspeak"
+        data-preview-for="#<%= "#{form.object_name}-#{field_name}-field".gsub('_', '-') %>">
         <%= form.object.preview if form.object.respond_to?(:preview) %>
       </div>
     </div>

--- a/app/views/application/_markdown_field.html.erb
+++ b/app/views/application/_markdown_field.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-one-half">
+    <%= form.govuk_text_area field_name, **field_options %>
+
+    <p>
+      <a href="http://govspeak-preview.herokuapp.com/guide" rel="noopener" target="_blank">
+        Markdown guide
+      </a>
+    </p>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <div class="govuk-form-group">
+      <label class="govuk-label">Preview</label>
+
+      <div class="hott-markdown-preview">
+        <%= form.object.preview if form.object.respond_to?(:preview) %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/webpacker/javascripts/jquery.autosize.js
+++ b/app/webpacker/javascripts/jquery.autosize.js
@@ -1,0 +1,258 @@
+/*!
+	Autosize v1.17.8 - 2013-09-07
+	Automatically adjust textarea height based on user input.
+	(c) 2013 Jack Moore - http://www.jacklmoore.com/autosize
+	license: http://www.opensource.org/licenses/mit-license.php
+*/
+(function (factory) {
+	if (typeof define === 'function' && define.amd) {
+		// AMD. Register as an anonymous module.
+		define(['jquery'], factory);
+	} else {
+		// Browser globals: jQuery or jQuery-like library, such as Zepto
+		factory(window.jQuery || window.$);
+	}
+}(function ($) {
+	var
+	defaults = {
+		className: 'autosizejs',
+		append: '',
+		callback: false,
+		resizeDelay: 10
+	},
+
+	// border:0 is unnecessary, but avoids a bug in FireFox on OSX
+	copy = '<textarea tabindex="-1" style="position:absolute; top:-999px; left:0; right:auto; bottom:auto; border:0; padding: 0; -moz-box-sizing:content-box; -webkit-box-sizing:content-box; box-sizing:content-box; word-wrap:break-word; height:0 !important; min-height:0 !important; overflow:hidden; transition:none; -webkit-transition:none; -moz-transition:none;"/>',
+
+	// line-height is conditionally included because IE7/IE8/old Opera do not return the correct value.
+	typographyStyles = [
+		'fontFamily',
+		'fontSize',
+		'fontWeight',
+		'fontStyle',
+		'letterSpacing',
+		'textTransform',
+		'wordSpacing',
+		'textIndent'
+	],
+
+	// to keep track which textarea is being mirrored when adjust() is called.
+	mirrored,
+
+	// the mirror element, which is used to calculate what size the mirrored element should be.
+	mirror = $(copy).data('autosize', true)[0];
+
+	// test that line-height can be accurately copied.
+	mirror.style.lineHeight = '99px';
+	if ($(mirror).css('lineHeight') === '99px') {
+		typographyStyles.push('lineHeight');
+	}
+	mirror.style.lineHeight = '';
+
+	$.fn.autosize = function (options) {
+		if (!this.length) {
+			return this;
+		}
+
+		options = $.extend({}, defaults, options || {});
+
+		if (mirror.parentNode !== document.body) {
+			$(document.body).append(mirror);
+		}
+
+		return this.each(function () {
+			var
+			ta = this,
+			$ta = $(ta),
+			maxHeight,
+			minHeight,
+			boxOffset = 0,
+			callback = $.isFunction(options.callback),
+			originalStyles = {
+				height: ta.style.height,
+				overflow: ta.style.overflow,
+				overflowY: ta.style.overflowY,
+				wordWrap: ta.style.wordWrap,
+				resize: ta.style.resize
+			},
+			timeout,
+			width = $ta.width();
+
+			if ($ta.data('autosize')) {
+				// exit if autosize has already been applied, or if the textarea is the mirror element.
+				return;
+			}
+			$ta.data('autosize', true);
+
+			if ($ta.css('box-sizing') === 'border-box' || $ta.css('-moz-box-sizing') === 'border-box' || $ta.css('-webkit-box-sizing') === 'border-box'){
+				boxOffset = $ta.outerHeight() - $ta.height();
+			}
+
+			// IE8 and lower return 'auto', which parses to NaN, if no min-height is set.
+			minHeight = Math.max(parseInt($ta.css('minHeight'), 10) - boxOffset || 0, $ta.height());
+
+			$ta.css({
+				overflow: 'hidden',
+				overflowY: 'hidden',
+				wordWrap: 'break-word', // horizontal overflow is hidden, so break-word is necessary for handling words longer than the textarea width
+				resize: ($ta.css('resize') === 'none' || $ta.css('resize') === 'vertical') ? 'none' : 'horizontal'
+			});
+
+			// The mirror width must exactly match the textarea width, so using getBoundingClientRect because it doesn't round the sub-pixel value.
+			function setWidth() {
+				var style, width;
+				
+				if ('getComputedStyle' in window) {
+					style = window.getComputedStyle(ta);
+					width = ta.getBoundingClientRect().width;
+
+					$.each(['paddingLeft', 'paddingRight', 'borderLeftWidth', 'borderRightWidth'], function(i,val){
+						width -= parseInt(style[val],10);
+					});
+
+					mirror.style.width = width + 'px';
+				}
+				else {
+					// window.getComputedStyle, getBoundingClientRect returning a width are unsupported and unneeded in IE8 and lower.
+					mirror.style.width = Math.max($ta.width(), 0) + 'px';
+				}
+			}
+
+			function initMirror() {
+				var styles = {};
+
+				mirrored = ta;
+				mirror.className = options.className;
+				maxHeight = parseInt($ta.css('maxHeight'), 10);
+
+				// mirror is a duplicate textarea located off-screen that
+				// is automatically updated to contain the same text as the
+				// original textarea.  mirror always has a height of 0.
+				// This gives a cross-browser supported way getting the actual
+				// height of the text, through the scrollTop property.
+				$.each(typographyStyles, function(i,val){
+					styles[val] = $ta.css(val);
+				});
+				$(mirror).css(styles);
+
+				setWidth();
+
+				// Chrome-specific fix:
+				// When the textarea y-overflow is hidden, Chrome doesn't reflow the text to account for the space
+				// made available by removing the scrollbar. This workaround triggers the reflow for Chrome.
+				if (window.chrome) {
+					var width = ta.style.width;
+					ta.style.width = '0px';
+					var ignore = ta.offsetWidth;
+					ta.style.width = width;
+				}
+			}
+
+			// Using mainly bare JS in this function because it is going
+			// to fire very often while typing, and needs to very efficient.
+			function adjust() {
+				var height, original;
+
+				if (mirrored !== ta) {
+					initMirror();
+				} else {
+					setWidth();
+				}
+
+				mirror.value = ta.value + options.append;
+				mirror.style.overflowY = ta.style.overflowY;
+				original = parseInt(ta.style.height,10);
+
+				// Setting scrollTop to zero is needed in IE8 and lower for the next step to be accurately applied
+				mirror.scrollTop = 0;
+
+				mirror.scrollTop = 9e4;
+
+				// Using scrollTop rather than scrollHeight because scrollHeight is non-standard and includes padding.
+				height = mirror.scrollTop;
+
+				if (maxHeight && height > maxHeight) {
+					ta.style.overflowY = 'scroll';
+					height = maxHeight;
+				} else {
+					ta.style.overflowY = 'hidden';
+					if (height < minHeight) {
+						height = minHeight;
+					}
+				}
+
+				height += boxOffset;
+
+				if (original !== height) {
+					ta.style.height = height + 'px';
+					if (callback) {
+						options.callback.call(ta,ta);
+					}
+				}
+			}
+
+			function resize () {
+				clearTimeout(timeout);
+				timeout = setTimeout(function(){
+					var newWidth = $ta.width();
+
+					if (newWidth !== width) {
+						width = newWidth;
+						adjust();
+					}
+				}, parseInt(options.resizeDelay,10));
+			}
+
+			if ('onpropertychange' in ta) {
+				if ('oninput' in ta) {
+					// Detects IE9.  IE9 does not fire onpropertychange or oninput for deletions,
+					// so binding to onkeyup to catch most of those occasions.  There is no way that I
+					// know of to detect something like 'cut' in IE9.
+					$ta.on('input.autosize keyup.autosize', adjust);
+				} else {
+					// IE7 / IE8
+					$ta.on('propertychange.autosize', function(){
+						if(event.propertyName === 'value'){
+							adjust();
+						}
+					});
+				}
+			} else {
+				// Modern Browsers
+				$ta.on('input.autosize', adjust);
+			}
+
+			// Set options.resizeDelay to false if using fixed-width textarea elements.
+			// Uses a timeout and width check to reduce the amount of times adjust needs to be called after window resize.
+
+			if (options.resizeDelay !== false) {
+				$(window).on('resize.autosize', resize);
+			}
+
+			// Event for manual triggering if needed.
+			// Should only be needed when the value of the textarea is changed through JavaScript rather than user input.
+			$ta.on('autosize.resize', adjust);
+
+			// Event for manual triggering that also forces the styles to update as well.
+			// Should only be needed if one of typography styles of the textarea change, and the textarea is already the target of the adjust method.
+			$ta.on('autosize.resizeIncludeStyle', function() {
+				mirrored = null;
+				adjust();
+			});
+
+			$ta.on('autosize.destroy', function(){
+				mirrored = null;
+				clearTimeout(timeout);
+				$(window).off('resize', resize);
+				$ta
+					.off('autosize')
+					.off('.autosize')
+					.css(originalStyles)
+					.removeData('autosize');
+			});
+
+			// Call adjust in case the textarea already contains text.
+			adjust();
+		});
+	};
+}));

--- a/app/webpacker/javascripts/markdown-preview.js
+++ b/app/webpacker/javascripts/markdown-preview.js
@@ -1,0 +1,27 @@
+import $ from "jquery";
+
+$(document).ready(function(){
+  var Previewer = {
+    preview: function(content, output) {
+      $.ajax({
+        type: 'POST',
+        url: "/govspeak",
+        data: { govspeak: content.val() },
+        dataType: 'json'
+      }).done(function(data){
+        output.html(data['govspeak']);
+      });
+    }
+  };
+
+  $("[data-preview]").each(function(){
+    var source_field = $($(this).data('preview-for'));
+    var render_area = $(this);
+
+    source_field.keyup(function() {
+      Previewer.preview(source_field, render_area);
+    })
+  });
+
+  //$('textarea').autosize();
+});

--- a/app/webpacker/javascripts/markdown-preview.js
+++ b/app/webpacker/javascripts/markdown-preview.js
@@ -1,4 +1,5 @@
-import $ from "jquery";
+import $ from 'jquery';
+import 'jquery.autosize' ;
 
 $(document).ready(function(){
   var Previewer = {
@@ -23,5 +24,5 @@ $(document).ready(function(){
     })
   });
 
-  //$('textarea').autosize();
+  $('textarea').autosize();
 });

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -17,5 +17,7 @@ import './application.scss';
 import Rails from 'rails-ujs';
 import { initAll } from 'govuk-frontend';
 
+import '../javascripts/markdown-preview';
+
 Rails.start();
 initAll();

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -54,3 +54,15 @@ $govuk-image-url-function: frontend-image-url;
     width: 20%
   }
 }
+
+.hott-markdown-preview {
+  ul {
+    @extend .govuk-list;
+    @extend .govuk-list--bullet;
+  }
+
+  ol {
+    @extend .govuk-list;
+    @extend .govuk-list--number;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "dependencies": {
     "@rails/webpacker": "^5.4.0",
     "govuk-frontend": "^3.12.0",
+    "jquery": "^3.6.0",
     "rails-ujs": "^5.2.6"
   },
   "devDependencies": {

--- a/spec/helpers/govuk_helper_spec.rb
+++ b/spec/helpers/govuk_helper_spec.rb
@@ -10,6 +10,10 @@ RSpec.describe GovukHelper do
       def self.name
         'Person'
       end
+
+      def preview
+        '<p>preview content</p>'.html_safe
+      end
     end
   end
 
@@ -83,7 +87,10 @@ RSpec.describe GovukHelper do
       end
     end
 
-    it { is_expected.to have_css 'textarea.govuk-textarea' }
+    it { is_expected.to have_css '.govuk-grid-row .govuk-grid-column-one-half', count: 2 }
+    it { is_expected.to have_css '.govuk-grid-column-one-half textarea.govuk-textarea' }
     it { is_expected.to have_link 'Markdown guide' }
+    it { is_expected.to have_css '.govuk-grid-column-one-half .hott-markdown-preview' }
+    it { is_expected.to have_css '.hott-markdown-preview p', text: 'preview content' }
   end
 end

--- a/spec/helpers/govuk_helper_spec.rb
+++ b/spec/helpers/govuk_helper_spec.rb
@@ -92,5 +92,7 @@ RSpec.describe GovukHelper do
     it { is_expected.to have_link 'Markdown guide' }
     it { is_expected.to have_css '.govuk-grid-column-one-half .hott-markdown-preview' }
     it { is_expected.to have_css '.hott-markdown-preview p', text: 'preview content' }
+    it { is_expected.to have_css '.hott-markdown-preview[data-preview="govspeak"]' }
+    it { is_expected.to have_css '.hott-markdown-preview[data-preview-for="#person-name-field"]' }
   end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -3780,6 +3780,11 @@ jest-worker@^26.5.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@^3.6.0:
+  version "3.6.0"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
+  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
+
 js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Added a markdown preview to the govuk markdown field
- [x] Added a webpacker-ised version of the preview javascript

### Why?

I am doing this because:

- The existing UI framework is hard to maintain
- We can get more value for money investing in the new govuk framework
- Its one less tool for the developers to need to understand
- We will be expanding the admin area in the coming months

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- currently it needs GOVUK_FRONTEND=true so it can be booted in either UI

### Screenshots

![Screenshot from 2021-11-15 15-30-19](https://user-images.githubusercontent.com/10818/141811761-00f45498-5b18-4a70-be83-c3923039e001.png)
![Screenshot from 2021-11-15 15-24-17](https://user-images.githubusercontent.com/10818/141811768-ed6e352d-9675-46a0-9835-9b1af0557885.png)
![Screenshot from 2021-11-15 15-23-55](https://user-images.githubusercontent.com/10818/141811771-853f373c-46f8-4091-ad52-1860c0d8c987.png)
![Screenshot from 2021-11-15 15-23-21](https://user-images.githubusercontent.com/10818/141811773-58873f85-044c-4a9c-bc33-0d8ca92f557c.png)
