### PR TITLE
HOTT-1206 Added queuing to deploy step in CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ orbs:
   node: circleci/node@4.7.0
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0
+  queue: eddiewebb/queue@1.6.4
   gh: circleci/github-cli@1.0
 
 commands:
@@ -194,6 +195,10 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "development"
     steps:
+      - queue/until_front_of_line:
+          time: '10'
+          consider-branch: false
+          dont-quit: true
       - deploy:
           docker_image_tag: dev-$CIRCLE_SHA1
           space: "development"
@@ -206,6 +211,10 @@ jobs:
     environment:
       SENTRY_ENVIRONMENT: "staging"
     steps:
+      - queue/until_front_of_line:
+          time: '10'
+          consider-branch: true
+          dont-quit: true
       - deploy:
           docker_image_tag: $CIRCLE_SHA1
           space: "staging"


### PR DESCRIPTION
### Jira link

[HOTT-1206](https://transformuk.atlassian.net/browse/HOTT-1206)

### What?

I have added/removed/altered:

- [x] Fix for deploy step in CI not queueing

### Why?

I am doing this because:

- CI does not queue and concurrent downloads can result in the deletion of the server being deployed to
