### PR TITLE
HOTT-1132 service tags

### DIFF
--- a/app/controllers/govspeak_controller.rb
+++ b/app/controllers/govspeak_controller.rb
@@ -5,7 +5,8 @@ class GovspeakController < AuthenticatedController
     flash.keep
 
     if params[:govspeak]
-      doc = Govspeak::Document.new(params[:govspeak], sanitize: true)
+      substituted_content = helpers.replace_service_tags(params[:govspeak].to_s)
+      doc = Govspeak::Document.new(substituted_content, sanitize: true)
 
       respond_to do |format|
         format.json { render json: { govspeak: doc.to_html } }

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -7,6 +7,33 @@ module ServiceHelper
     end
   end
 
+  def service_name
+    if TradeTariffAdmin::ServiceChooser.uk?
+      'UK Integrated Online Tariff'
+    else
+      'Northern Ireland Online Tariff'
+    end
+  end
+
+  def service_region
+    TradeTariffAdmin::ServiceChooser.uk? ? 'the UK' : 'Northern Ireland'
+  end
+
+  def replace_service_tags(content)
+    content.gsub %r{\[\[SERVICE_[A-Z_]+\]\]} do |match|
+      case match
+      when '[[SERVICE_NAME]]'
+        service_name
+      when '[[SERVICE_PATH]]'
+        TradeTariffAdmin::ServiceChooser.uk? ? '' : '/xi'
+      when '[[SERVICE_REGION]]'
+        service_region
+      else
+        match
+      end
+    end
+  end
+
   private
 
   def current_path

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -14,6 +14,8 @@ class NewsItem
   validates :start_date, presence: true
 
   def preview
-    Govspeak::Document.new(content, sanitize: true).to_html.html_safe
+    substituted_content = ApplicationController.helpers.replace_service_tags(content.to_s)
+
+    Govspeak::Document.new(substituted_content, sanitize: true).to_html.html_safe
   end
 end

--- a/app/views/news_items/_form.html+govuk.erb
+++ b/app/views/news_items/_form.html+govuk.erb
@@ -3,6 +3,50 @@
 
   <%= govuk_markdown_area f, :content, rows: 12 %>
 
+  <details class="govuk-details" data-module="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">
+        Replaceable service tags
+      </span>
+    </summary>
+    <div class="govuk-details__text">
+      <p>
+        These are pieces of text you can insert into your content and they
+        will be replaced with content appropriate to the service the user is viewing
+      </p>
+      <dl class="govuk-summary-list">
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            [[SERVICE_NAME]]
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Either <em>UK Integrated Online Tariff</em> or
+            <em>Northern Ireland Online Tariff</em>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            [[SERVICE_REGION]]
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Either <em>the UK</em> or <em>Northern Ireland</em>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            [[SERVICE_PATH]]
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Useful for links that work for both UK and XI services, eg
+            <pre>[Browse]([[SERVICE_PATH]]/browse)</pre>
+          </dd>
+        </div>
+      </dl>
+    </div>
+  </details>
+
   <%= f.govuk_text_field :start_date, width: 'one-third' %>
   <%= f.govuk_text_field :end_date, width: 'one-third' %>
 

--- a/app/views/news_items/_form.html.erb
+++ b/app/views/news_items/_form.html.erb
@@ -5,6 +5,30 @@
     <div class="col-sm-6">
       <%= f.input :content, as: :text, input_html: { rows: 12 }, wrapper: :vertical_form %>
       <p><%= link_to 'Markdown guide', 'http://govspeak-preview.herokuapp.com/guide', target: '_blank'  %></p>
+      <details>
+        <summary>Replaceable service tags</summary>
+        <p>
+          These are pieces of text you can insert into your content and they
+          will be replaced with content appropriate to the service the user is viewing
+        </p>
+        <dl class="dl-horizontal">
+          <dt>[[SERVICE_NAME]]</dt>
+          <dd>
+            Either <em>UK Integrated Online Tariff</em> or
+            <em>Northern Ireland Online Tariff</em>
+          </dd>
+
+          <dt>[[SERVICE_REGION]]</dt>
+          <dd>
+            Either <em>the UK</em> or <em>Northern Ireland</em>
+          </dd>
+
+          <dt>[[SERVICE_PATH]]</dt>
+          <dd>
+            Useful for links that work for both UK and XI services, eg <pre>[Browse]([[SERVICE_PATH]]/browse)</pre>
+          </dd>
+        </dl>
+      </details>
     </div>
       <div class="col-sm-6">
       <%= f.label :preview, required: false %>

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -1,8 +1,36 @@
 require 'rails_helper'
 
 RSpec.describe ServiceHelper, type: :helper do
