### PR TITLE
HOTT-1223 Tagged docker images as production releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,14 +220,24 @@ jobs:
   create_production_release:
     docker:
       - image: cimg/ruby:3.0.3-node
+    environment:
+      IMAGE_NAME: tariff-admin
     steps:
       - checkout
+      - setup_remote_docker:
+          version: 20.10.2
+          docker_layer_caching: false
+      - aws-cli/install
       - run:
           name: Generate release notes
           command: |
-            LAST_RELEASE=$(git tag --list 'release-202*-*' | sort | tail -n 1)
-
             mkdir release-details
+
+            NEW_RELEASE=$(date +"%Y%m%d-%H%M")
+            echo "${NEW_RELEASE}" > release-details/name.txt
+            echo "export NEW_RELEASE='${NEW_RELEASE}'" >> $BASH_ENV
+
+            LAST_RELEASE=$(git tag --list 'release-202*-*' | sort | tail -n 1)
             if [[ -z "${LAST_RELEASE}" ]]; then
               echo "First release" > release-details/notes.txt
             else
@@ -239,13 +249,17 @@ jobs:
             fi
       - run:
           command: cat release-details/notes.txt
+      - run:
+          name: Tag Docker Image as production release
+          command: |
+            aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
+            docker pull "${ECR_REPO}/${IMAGE_NAME}:${CIRCLE_SHA1}"
+            docker tag "${ECR_REPO}/${IMAGE_NAME}:${CIRCLE_SHA1}" "${ECR_REPO}/${IMAGE_NAME}:release-${NEW_RELEASE}"
+            docker push "${ECR_REPO}/${IMAGE_NAME}:release-${NEW_RELEASE}"
       - gh/setup
       - run:
           name: Create GitHub release
           command: |
-            NEW_RELEASE=$(date +"%Y%m%d-%H%M")
-            echo "${NEW_RELEASE}" > release-details/name.txt
-
             gh release create release-$NEW_RELEASE --notes-file release-details/notes.txt --title "Release $NEW_RELEASE"
       - persist_to_workspace:
           root: .


### PR DESCRIPTION
### Jira link

[HOTT-1223](https://transformuk.atlassian.net/browse/HOTT-1223)

### What?

I have added/removed/altered:

- [x] Tag build docker image with the github release version when publishing a release

### Why?

I am doing this because:

- It makes it easier to identify docker images which were released to production

### Notes

The docker image is tagged _before_ the GitHub release is created - this seems back to front _but_ I'm planning to change the actual release to production to be triggered by an appropriately named git tag (which will allow for easy rollbacks from CI), since the creation of a GitHub release will create that tag, and that will trigger deployment of the docker image - it needs the docker tag to exist before the git tag is created to avoid a race condition in CI