### PR TITLE
HOTT-1248: Support productline_suffix in commodity search references

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,4 +1,4 @@
-API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3018","xi":"http://localhost:3019" }
+API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000","xi":"http://localhost:3000" }
 SERVICE_DEFAULT=uk
 PORT=3003
-ADMIN_HOST='http://localhost:3018'
+ADMIN_HOST='http://localhost:3000'

--- a/app/controllers/synonyms/exports_controller.rb
+++ b/app/controllers/synonyms/exports_controller.rb
@@ -2,7 +2,7 @@ module Synonyms
   class ExportsController < AuthenticatedController
     def create
       export_service = SearchReference::ExportAllService.new
-      filename = "all-synonyms-#{Time.zone.now.to_i}.csv"
+      filename = "all-synonyms-#{Time.zone.now.iso8601}.csv"
       send_data export_service.to_csv,
                 filename: filename
     end

--- a/app/models/chapter.rb
+++ b/app/models/chapter.rb
@@ -40,6 +40,10 @@ class Chapter
     short_code
   end
 
+  def export_filename
+    "#{self.class.name.tableize}-#{short_code}-synonyms-#{Time.zone.now.iso8601}.csv"
+  end
+
   def reference_title
     "Chapter (#{short_code})"
   end

--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -5,22 +5,28 @@ class Commodity
 
   collection_path '/admin/commodities'
 
+  attributes :id, :description
+
   has_many :search_references, class_name: 'Commodity::SearchReference'
 
-  def id
-    to_param
+  def productline_suffix
+    id.split('-', 2).last
   end
 
-  def to_param
-    goods_nomenclature_item_id
+  def goods_nomenclature_item_id
+    id.split('-', 2).first
   end
 
   def heading_id
     goods_nomenclature_item_id.first(4)
   end
 
+  def export_filename
+    "#{self.class.name.tableize}-#{id}-synonyms-#{Time.zone.now.iso8601}.csv"
+  end
+
   def reference_title
-    "Commodity (#{to_param})"
+    "Commodity (#{goods_nomenclature_item_id})"
   end
 
   def request_path(_opts = {})

--- a/app/models/commodity/search_reference.rb
+++ b/app/models/commodity/search_reference.rb
@@ -1,6 +1,23 @@
 class Commodity
   class SearchReference < ::SearchReference
-    collection_path '/admin/commodities/:referenced_id/search_references'
+    attributes :productline_suffix
+
+    collection_path '/admin/commodities/:referenced_id-:productline_suffix/search_references'
+
     type name.demodulize.tableize
+
+    # We special case the commodity with the override below because its id is formed of the composite keys of
+    # goods_nomenclature_item_id and the productline_suffix. Without this we would fail to be able to
+    # manage subheading commodities that have the same goods_nomenclature_item_id.
+    def referenced_id=(id_or_composite_id)
+      if id_or_composite_id.to_s.match?(%r{\d{10}-\d{2}})
+        referenced_id, productline_suffix = id_or_composite_id.split('-', 2)
+
+        attributes[:referenced_id] = referenced_id
+        attributes[:productline_suffix] = productline_suffix
+      else
+        attributes[:referenced_id] = id_or_composite_id
+      end
+    end
   end
 end

--- a/app/models/heading.rb
+++ b/app/models/heading.rb
@@ -26,6 +26,10 @@ class Heading
     heading_id.to_s
   end
 
+  def export_filename
+    "#{self.class.name.tableize}-#{heading_id}-synonyms-#{Time.zone.now.iso8601}.csv"
+  end
+
   def reference_title
     "Heading (#{heading_id})"
   end

--- a/app/models/section.rb
+++ b/app/models/section.rb
@@ -31,6 +31,10 @@ class Section
     end
   end
 
+  def export_filename
+    "#{self.class.name.tableize}-#{position}-synonyms-#{Time.zone.now.iso8601}.csv"
+  end
+
   def reference_title
     "Section (#{position})"
   end

--- a/app/services/search_reference/import_service.rb
+++ b/app/services/search_reference/import_service.rb
@@ -42,7 +42,7 @@ class SearchReference
                 'Chapter'
               elsif goods_nomenclature_item_id.ends_with?('000000')
                 'Heading'
-              elsif goods_nomenclature_item_id.length == 10
+              elsif goods_nomenclature_item_id.ends_with?(/-\d{2}/)
                 'Commodity'
               else
                 'Section'

--- a/app/views/synonyms/headings/commodities/index.html.erb
+++ b/app/views/synonyms/headings/commodities/index.html.erb
@@ -8,6 +8,7 @@
     <tr>
       <th>Commodity</th>
       <th>Title</th>
+      <th>Productline Suffix</th>
       <th class="actions_col">Synonyms</th>
     </tr>
   </thead>
@@ -16,6 +17,7 @@
       <tr id="<%= dom_id(commodity) %>">
         <td><%= commodity.goods_nomenclature_item_id %></td>
         <td><%= commodity.description.titleize %></td>
+        <td><%= commodity.productline_suffix %></td>
         <td class="hott-link-group">
           <div>
             <%= pluralize commodity.search_references_count, "synonym" %>

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -1,6 +1,13 @@
 FactoryBot.define do
   factory :commodity do
