### PR TITLE
Fix for trying to deploy dependabot prs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -319,6 +319,7 @@ workflows:
             branches:
               ignore:
                 - main
+                - /^dependabot\/.*/
           requires:
             - build_dev
             - test


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Avoid trying to deploy PRs for dependabot

### Why?

I am doing this because:

- Currently we are - and it wont work because we're not building the images - we don't want to be anyway
