### PR TITLE
Require confirmation before deploying to production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -208,6 +208,14 @@ workflows:
             branches:
               only:
                 - main
+      - hold_production:
+          type: approval
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - deploy_staging
       - deploy_prod:
           context: trade-tariff
           filters:
@@ -215,5 +223,5 @@ workflows:
               only:
                 - main
           requires:
-            - deploy_staging
+            - hold_production
 


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [ ] Added a confirmation step before deploying to production

### Why?

I am doing this because:

- Currently its not possible to check the app on staging after merging - by the point you are checking it is already deploying to production.
