### PR TITLE
HOTT-1216: Dockerise admin app

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,12 +1,96 @@
 version: 2.1
 
 orbs:
+  aws-cli: circleci/aws-cli@2.0.3
   ruby: circleci/ruby@1.2.0
   node: circleci/node@4.7.0
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0
 
 commands:
+  deploy_docker:
+    parameters:
+      dev-release:
+        default: false
+        type: boolean
+      space:
+        type: string
+      environment_key:
+        type: string
+    steps:
+      - checkout
+      - run:
+          name: "Setup CF CLI"
+          command: |
+            curl -L -o cf.deb --retry 3 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.2.0&source=github-rel'
+            file cf.deb
+            sudo dpkg -i cf.deb
+            cf -v
+            cf api "$CF_ENDPOINT"
+            cf auth "$CF_USER" "$CF_PASSWORD"
+            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+            cf install-plugin app-autoscaler-plugin -r CF-Community -f
+            cf target -o "$CF_ORG" -s "<< parameters.space >>"
+      - run:
+          name: "Fetch existing manifest"
+          command: |
+            cf create-app-manifest "$CF_APP-<< parameters.environment_key >>" -p deploy_manifest.yml
+      - run:
+          name: "Push new app in dark mode"
+          command: |
+            export DOCKER_IMAGE=tariff-admin
+            export DOCKER_TAG=<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
+
+            # Push as "dark" instance
+            CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
+            # Map dark route
+            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
+            # Enable routing from this service to the backend applications which are private
+            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" --protocol tcp --port 8080
+            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_UK-<< parameters.environment_key >>" --protocol tcp --port 8080
+      - run:
+          name: "Verify new version is working on dark URL."
+          command: |
+            sleep 15
+            # TODO: Retry
+            # Verify new version is working on dark URL.
+            HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-<< parameters.environment_key >>-dark.london.cloudapps.digital/healthcheck`
+
+            if [ "$HTTPCODE" -ne 200 ];then
+              echo "dark route not available, failing deploy ($HTTPCODE)"
+              cf logs "$CF_APP-<< parameters.environment_key >>-dark" --recent
+              cf delete -f  "$CF_APP-<< parameters.environment_key >>-dark"
+              exit 1
+            fi
+      - run:
+          name: "Switch dark app to live"
+          command: |
+            # Send "real" url to new version
+            cf unmap-route "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
+
+            # Start sending traffic to new version
+            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
+
+            # Stop sending traffic to previous version
+            cf unmap-route  "$CF_APP-<< parameters.environment_key >>" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
+
+            # stop previous version
+            cf stop "$CF_APP-<< parameters.environment_key >>"
+
+            # delete previous version
+            cf delete "$CF_APP-<< parameters.environment_key >>" -f
+
+            # Switch name of "dark" version to claim correct name
+            cf rename "$CF_APP-<< parameters.environment_key >>-dark" "$CF_APP-<< parameters.environment_key >>"
+      - slack/notify:
+          channel: deployments
+          event: fail
+          template: basic_fail_1
+      - slack/notify:
+          channel: deployments
+          event: pass
+          template: basic_success_1
+
   cf_deploy:
     parameters:
       space:
@@ -52,7 +136,6 @@ commands:
           name: "Verify new version is working on dark URL."
           command: |
             sleep 15
-            # TODO: Retry
             # Verify new version is working on dark URL.
             HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-<< parameters.environment_key >>-dark.london.cloudapps.digital/healthcheck`
             if [ "$HTTPCODE" -ne 200 ];then
@@ -98,6 +181,37 @@ commands:
 
 
 jobs:
+  build_docker:
+    environment:
+      IMAGE_NAME: tariff-admin
+    parameters:
+      dev-build:
+        default: false
+        type: boolean
+    docker:
+      - image: cimg/ruby:3.0.3-node
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 20.10.2
+          docker_layer_caching: false
+      - aws-cli/install
+      - run:
+          name: "Set docker tag"
+          command: |
+            echo "export DOCKER_TAG=<<# parameters.dev-build >>dev-<</ parameters.dev-build >>${CIRCLE_SHA1}" >> $BASH_ENV
+      - run:
+          name: "Build Docker image"
+          command: |
+            export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
+            echo $GIT_NEW_REVISION >REVISION
+            docker build -t $IMAGE_NAME:$DOCKER_TAG .
+      - run:
+          name: "Push image to ECR"
+          command: |
+            aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
+            docker tag $IMAGE_NAME:$DOCKER_TAG $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
+            docker push $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
   build:
     docker:
       - image: cimg/ruby:3.0.3-node
@@ -179,6 +293,7 @@ jobs:
       - ruby/rspec-test
       - store_artifacts:
           path: coverage
+
   deploy_dev:
     docker:
       - image: cimg/ruby:3.0.3-node
@@ -214,10 +329,54 @@ jobs:
           environment_key: "production"
       - sentry-release
 