-    goods_nomenclature_item_id { 10.times.map { Random.rand(1..9) }.join }
+    id do
+      referenced_id = 10.times.map { Random.rand(1..9) }.join
+      productline_suffix = 2.times.map { Random.rand(1..9) }.join
+
+      "#{referenced_id}-#{productline_suffix}"
+    end
+
+    referenced_class { 'Commodity' }
 
     trait :with_heading do
       association :heading, strategy: :build

--- a/spec/factories/search_reference_factory.rb
+++ b/spec/factories/search_reference_factory.rb
@@ -32,10 +32,7 @@ FactoryBot.define do
   end
 
   factory :commodity_search_reference, parent: :search_reference, class: 'Commodity::SearchReference' do
-    transient do
-      referenced { attributes_for(:commodity) }
-    end
     referenced_class { 'Commodity' }
-    referenced_id { referenced[:goods_nomenclature_item_id] }
+    referenced_id { build(:commodity).id }
   end
 end

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -7,5 +7,9 @@ FactoryBot.define do
     trait :gds_editor do
       permissions { [User::Permissions::GDS_EDITOR] }
     end
+
+    trait :hmrc_editor do
+      permissions { [User::Permissions::SIGNIN, User::Permissions::HMRC_EDITOR] }
+    end
   end
 end

--- a/spec/models/chapter_spec.rb
+++ b/spec/models/chapter_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Chapter do
+  describe '#export_filename' do
+    subject(:result) { build(:chapter, goods_nomenclature_item_id: '0200000000').export_filename }
+
+    it { is_expected.to match(/^chapters-02-synonyms-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\.csv/) }
+  end
+end

--- a/spec/models/commodity/search_reference_spec.rb
+++ b/spec/models/commodity/search_reference_spec.rb
@@ -1,0 +1,23 @@
+require 'rails_helper'
+
+RSpec.describe Commodity::SearchReference do
+  describe '#referenced_id=' do
+    subject(:search_reference) { build(:commodity_search_reference, productline_suffix: '80') }
+
+    before do
+      search_reference.referenced_id = referenced_id
+    end
+
+    context 'when the referenced id is a composite goods_nomenclature_item_id and productline_suffix' do
+      let(:referenced_id) { '0201000023-10' }
+
+      it { is_expected.to have_attributes(referenced_id: '0201000023', productline_suffix: '10') }
+    end
+
+    context 'when the referenced id is a goods_nomenclature_item_id' do
+      let(:referenced_id) { '0201000023' }
+
+      it { is_expected.to have_attributes(referenced_id: '0201000023', productline_suffix: '80') }
+    end
+  end
+end

--- a/spec/models/commodity_spec.rb
+++ b/spec/models/commodity_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Commodity do
+  describe '#export_filename' do
+    subject(:result) { build(:commodity, id: '0201000023-10').export_filename }
+
+    it { is_expected.to match(/^commodities-0201000023-10-synonyms-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\.csv/) }
+  end
+end

--- a/spec/models/heading_spec.rb
+++ b/spec/models/heading_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Heading do
+  describe '#export_filename' do
+    subject(:result) { build(:heading, goods_nomenclature_item_id: '0201000000').export_filename }
+
+    it { is_expected.to match(/^headings-0201-synonyms-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\.csv/) }
+  end
+end

--- a/spec/models/section_spec.rb
+++ b/spec/models/section_spec.rb
@@ -1,0 +1,9 @@
+require 'rails_helper'
+
+RSpec.describe Section do
+  describe '#export_filename' do
+    subject(:result) { build(:section, position: 'XI').export_filename }
+
+    it { is_expected.to match(/^sections-XI-synonyms-\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z\.csv/) }
+  end
+end

--- a/spec/requests/synonyms/commodities/search_references_controller_spec.rb
+++ b/spec/requests/synonyms/commodities/search_references_controller_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+RSpec.describe Synonyms::Commodities::SearchReferencesController do
+  subject(:rendered) { create_user && make_request && response }
+
+  let(:create_user) { create(:user, :hmrc_editor) }
+
+  describe 'POST #export' do
+    let(:make_request) { post export_synonyms_commodity_search_references_path(commodity_id) }
+    let(:commodity) { build(:commodity, id: commodity_id) }
+    let(:commodity_id) { '0101210000-80' }
+    let(:commodity_search_reference) { build :commodity_search_reference, title: 'Blips and Chitz', referenced: commodity.attributes }
+
+    before do
+      allow(SearchReference::ExportService).to receive(:new).and_call_original
+
+      stub_api_for(Commodity) do |stub|
+        stub.get("/admin/commodities/#{commodity.to_param}") do |_env|
+          jsonapi_success_response('commodity', commodity.attributes)
+        end
+      end
+
+      stub_api_for(Commodity::SearchReference) do |stub|
+        stub.get("/admin/commodities/#{commodity.to_param}/search_references") do |_env|
+          jsonapi_success_response('search_reference', [commodity_search_reference.attributes], {})
+        end
+      end
+    end
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.to have_attributes media_type: 'text/csv' }
+
+    it 'initializes the ExportService with the correct args' do
+      rendered
+
+      expect(SearchReference::ExportService).to have_received(:new)
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1248

### What?

I have added/removed/altered:

- [x] Added support for the productline suffix when managing commodity search references

### Why?

I am doing this because:

- This is needed in order to differentiate between different commodity subheadings
