### PR TITLE
HOTT-1216: Clean up after docker migration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
   slack: circleci/slack@4.3.0
 
 commands:
-  deploy_docker:
+  deploy:
     parameters:
       dev-release:
         default: false
@@ -91,80 +91,6 @@ commands:
           event: pass
           template: basic_success_1
 
-  cf_deploy:
-    parameters:
-      space:
-        type: string
-      environment_key:
-        type: string
-      buildpack_version:
-        type: string
-        default: "v1.8.49"
-    steps:
-      - checkout
-      - run:
-          name: "Setup CF CLI"
-          command: |
-            curl -L -o cf.deb 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.2.0&source=github-rel'
-            sudo dpkg -i cf.deb
-            cf -v
-            cf api "$CF_ENDPOINT"
-            cf auth "$CF_USER" "$CF_PASSWORD"
-            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-            cf install-plugin app-autoscaler-plugin -r CF-Community -f
-            cf target -o "$CF_ORG" -s "<< parameters.space >>"
-      - run:
-          name: "Fetch existing manifest"
-          command: |
-            cf create-app-manifest "$CF_APP-<< parameters.environment_key >>" -p deploy_manifest.yml
-      - run:
-          name: "Push new app in dark mode"
-          command: |
-            # Enables /healthcheck to show the current deployed git sha
-            export GIT_NEW_REVISION=$(git rev-parse --short HEAD)
-            echo $GIT_NEW_REVISION >REVISION
-
-            export BUILDPACK="https://github.com/cloudfoundry/ruby-buildpack.git#<< parameters.buildpack_version >>"
-            # Push as "dark" instance
-            cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --buildpack $BUILDPACK
-            # Map dark route
-            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
-            # Enable routing from this frontend to backend applications which are private
-            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_XI-<< parameters.environment_key >>" --protocol tcp --port 8080
-            cf add-network-policy "$CF_APP-<< parameters.environment_key >>-dark" "$CF_BACKEND_APP_UK-<< parameters.environment_key >>"  --protocol tcp --port 8080
-      - run:
-          name: "Verify new version is working on dark URL."
-          command: |
-            sleep 15
-            # Verify new version is working on dark URL.
-            HTTPCODE=`curl -s -o /dev/null -w "%{http_code}" https://$CF_APP-<< parameters.environment_key >>-dark.london.cloudapps.digital/healthcheck`
-            if [ "$HTTPCODE" -ne 200 ];then
-              echo "dark route not available, failing deploy ($HTTPCODE)"
-              exit 1
-            fi
-      - run:
-          name: "Switch dark app to live"
-          command: |
-            # Send "real" url to new version
-            cf unmap-route "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>-dark"
-            cf map-route  "$CF_APP-<< parameters.environment_key >>-dark" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
-            # Stop sending traffic to previous version
-            cf unmap-route  "$CF_APP-<< parameters.environment_key >>" london.cloudapps.digital -n "$CF_APP-<< parameters.environment_key >>"
-            # stop previous version
-            cf stop "$CF_APP-<< parameters.environment_key >>"
-            # delete previous version
-            cf delete "$CF_APP-<< parameters.environment_key >>" -f
-            # Switch name of "dark" version to claim correct name
-            cf rename "$CF_APP-<< parameters.environment_key >>-dark" "$CF_APP-<< parameters.environment_key >>"
-      - slack/notify:
-          channel: deployments
-          event: fail
-          template: basic_fail_1
-      - slack/notify:
-          channel: deployments
-          event: pass
-          template: basic_success_1
-
   sentry-release:
     steps:
       - checkout
@@ -181,7 +107,7 @@ commands:
 
 
 jobs:
-  build_docker:
+  build:
     environment:
       IMAGE_NAME: tariff-admin
     parameters:
@@ -212,14 +138,6 @@ jobs:
             aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
             docker tag $IMAGE_NAME:$DOCKER_TAG $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
             docker push $ECR_REPO/$IMAGE_NAME:$DOCKER_TAG
-  build:
-    docker:
-      - image: cimg/ruby:3.0.3-node
-    steps:
-      - checkout
-      - ruby/install-deps
-      - node/install-packages:
-          pkg-manager: yarn
   linters:
     docker:
       - image: 'cimg/ruby:3.0.3-node'
@@ -264,14 +182,14 @@ jobs:
       - store_artifacts:
           path: coverage
 
-  deploy_dev:
+  deploy_development:
     docker:
-      - image: cimg/ruby:3.0.3-node
+      - image: cimg/ruby:3.0.3
     environment:
-      SENTRY_ENVIRONMENT: development
+      SENTRY_ENVIRONMENT: "development"
     steps:
-      - checkout
-      - cf_deploy:
+      - deploy:
+          dev-release: true
           space: "development"
           environment_key: "dev"
       - sentry-release
@@ -280,66 +198,30 @@ jobs:
     docker:
       - image: cimg/ruby:3.0.3-node
     environment:
-      SENTRY_ENVIRONMENT: staging
-    steps:
-      - checkout
-      - cf_deploy:
-          space: "staging"
-          environment_key: "staging"
-      - sentry-release
-
-  deploy_prod:
-    docker:
-      - image: cimg/ruby:3.0.3-node
-    environment:
-      SENTRY_ENVIRONMENT: production
-    steps:
-      - cf_deploy:
-          space: "production"
-          environment_key: "production"
-      - sentry-release
-
-  deploy_development_docker:
-    docker:
-      - image: cimg/ruby:3.0.3
-    environment:
-      SENTRY_ENVIRONMENT: "development"
-    steps:
-      - deploy_docker:
-          dev-release: true
-          space: "development"
-          environment_key: "dev"
-      - sentry-release
-
-  deploy_staging_docker:
-    docker:
-      - image: cimg/ruby:3.0.3-node
-    environment:
       SENTRY_ENVIRONMENT: "staging"
     steps:
-      - deploy_docker:
+      - deploy:
           space: "staging"
           environment_key: "staging"
       - sentry-release
 
-  deploy_production_docker:
+  deploy_production:
     docker:
       - image: cimg/ruby:3.0.3-node
     environment:
       SENTRY_ENVIRONMENT: "production"
     steps:
-      - deploy_docker:
+      - deploy:
           space: "production"
           environment_key: "production"
       - sentry-release
-
 
 workflows:
   version: 2
   build_and_test:
     jobs:
-      - build_docker:
-          name: build_docker_dev
+      - build:
+          name: build_dev
           context: trade-tariff
           dev-build: true
           filters:
@@ -355,23 +237,23 @@ workflows:
             branches:
               ignore:
                 - main
-      - deploy_development_docker:
+      - deploy_development:
           context: trade-tariff
           filters:
             branches:
               ignore:
                 - main
           requires:
-            - build_docker_dev
+            - build_dev
             - test
-      - build_docker:
+      - build:
           name: build_live
           context: trade-tariff
           filters:
             branches:
               only:
                 - main
-      - deploy_staging_docker:
+      - deploy_staging:
           context: trade-tariff
           filters:
             branches:
@@ -386,8 +268,8 @@ workflows:
               only:
                 - main
           requires:
-            - deploy_staging_docker
-      - deploy_production_docker:
+            - deploy_staging
+      - deploy_production:
           context: trade-tariff
           filters:
             branches:


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1216

### What?

I have added/removed/altered:

- [x] Remove arbitrary references to docker in job/command names
- [x] Remove old commands/jobs that are no longer used in our ci process

### Why?

I am doing this because:

- Reduce cognitive overhead when reviewing our ci config