+  deploy_development_docker:
+    docker:
+      - image: cimg/ruby:3.0.3
+    environment:
+      SENTRY_ENVIRONMENT: "development"
+    steps:
+      - deploy_docker:
+          dev-release: true
+          space: "development"
+          environment_key: "dev"
+      - sentry-release
+
+  deploy_staging_docker:
+    docker:
+      - image: cimg/ruby:3.0.3-node
+    environment:
+      SENTRY_ENVIRONMENT: "staging"
+    steps:
+      - cf_deploy_docker:
+          space: "staging"
+          environment_key: "staging"
+      - sentry-release
+
+  deploy_production_docker:
+    docker:
+      - image: cimg/ruby:3.0.3-node
+    environment:
+      SENTRY_ENVIRONMENT: "production"
+    steps:
+      - cf_deploy_docker:
+          space: "production"
+          environment_key: "production"
+      - sentry-release
+
+
 workflows:
   version: 2
   build_and_test:
     jobs:
+      - build_docker:
+          name: build_docker_dev
+          context: trade-tariff
+          dev-build: true
+          filters:
+            branches:
+              ignore:
+                - main
+                - /^dependabot\/.*/
       - linters:
           context: trade-tariff
       - test:
@@ -232,15 +391,23 @@ workflows:
             branches:
               ignore:
                 - main
-      - deploy_dev:
+      - deploy_development_docker:
           context: trade-tariff
           filters:
             branches:
               ignore:
                 - main
           requires:
+            - build_docker_dev
             - test
             - govuktest
+      - build_docker:
+          name: build_live
+          context: trade-tariff
+          filters:
+            branches:
+              only:
+                - main
       - deploy_staging:
           context: trade-tariff
           filters:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,61 @@
+# Build compilation image
+FROM ruby:3.0.3-alpine3.13 as builder
+
+# The application runs from /app
+WORKDIR /app
+
+# build-base: compilation tools for bundle
+# git: used to pull gems from git
+# yarn: node package manager
+RUN apk add --update --no-cache build-base git yarn postgresql-dev tzdata && \
+  cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
+  echo "Europe/London" > /etc/timezone
+
+RUN bundle config set without 'development test'
+
+# Install gems defined in Gemfile
+COPY .ruby-version Gemfile Gemfile.lock /app/
+RUN bundle install --jobs=4 --no-binstubs
+
+# Install node packages defined in package.json, including webpack
+COPY package.json yarn.lock /app/
+RUN yarn install --frozen-lockfile
+
+# Copy all files to /app (except what is defined in .dockerignore)
+COPY . /app/
+
+ENV GOVUK_APP_DOMAIN=localhost
+ENV GOVUK_WEBSITE_ROOT=http://localhost/
+ENV RAILS_ENV=production
+ENV SECRET_TOKEN="foo"
+ENV SECRET_KEY_BASE="bar"
+
+RUN bundle exec rails assets:precompile
+
+# Cleanup to save space in the production image
+RUN rm -rf node_modules log tmp && \
+      rm -rf /usr/local/bundle/cache && \
+      rm -rf .env && \
+      find /usr/local/bundle/gems -name "*.c" -delete && \
+      find /usr/local/bundle/gems -name "*.h" -delete && \
+      find /usr/local/bundle/gems -name "*.o" -delete && \
+      find /usr/local/bundle/gems -name "*.html" -delete
+
+# Build runtime image
+FROM ruby:3.0.3-alpine3.13 as production
+
+RUN apk add --update --no-cache tzdata postgresql-dev nodejs && \
+  cp /usr/share/zoneinfo/Europe/London /etc/localtime && \
+  echo "Europe/London" > /etc/timezone
+
+# The application runs from /app
+WORKDIR /app
+
+ENV RAILS_SERVE_STATIC_FILES=true
+ENV RAILS_ENV=production
+
+# Copy files generated in the builder image
+COPY --from=builder /app /app
+COPY --from=builder /usr/local/bundle/ /usr/local/bundle/
+
+CMD ["bundle", "exec", "rails", "server", "-b", "0.0.0.0"]

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,8 +1,7 @@
-if defined?(Raven)
+if defined?(Raven) && ENV['VCAP_APPLICATION'].present?
   tags = JSON.parse(ENV['VCAP_APPLICATION'])
              .except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version')
              .merge({ server_name: ENV['GOVUK_APP_DOMAIN'] })
-  Raven.configure do |config|
-    config.tags = tags
-  end
+
+  Raven.configure { |config| config.tags = tags }
 end

--- a/lib/trade_tariff_admin/service_chooser.rb
+++ b/lib/trade_tariff_admin/service_chooser.rb
@@ -6,7 +6,7 @@ module TradeTariffAdmin
       end
 
       def service_choices
-        @service_choices ||= JSON.parse(ENV['API_SERVICE_BACKEND_URL_OPTIONS'])
+        @service_choices ||= JSON.parse(ENV.fetch('API_SERVICE_BACKEND_URL_OPTIONS', '{}'))
       end
 
       def service_choice=(service_choice)


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1216

### What?

I have added/removed/altered:

- [x] Added dockerfile and circle ci workflows for building and deploying an admin app in docker

### Why?

I am doing this because:

- This makes the admin app consistent with all of our other apps and means we can manage it more consistently - recently, for example, I couldn't bump ruby until buildpacks were available reflecting a different cadence of upgrades between our apps.

### AC

- [x] Deploying to staging and production are unaffected for the moment