### PR TITLE
HOTT-1241 Add rollback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -262,27 +262,30 @@ jobs:
               --notes-file release-details/notes.txt \
               --title "Release $NEW_RELEASE" \
               --target "${CIRCLE_SHA1}"
-      - persist_to_workspace:
-          root: .
-          paths:
-            - "release-details"
 
   notify_production_release:
     docker:
       - image: cimg/ruby:3.0.3-node
     steps:
-      - attach_workspace:
-          at: .
       - run:
-          name: Read release details
+          name: Read release name
           command: |
-            echo 'export RELEASE_NAME="$(cat release-details/name.txt)"' >> $BASH_ENV
-            cat release-details/notes.txt | jq -aRsr . > release-details/cleaned-notes.txt
-            sed -i 's/\"//g' release-details/cleaned-notes.txt
-            sed -i "s/\'//g" release-details/cleaned-notes.txt
-            sed -i 's/"//g' release-details/cleaned-notes.txt
-            sed -i "s/'//g" release-details/cleaned-notes.txt
-            echo 'export RELEASE_NOTES="$(< release-details/cleaned-notes.txt)"' >> $BASH_ENV
+            RELEASE_NAME=$(echo "${CIRCLE_TAG}" | sed 's/^release-//')
+            echo "export RELEASE_NAME='${RELEASE_NAME}'" >> $BASH_ENV
+      - run:
+          name: Fetch release notes
+          command: |
+            REPO_API_URL=$(echo "${CIRCLE_REPOSITORY_URL}/" | sed 's|.git/$||' | sed 's|git@github.com:|https://api.github.com/repos/|')
+            curl --silent --show-error "${REPO_API_URL}/releases/tags/${CIRCLE_TAG}" | jq -r .body > release-notes.txt
+      - run:
+          name: Clean up notes
+          command: |
+            cat release-notes.txt | jq -aRsr . > cleaned-release-notes.txt
+            sed -i 's/\"//g' cleaned-release-notes.txt
+            sed -i "s/\'//g" cleaned-release-notes.txt
+            sed -i 's/"//g' cleaned-release-notes.txt
+            sed -i "s/'//g" cleaned-release-notes.txt
+            echo 'export RELEASE_NOTES="$(< cleaned-release-notes.txt)"' >> $BASH_ENV
       - slack/notify:
           channel: trade_tariff
           event: pass

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,8 +105,6 @@ commands:
             sentry-cli releases finalize $SENTRY_RELEASE
             sentry-cli releases deploys $SENTRY_RELEASE new -e $SENTRY_ENVIRONMENT
 
-
-
 jobs:
   build:
     environment:
@@ -374,16 +372,16 @@ workflows:
       - deploy_production:
           context: trade-tariff
           filters:
+            tags:
+              only: /^release-202[\d-]+/
             branches:
-              only:
-                - main
-          requires:
-            - create_production_release
+              ignore: /.*/
       - notify_production_release:
           context: trade-tariff
           filters:
+            tags:
+              only: /^release-202[\d-]+/
             branches:
-              only:
-                - main
+              ignore: /.*/
           requires:
             - deploy_production

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,7 +260,10 @@ jobs:
       - run:
           name: Create GitHub release
           command: |
-            gh release create release-$NEW_RELEASE --notes-file release-details/notes.txt --title "Release $NEW_RELEASE"
+            gh release create release-$NEW_RELEASE \
+              --notes-file release-details/notes.txt \
+              --title "Release $NEW_RELEASE" \
+              --target "${CIRCLE_SHA1}"
       - persist_to_workspace:
           root: .
           paths:


### PR DESCRIPTION
### Jira link

[HOTT-1241](https://transformuk.atlassian.net/browse/HOTT-1241)

### What?

I have added/removed/altered:

- [x] Changed the`create_production_release` step to tag the release the pipeline is against instead of the tip of main
- [x] Changed the `deploy_production` step to run from a matching tag instead of the completion of the `create-production-release` step
- [x] Changed the `notify_production_release` step to read the release name from the tag, and the release notes from GitHub instead of relying on files passed via the workspace. 

### Why?

I am doing this because:

- This will allow us to re-run the tagged release pipeline, there by giving us a rollback / re-deploy feature for our pipelines
- The reworking of the slack notification step is because now the pipeline is split up with the second being triggered by the tag, they no longer share a workspace so can no longer share files

### Deployment risks (optional)

- May potentially break production deploys but should fail rather then resulting in outage. Has been tested (via pipeline hacking) in dev space but final 'production' pipeline can only be tested after merge.
