### PR TITLE
Surface whether a commodity is declarable

### DIFF
--- a/app/models/commodity.rb
+++ b/app/models/commodity.rb
@@ -5,7 +5,7 @@ class Commodity
 
   collection_path '/admin/commodities'
 
-  attributes :id, :description
+  attributes :id, :description, :declarable
 
   has_many :search_references, class_name: 'Commodity::SearchReference'
 

--- a/app/views/synonyms/headings/commodities/index.html.erb
+++ b/app/views/synonyms/headings/commodities/index.html.erb
@@ -9,6 +9,7 @@
       <th>Commodity</th>
       <th>Title</th>
       <th>Productline Suffix</th>
+      <th>Declarable</th>
       <th class="actions_col">Synonyms</th>
     </tr>
   </thead>
@@ -18,6 +19,7 @@
         <td><%= commodity.goods_nomenclature_item_id %></td>
         <td><%= commodity.description.titleize %></td>
         <td><%= commodity.productline_suffix %></td>
+        <td><%= commodity.declarable %></td>
         <td class="hott-link-group">
           <div>
             <%= pluralize commodity.search_references_count, "synonym" %>


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Added whether a commodity we're managing search references for is declarable

### Why?

I am doing this because:

- Required for understanding what type of search reference is going to be created