### PR TITLE
HOTT-1223 Fixed detection of empty release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ jobs:
             else
               git log --merges --format=format:"* %b" $LAST_RELEASE..HEAD > release-details/notes.txt
 
-              if [[ $(wc -l release-details/notes.txt | cut -d ' ' -f 1) == "0" ]]; then
+              if [[ ! -s release-details/notes.txt ]]; then
                 echo "No merged changes - possible re-release" > release-details/notes.txt
               fi
             fi


### PR DESCRIPTION
### Jira link

[HOTT-1223](https://transformuk.atlassian.net/browse/HOTT-1223)

### What?

I have added/removed/altered:

- [x] Fixed detection of blank release notes

### Why?

I am doing this because:

[Release 20220117-1446](https://github.com/trade-tariff/trade-tariff-admin/releases/tag/release-20220117-1446) ended up with with the fallback release notes, incorrectly. 

It turns out `wc -l` counts explicit line endings, not lines. Because the last line of git log output lacks a new line (or bash is stripping it when writing to a file) this means wc -l is returning the real line count - 1.

Which means if there was only a single PR merged, and so a single line then this will be read as 0 lines, ie blank release notes and the fallback release notes will be created.

Solution is to just rely on bash' ability to detect empty files.
