### PR TITLE
HOTT-1216: Enable docker in staging and production

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -317,7 +317,7 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "staging"
     steps:
-      - cf_deploy_docker:
+      - deploy_docker:
           space: "staging"
           environment_key: "staging"
       - sentry-release
@@ -328,7 +328,7 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "production"
     steps:
-      - cf_deploy_docker:
+      - deploy_docker:
           space: "production"
           environment_key: "production"
       - sentry-release
@@ -371,12 +371,14 @@ workflows:
             branches:
               only:
                 - main
-      - deploy_staging:
+      - deploy_staging_docker:
           context: trade-tariff
           filters:
             branches:
               only:
                 - main
+          requires:
+            - build_live
       - hold_production:
           type: approval
           filters:
@@ -384,8 +386,8 @@ workflows:
               only:
                 - main
           requires:
-            - deploy_staging
-      - deploy_prod:
+            - deploy_staging_docker
+      - deploy_production_docker:
           context: trade-tariff
           filters:
             branches:


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1216

### What?

I have added/removed/altered:

- [x] Altered deploy steps for staging and production to use the docker deploy command

### Why?

I am doing this because:

- This is required in order to kick off a staging and production deploy using the docker image


The rollout plan is to:

1. Rename staging app
2. Manually create staging app with a arbitrary docker image in manifest with the old name
3. Kick off ci process by merging this PR
4. Validate staging is up and running
5. Stop old renamed staging app
6. Validate staging is still up and running
7. Delete old renamed staging app

... repeat for production
