### PR TITLE
HOTT-1241 Explicitly specify docker tag to deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,7 +211,7 @@ jobs:
       SENTRY_ENVIRONMENT: "production"
     steps:
       - deploy:
-          docker_image_tag: $CIRCLE_SHA1
+          docker_image_tag: $CIRCLE_TAG
           space: "production"
           environment_key: "production"
       - sentry-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,8 @@ orbs:
 commands:
   deploy:
     parameters:
-      dev-release:
-        default: false
-        type: boolean
+      docker_image_tag:
+        type: string
       space:
         type: string
       environment_key:
@@ -40,7 +39,7 @@ commands:
           name: "Push new app in dark mode"
           command: |
             export DOCKER_IMAGE=tariff-admin
-            export DOCKER_TAG=<<# parameters.dev-release >>dev-<</ parameters.dev-release >>${CIRCLE_SHA1}
+            export DOCKER_TAG="<< parameters.docker_image_tag >>"
 
             # Push as "dark" instance
             CF_DOCKER_PASSWORD=$AWS_SECRET_ACCESS_KEY cf push "$CF_APP-<< parameters.environment_key >>-dark" -f deploy_manifest.yml --no-route --docker-image "$ECR_REPO/$DOCKER_IMAGE:$DOCKER_TAG" --docker-username "$AWS_ACCESS_KEY_ID"
@@ -188,7 +187,7 @@ jobs:
       SENTRY_ENVIRONMENT: "development"
     steps:
       - deploy:
-          dev-release: true
+          docker_image_tag: dev-$CIRCLE_SHA1
           space: "development"
           environment_key: "dev"
       - sentry-release
@@ -200,6 +199,7 @@ jobs:
       SENTRY_ENVIRONMENT: "staging"
     steps:
       - deploy:
+          docker_image_tag: $CIRCLE_SHA1
           space: "staging"
           environment_key: "staging"
       - sentry-release
@@ -211,6 +211,7 @@ jobs:
       SENTRY_ENVIRONMENT: "production"
     steps:
       - deploy:
+          docker_image_tag: $CIRCLE_SHA1
           space: "production"
           environment_key: "production"
       - sentry-release


### PR DESCRIPTION
### Jira link

[HOTT-1241](https://transformuk.atlassian.net/browse/HOTT-1241)

### What?

I have added/removed/altered:

- [x] Removed inferring of docker image in command and explicitly require the docker image to be supplied
- [x] Supply the relevant docker image in the different jobs for development/staging/production

### Why?

I am doing this because:

- We want to deploy release tagged docker images, this change will facilitate using release tags in production but continuing to use SHA derived tags in staging and development

### Deployment risks (optional)

- Changes production deployment pipeline, follows same pattern as dev and staging so problems should show up at those stages