-  before do
-    allow(TradeTariffAdmin::ServiceChooser).to receive(:service_choice).and_return(choice)
+  describe '.service_name' do
+    subject { service_name }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      it { is_expected.to eql 'UK Integrated Online Tariff' }
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      it { is_expected.to eql 'Northern Ireland Online Tariff' }
+    end
+  end
+
+  describe '.service_region' do
+    subject { service_region }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      it { is_expected.to eql 'the UK' }
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      it { is_expected.to eql 'Northern Ireland' }
+    end
   end
 
   describe '.switch_service_link' do
@@ -13,8 +41,9 @@ RSpec.describe ServiceHelper, type: :helper do
     end
 
     context 'when the selected service choice is nil' do
+      include_context 'with default service'
+
       let(:path) { '/rollbacks/new' }
-      let(:choice) { nil }
 
       it 'returns the link to the XI service' do
         expect(switch_service_link).to eq(link_to('Switch to XI service', '/xi/rollbacks/new'))
@@ -22,8 +51,9 @@ RSpec.describe ServiceHelper, type: :helper do
     end
 
     context 'when the selected service choice is uk' do
+      include_context 'with UK service'
+
       let(:path) { '/uk/rollbacks/new' }
-      let(:choice) { 'uk' }
 
       it 'returns the link to the XI service' do
         expect(switch_service_link).to eq(link_to('Switch to XI service', '/xi/rollbacks/new'))
@@ -31,8 +61,9 @@ RSpec.describe ServiceHelper, type: :helper do
     end
 
     context 'when the selected service choice is xi' do
+      include_context 'with XI service'
+
       let(:path) { '/xi/rollbacks/new' }
-      let(:choice) { 'xi' }
 
       it 'returns the link to the current UK service' do
         expect(switch_service_link).to eq(link_to('Switch to UK service', '/rollbacks/new'))
@@ -40,7 +71,6 @@ RSpec.describe ServiceHelper, type: :helper do
 
       context 'when using the root path' do
         let(:path) { '/xi' }
-        let(:choice) { 'xi' }
 
         it 'returns the link to the current UK service' do
           expect(switch_service_link).to eq(link_to('Switch to UK service', '/'))
@@ -51,10 +81,111 @@ RSpec.describe ServiceHelper, type: :helper do
     context 'with a css class' do
       subject { switch_service_link class: 'test-class' }
 
+      include_context 'with default service'
+
       let(:path) { '/rollbacks/new' }
-      let(:choice) { nil }
 
       it { is_expected.to have_css 'a.test-class' }
