### PR TITLE
HOTT-1240: Removes leaf from commodity api

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -5,8 +5,6 @@ class Commodity
 
   collection_path '/admin/commodities'
 
-  attributes :leaf
-
   has_many :search_references, class_name: 'Commodity::SearchReference'
 
   def id
@@ -23,10 +21,6 @@ class Commodity
 
   def reference_title
     "Commodity (#{to_param})"
-  end
-
-  def declarable
-    leaf
   end
 
   def request_path(_opts = {})

--- a/app/views/synonyms/headings/commodities/index.html.erb
+++ b/app/views/synonyms/headings/commodities/index.html.erb
@@ -17,16 +17,12 @@
         <td><%= commodity.goods_nomenclature_item_id %></td>
         <td><%= commodity.description.titleize %></td>
         <td class="hott-link-group">
-          <% if commodity.leaf %>
-            <div>
-              <%= pluralize commodity.search_references_count, "synonym" %>
-            </div>
-            <%= link_to 'Edit', synonyms_commodity_search_references_path(commodity) %>
-            <% if commodity.search_references_count > 0 %>
-              <%= link_to 'Export', export_synonyms_commodity_search_references_path(commodity), method: :post %>
-            <% end %>
-          <% else %>
-            <em>Intermediate code</em>
+          <div>
+            <%= pluralize commodity.search_references_count, "synonym" %>
+          </div>
+          <%= link_to 'Edit', synonyms_commodity_search_references_path(commodity) %>
+          <% if commodity.search_references_count > 0 %>
+            <%= link_to 'Export', export_synonyms_commodity_search_references_path(commodity), method: :post %>
           <% end %>
         </td>
       </tr>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1240

### What?

I have added/removed/altered:

- [x] Removed leaf from the commodity api

### Why?

I am doing this because:

- This is no longer relevant since we can create search references for non 80 productline suffix commodities
