### PR TITLE
Split cf install into separate command for reuse

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,24 @@ orbs:
   gh: circleci/github-cli@1.0
 
 commands:
+  cf_install:
+    parameters:
+      space:
+        type: string
+    steps:
+      - run:
+          name: "Setup CF CLI"
+          command: |
+            curl -L -o cf.deb --retry 3 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.4.0&source=github-rel'
+            file cf.deb
+            sudo dpkg -i cf.deb
+            cf -v
+            cf api "$CF_ENDPOINT"
+            cf auth "$CF_USER" "$CF_PASSWORD"
+            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
+            cf install-plugin app-autoscaler-plugin -r CF-Community -f
+            cf target -o "$CF_ORG" -s "<< parameters.space >>"
+
   deploy:
     parameters:
       docker_image_tag:
@@ -19,18 +37,8 @@ commands:
         type: string
     steps:
       - checkout
-      - run:
-          name: "Setup CF CLI"
-          command: |
-            curl -L -o cf.deb --retry 3 'https://packages.cloudfoundry.org/stable?release=debian64&version=7.2.0&source=github-rel'
-            file cf.deb
-            sudo dpkg -i cf.deb
-            cf -v
-            cf api "$CF_ENDPOINT"
-            cf auth "$CF_USER" "$CF_PASSWORD"
-            cf add-plugin-repo CF-Community https://plugins.cloudfoundry.org
-            cf install-plugin app-autoscaler-plugin -r CF-Community -f
-            cf target -o "$CF_ORG" -s "<< parameters.space >>"
+      - cf_install:
+          space: << parameters.space >>
       - run:
           name: "Fetch existing manifest"
           command: |


### PR DESCRIPTION
### Jira link

HOTT-???

### What?

I have added/removed/altered:

- [x] Move cf install to own command to reduce duplication

### Why?

I am doing this because:

- We're defining how to download and retrieve the cf command in multiple places - this removes the duplication