+    end
+  end
+
+  describe '.replace_service_tags' do
+    subject { replace_service_tags content }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      context 'without tags' do
+        let(:content) { 'this is some sample content' }
+
+        it { is_expected.to eql 'this is some sample content' }
+      end
+
+      context 'with SERVICE_NAME tag' do
+        let(:content) { 'You are on the [[SERVICE_NAME]]' }
+
+        it { is_expected.to eql 'You are on the UK Integrated Online Tariff' }
+      end
+
+      context 'with SERVICE_PATH tag' do
+        let(:content) { '<a href="[[SERVICE_PATH]]/browse">Browse</a>' }
+
+        it { is_expected.to eql '<a href="/browse">Browse</a>' }
+      end
+
+      context 'with SERVICE_REGION' do
+        let(:content) { 'within [[SERVICE_REGION]]' }
+
+        it { is_expected.to eql 'within the UK' }
+      end
+
+      context 'with multiple tags' do
+        let :content do
+          <<~END_OF_CONTENT
+            [[SERVICE_NAME]]
+            * [Find commodity]([[SERVICE_PATH]]/find_commodity)
+            * [Browse]([[SERVICE_PATH]]/browse)
+          END_OF_CONTENT
+        end
+
+        let :expected do
+          <<~END_OF_EXPECTED
+            UK Integrated Online Tariff
+            * [Find commodity](/find_commodity)
+            * [Browse](/browse)
+          END_OF_EXPECTED
+        end
+
+        it { is_expected.to eql expected }
+      end
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      context 'without tags' do
+        let(:content) { 'this is some sample content' }
+
+        it { is_expected.to eql 'this is some sample content' }
+      end
+
+      context 'with SERVICE_NAME tag' do
+        let(:content) { 'You are on the [[SERVICE_NAME]]' }
+
+        it { is_expected.to eql 'You are on the Northern Ireland Online Tariff' }
+      end
+
+      context 'with SERVICE_PATH tag' do
+        let(:content) { '<a href="[[SERVICE_PATH]]/browse">Browse</a>' }
+
+        it { is_expected.to eql '<a href="/xi/browse">Browse</a>' }
+      end
+
+      context 'with SERVICE_REGION' do
+        let(:content) { 'within [[SERVICE_REGION]]' }
+
+        it { is_expected.to eql 'within Northern Ireland' }
+      end
+
+      context 'with multiple tags' do
+        let :content do
+          <<~END_OF_CONTENT
+            [[SERVICE_NAME]]
+            * [Find commodity]([[SERVICE_PATH]]/find_commodity)
+            * [Browse]([[SERVICE_PATH]]/browse)
+          END_OF_CONTENT
+        end
+
+        let :expected do
+          <<~END_OF_EXPECTED
+            Northern Ireland Online Tariff
+            * [Find commodity](/xi/find_commodity)
+            * [Browse](/xi/browse)
+          END_OF_EXPECTED
+        end
+
+        it { is_expected.to eql expected }
+      end
     end
   end
 end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -35,6 +35,16 @@ describe NewsItem do
     let(:news_item) { build :news_item, content: '# Hello world' }
 
     it { is_expected.to eql %(<h1 id="hello-world">Hello world</h1>\n) }
+
+    context 'with service tags' do
+      include_context 'with XI service'
+
+      let :news_item do
+        build :news_item, content: '[Browse]([[SERVICE_PATH]]/browse)'
+      end
+
+      it { is_expected.to eql %(<p><a href="/xi/browse">Browse</a></p>\n) }
+    end
   end
 
   describe '#all' do

--- a/spec/requests/govspeak_controller_spec.rb
+++ b/spec/requests/govspeak_controller_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+describe GovspeakController do
+  subject(:rendered_page) { create_user && make_request && response }
+
+  let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
+
+  describe 'POST #govspeak' do
+    let :make_request do
+      post govspeak_path(format: :json), params: { govspeak: '# Hello world' }
+    end
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.to have_attributes media_type: /json/ }
+  end
+end

--- a/spec/requests/govspeak_controller_spec.rb
+++ b/spec/requests/govspeak_controller_spec.rb
@@ -1,12 +1,12 @@
 require 'rails_helper'
 
 describe GovspeakController do
-  subject(:rendered_page) { create_user && make_request && response }
+  subject(:rendered_page) { response }
 
-  let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
+  before { create :user, permissions: ['signin', 'HMRC Editor'] }
 
   describe 'POST #govspeak' do
-    let :make_request do
+    before do
       post govspeak_path(format: :json), params: { govspeak: '# Hello world' }
     end
 

--- a/spec/support/shared_context/service_chooser.rb
+++ b/spec/support/shared_context/service_chooser.rb
@@ -1,0 +1,20 @@
+RSpec.shared_context 'with UK service' do
+  before do
+    allow(TradeTariffAdmin::ServiceChooser).to \
+      receive(:service_choice).and_return 'uk'
+  end
+end
+
+RSpec.shared_context 'with XI service' do
+  before do
+    allow(TradeTariffAdmin::ServiceChooser).to \
+      receive(:service_choice).and_return 'xi'
+  end
+end
+
+RSpec.shared_context 'with default service' do
+  before do
+    allow(TradeTariffAdmin::ServiceChooser).to \
+      receive(:service_choice).and_return nil
+  end
+end


### PR DESCRIPTION
### Jira link

[HOTT-1132](https://transformuk.atlassian.net/browse/HOTT-1132)

### What?

I have added/removed/altered:

- [x] Added a `replace_service_tags` helper to allow inserting the service name/region into the News Item content
- [x] Extended the news items forms to use this, along with explanation text
- [x] Added a spec for the `/govspeak` previewing endpoint

### Why?

I am doing this because:

- We want a way to insert the Service name into news item content shown on the frontend
