### PR TITLE
HOTT-1364: Surface oplog inserts in the admin UI

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,2 @@
+--require rails_helper
 --color

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -541,7 +541,7 @@ DEPENDENCIES
   webpacker
 
 RUBY VERSION
-   ruby 3.1.0p0
+   ruby 3.1.1p18
 
 BUNDLED WITH
    2.2.32

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -15,12 +15,8 @@ module ServiceHelper
     end
   end
 
-  def update_type
-    if TradeTariffAdmin::ServiceChooser.uk?
-      'CDS'
-    else
-      'Taric'
-    end
+  def service_update_type
+    t("helpers.service_update_type.#{TradeTariffAdmin::ServiceChooser.service_name}")
   end
 
   def service_region

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -15,6 +15,14 @@ module ServiceHelper
     end
   end
 
+  def update_type
+    if TradeTariffAdmin::ServiceChooser.uk?
+      'CDS'
+    else
+      'Taric'
+    end
+  end
+
   def service_region
     TradeTariffAdmin::ServiceChooser.uk? ? 'the UK' : 'Northern Ireland'
   end

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -23,7 +23,7 @@ class TariffUpdate
     'F' => 'Failed',
   }.freeze
 
-  ROLLBACK_APPLICABLE_STATES = %w[A P].freeze
+  ROLLBACK_APPLICABLE_STATES = %w[A].freeze
 
   def state
     STATES[super]
@@ -46,6 +46,6 @@ class TariffUpdate
   end
 
   def id
-    created_at.parameterize
+    created_at.to_s.parameterize
   end
 end

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -4,62 +4,56 @@ class TariffUpdate
 
   collection_path '/admin/updates'
 
-  attributes :update_type, :state, :issue_date, :created_at, :updated_at, :applied_at, :filesize,
-             :exception_backtrace, :exception_class, :exception_queries,
-             :file_presigned_url, :log_presigned_urls, :presence_errors
+  attributes :update_type,
+             :state,
+             :issue_date,
+             :created_at,
+             :updated_at,
+             :applied_at,
+             :filesize,
+             :exception_backtrace,
+             :exception_class,
+             :exception_queries,
+             :file_presigned_url,
+             :presence_errors
 
   STATES = {
     'A' => 'Applied',
-    'M' => 'Missing',
     'P' => 'Pending',
     'F' => 'Failed',
   }.freeze
+
+  ROLLBACK_APPLICABLE_STATES = %w[A P].freeze
 
   def state
     STATES[super]
   end
 
-  def update_type
-    case attributes[:update_type]
-    when /Taric/ then 'TARIC'
-    when /Chief/ then 'CHIEF'
-    when /Cds/   then 'CDS'
-    end
+  def inserts
+    JSON.parse(attributes[:inserts].presence || '{}')
   end
 
-  def log_presigned_urls
-    attributes[:log_presigned_urls] || {}
-  end
-
-  def missing?
-    attributes[:state] == 'M'
-  end
-
-  def filename
-    super unless missing?
+  def rollback?
+    attributes[:state].in?(ROLLBACK_APPLICABLE_STATES)
   end
 
   def file_date
-    if update_type == 'CDS'
-      Date.parse(issue_date)
+    if TradeTariffAdmin::ServiceChooser.xi?
+      issue_date
     else
       filename.try :slice, 0, 10
     end
   end
 
-  def created_at
-    Time.zone.parse(super)
+  def issue_date
+    Date.parse(attributes[:issue_date])
   end
 
   def applied_at
     Time.zone.parse(super) if super.present?
   end
 
-  def to_s
-    "Applied #{update_type} at #{updated_at} (#{filename})"
-  end
-
   def id
-    created_at.to_s.parameterize
+    created_at.parameterize
   end
 end

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -37,14 +37,6 @@ class TariffUpdate
     attributes[:state].in?(ROLLBACK_APPLICABLE_STATES)
   end
 
-  def file_date
-    if TradeTariffAdmin::ServiceChooser.xi?
-      issue_date
-    else
-      filename.try :slice, 0, 10
-    end
-  end
-
   def issue_date
     Date.parse(attributes[:issue_date])
   end

--- a/app/views/tariff_updates/_actions.html.erb
+++ b/app/views/tariff_updates/_actions.html.erb
@@ -1,6 +1,5 @@
 <% if tariff_update.rollback? %>
-  <% date = tariff_update.file_date %>
-  <%= link_to "Rollback to #{date}", new_rollback_path(rollback: {date: date}) %>
+  <%= link_to "Rollback to #{tariff_update.issue_date}", new_rollback_path(rollback: {date: tariff_update.issue_date}) %>
 <% end %>
 <% if tariff_update.filename.present? %>
   <%= link_to 'Download', tariff_update.file_presigned_url, target: "_blank", title: tariff_update.filename %>

--- a/app/views/tariff_updates/_actions.html.erb
+++ b/app/views/tariff_updates/_actions.html.erb
@@ -1,6 +1,11 @@
 <% if tariff_update.rollback? %>
   <%= link_to "Rollback to #{tariff_update.issue_date}", new_rollback_path(rollback: {date: tariff_update.issue_date}) %>
 <% end %>
+
+<% if tariff_update.rollback? && tariff_update.filename.present? %>
+  <br>
+<% end %>
+
 <% if tariff_update.filename.present? %>
   <%= link_to 'Download', tariff_update.file_presigned_url, target: "_blank", title: tariff_update.filename %>
 <% end %>

--- a/app/views/tariff_updates/_actions.html.erb
+++ b/app/views/tariff_updates/_actions.html.erb
@@ -1,4 +1,7 @@
-<% if tariff_update.state == "Applied" || tariff_update.state == "Failed" %>
+<% if tariff_update.rollback? %>
   <% date = tariff_update.file_date %>
   <%= link_to "Rollback to #{date}", new_rollback_path(rollback: {date: date}) %>
+<% end %>
+<% if tariff_update.filename.present? %>
+  <%= link_to 'Download', tariff_update.file_presigned_url, target: "_blank", title: tariff_update.filename %>
 <% end %>

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -1,44 +1,51 @@
-<h2>Tariff Updates</h2>
+<h2>Tariff Updates - <%= update_type %></h2>
 
 <table class='table table-bordered table-striped table-condensed table-tariff-updates'>
   <thead>
     <tr>
-      <th class='span2'>Update type</th>
-      <th class='span2'>File name</th>
       <th class='span2'>State</th>
-      <th class='span2'>Created at</th>
+      <th class='span2'>Issue date</th>
       <th class='span2'>Applied at</th>
       <th class='span2'>File size</th>
+      <th class='span2'>Inserts</th>
       <th class='span2'>Actions</th>
     </tr>
   </thead>
   <tbody>
     <% @tariff_updates.each do |tariff_update| %>
       <tr id='<%= dom_id(tariff_update) %>'>
-        <td><%= tariff_update.update_type %></td>
-        <td><%= link_to_if tariff_update.filename.present?, tariff_update.filename, tariff_update.file_presigned_url, target: "_blank" %></td>
         <td>
           <%= tariff_update.state %>
+
           <% if tariff_update.exception_class.present? %>
             <%= render "exception", tariff_update: tariff_update %>
           <% end %>
+
           <% if tariff_update.presence_errors.present? %>
             <%= render "presence_errors", tariff_update: tariff_update %>
           <% end %>
-          <% if tariff_update.log_presigned_urls["created"].present? %>
-            <div>
-              <%= link_to "Created records", tariff_update.log_presigned_urls["created"], target: "_blank" %>
-            </div>
-          <% end %>
-          <% if tariff_update.log_presigned_urls["failed"].present? %>
-            <div>
-                <%= link_to "Failed records", tariff_update.log_presigned_urls["failed"], target: "_blank" %>
-            </div>
-          <% end %>
         </td>
-        <td><%= l tariff_update.created_at, format: :tariff %></td>
+        <td><%= l(tariff_update.issue_date, format: :tariff) %></td>
         <td><%= l(tariff_update.applied_at, format: :tariff) if tariff_update.applied_at %></td>
         <td><%= number_to_human_size(tariff_update.filesize) %></td>
+        <td>
+          <% if tariff_update.inserts.present? %>
+            <details class="govuk-details" data-module="govuk-details">
+              <summary class="govuk-details__summary">
+                <span class="govuk-details__summary-text">
+                  Review inserts
+                </span>
+              </summary>
+              <div class="govuk-details__text">
+                <% tariff_update.inserts.each_with_index do |(key, value), index| %>
+                  <%= tag.br if index.positive? %>
+
+                  <%= key.sub('::Operation', '') %>: <%= value %>
+                <% end %>
+              </div>
+            </details>
+          <% end %>
+        </td>
         <td><%= render "actions", tariff_update: tariff_update %></td>
       </tr>
     <% end %>

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -1,4 +1,4 @@
-<h2>Tariff Updates - <%= update_type %></h2>
+<h2>Tariff Updates - <%= service_update_type %></h2>
 
 <table class='table table-bordered table-striped table-condensed table-tariff-updates'>
   <thead>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -33,6 +33,9 @@ en:
       tariff: "%d/%m/%Y"
 
   helpers:
+    service_update_type:
+      xi: Taric
+      uk: CDS
     label:
       rollback:
         date: Rollback to date

--- a/spec/factories/tariff_update_factory.rb
+++ b/spec/factories/tariff_update_factory.rb
@@ -1,20 +1,31 @@
 FactoryBot.define do
   factory :tariff_update do
-    update_type { ['TariffSynchronizer::TaricUpdate', 'TariffSynchronizer::ChiefUpdate'].sample }
+    update_type { 'TariffSynchronizer::TaricUpdate' }
     state { %w[A M P F].sample }
+    issue_date { Time.zone.today.iso8601 }
     updated_at { Time.zone.now }
     created_at { Time.zone.now }
+    inserts { '{}' }
+    filename { '2022-02-06_TGB22037.xml' }
 
-    trait :chief do
-      update_type { 'TariffSynchronizer::ChiefUpdate' }
+    trait :failed do
+      state { 'F' }
     end
 
     trait :taric do
       update_type { 'TariffSynchronizer::TaricUpdate' }
     end
 
+    trait :cds do
+      update_type { 'TariffSynchronizer::CdsUpdate' }
+    end
+
+    trait :with_inserts do
+      inserts { '{"something": "parseable"}' }
+    end
+
     trait :with_exception do
-      exception_class { 'ChiefImporter::ImportException' }
+      exception_class { 'CdsImporter::ImportException' }
       exception_queries { "(Sequel::Mysql2::Database) BEGIN \n(Sequel::Mysql2::Database) SELECT * FROM `measures` LIMIT 1 \n(Sequel::Mysql2::Database) ROLLBACK \n(Sequel::Mysql2::Database) UPDATE `tariff_updates` SET `state` = 'F', `updated_at` = '2014-07-22 16:16:15' WHERE ((`tariff_updates`.`update_type` IN ('TariffSynchronizer::TaricUpdate')) AND (`filename` = '2014-07-22_TGB14203.xml')) LIMIT 1 " }
       exception_backtrace { "/var/govuk/trade-tariff-backend/spec/unit/tariff_synchronizer/logger_spec.rb:179:in `block (4 levels) in <top (required)>'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:519:in `call'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:519:in `block in call'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:518:in `map'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:518:in `call'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/message_expectation.rb:186:in `invoke'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/proxy.rb:144:in `message_received'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/method_double.rb:174:in `import'\n/usr/lib/rbenv/versions/2.0.0-p353/lib/ruby/gems/2.0.0/gems/rspec-mocks-2.14.1/lib/rspec/mocks/any_instance/recorder.rb:187:in `import'" }
     end

--- a/spec/features/tariff_updates_spec.rb
+++ b/spec/features/tariff_updates_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe 'Tariff Update listing' do
   let!(:user) { create :user, :gds_editor }
-  let(:tariff_update) { attributes_for(:tariff_update, :chief, :missing, :with_exception) }
+  let(:tariff_update) { attributes_for(:tariff_update, :cds, :failed, :with_exception) }
 
   before do
     stub_api_for(TariffUpdate) do |stub|
@@ -18,9 +18,9 @@ RSpec.describe 'Tariff Update listing' do
   it 'lists all tariff updates' do
     visit tariff_updates_path
 
-    expect(page).to have_content 'CHIEF'
-    expect(page).to have_content 'Missing'
-    expect(page).to have_content 'ChiefImporter::ImportException'
+    expect(page).to have_content 'Cds'
+    expect(page).to have_content 'Failed'
+    expect(page).to have_content 'CdsImporter::ImportException'
     expect(page).to have_content 'logger_spec.rb:179'
     expect(page).to have_content '(Sequel::Mysql2::Database)'
   end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -1,6 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe ServiceHelper, type: :helper do
+  describe '.service_update_type' do
+    subject { helper.service_update_type }
+
+    context 'with UK service' do
+      include_context 'with UK service'
+
+      it { is_expected.to eq('CDS') }
+    end
+
+    context 'with XI service' do
+      include_context 'with XI service'
+
+      it { is_expected.to eq('Taric') }
+    end
+  end
+
   describe '.service_name' do
     subject { service_name }
 

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -46,22 +46,6 @@ RSpec.describe TariffUpdate do
     it_behaves_like 'a tariff update that does not rollback', 'X'
   end
 
-  describe '#file_date' do
-    subject(:file_date) { build(:tariff_update, filename: '0123456789foo', issue_date: '2022-01-01').file_date }
-
-    context 'when on the xi service' do
-      before { allow(TradeTariffAdmin::ServiceChooser).to receive(:xi?).and_return(true) }
-
-      it { is_expected.to eq(Date.parse('2022-01-01')) }
-    end
-
-    context 'when on the uk service' do
-      before { allow(TradeTariffAdmin::ServiceChooser).to receive(:xi?).and_return(false) }
-
-      it { is_expected.to eq('0123456789') }
-    end
-  end
-
   describe '#issue_date' do
     subject(:issue_date) { build(:tariff_update, issue_date: Time.zone.today.iso8601).issue_date }
 

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -40,9 +40,9 @@ RSpec.describe TariffUpdate do
     end
 
     it_behaves_like 'a tariff update that rolls back', 'A'
-    it_behaves_like 'a tariff update that rolls back', 'P'
 
     it_behaves_like 'a tariff update that does not rollback', 'F'
+    it_behaves_like 'a tariff update that does not rollback', 'P'
     it_behaves_like 'a tariff update that does not rollback', 'X'
   end
 

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -1,0 +1,84 @@
+RSpec.describe TariffUpdate do
+  describe '#state' do
+    shared_examples_for 'a tariff update state' do |actual_state, expected_state|
+      subject(:state) { build(:tariff_update, state: actual_state).state }
+
+      it { is_expected.to eq(expected_state) }
+    end
+
+    it_behaves_like 'a tariff update state', 'A', 'Applied'
+    it_behaves_like 'a tariff update state', 'P', 'Pending'
+    it_behaves_like 'a tariff update state', 'F', 'Failed'
+    it_behaves_like 'a tariff update state', 'X', nil
+  end
+
+  describe '#inserts' do
+    context 'when the inserts are supplied' do
+      subject(:inserts) { build(:tariff_update, :with_inserts).inserts }
+
+      it { is_expected.to eq('something' => 'parseable') }
+    end
+
+    context 'when the inserts are not supplied' do
+      subject(:inserts) { build(:tariff_update).inserts }
+
+      it { is_expected.to eq({}) }
+    end
+  end
+
+  describe '#rollback?' do
+    shared_examples_for 'a tariff update that rolls back' do |state, _will_rollback|
+      subject(:tariff_update) { build(:tariff_update, state:) }
+
+      it { is_expected.to be_rollback }
+    end
+
+    shared_examples_for 'a tariff update that does not rollback' do |state, _will_rollback|
+      subject(:tariff_update) { build(:tariff_update, state:) }
+
+      it { is_expected.not_to be_rollback }
+    end
+
+    it_behaves_like 'a tariff update that rolls back', 'A'
+    it_behaves_like 'a tariff update that rolls back', 'P'
+
+    it_behaves_like 'a tariff update that does not rollback', 'F'
+    it_behaves_like 'a tariff update that does not rollback', 'X'
+  end
+
+  describe '#file_date' do
+    subject(:file_date) { build(:tariff_update, filename: '0123456789foo', issue_date: '2022-01-01').file_date }
+
+    context 'when on the xi service' do
+      before { allow(TradeTariffAdmin::ServiceChooser).to receive(:xi?).and_return(true) }
+
+      it { is_expected.to eq(Date.parse('2022-01-01')) }
+    end
+
+    context 'when on the uk service' do
+      before { allow(TradeTariffAdmin::ServiceChooser).to receive(:xi?).and_return(false) }
+
+      it { is_expected.to eq('0123456789') }
+    end
+  end
+
+  describe '#issue_date' do
+    subject(:issue_date) { build(:tariff_update, issue_date: Time.zone.today.iso8601).issue_date }
+
+    it { is_expected.to eq(Time.zone.today) }
+  end
+
+  describe '#applied_at' do
+    subject(:issue_date) { build(:tariff_update, applied_at: now.iso8601).applied_at }
+
+    let(:now) { Time.zone.now }
+
+    it { is_expected.to eq(Time.zone.parse(now.iso8601)) }
+  end
+
+  describe '#id' do
+    subject(:id) { build(:tariff_update, created_at: '2022-01-01T12:13Z').id }
+
+    it { is_expected.to eq('2022-01-01t12-13z') }
+  end
+end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1364

![Screenshot from 2022-02-23 12-17-58](https://user-images.githubusercontent.com/8156884/155328715-f4f5278c-cd27-44b5-8cf6-568f0dd9ae3a.png)

### What?

I have added/removed/altered:

- [x] Added ability to view a details component of the oplog inserts on the updates page
- [x] Moved the filename to an abbreviation inside of a Download action
- [x] Removed some unused updates fields to tidy the UI a bunch
- [x] Removed the now-defunct missing state
- [x] Added some specs of the model functionality

### Why?

I am doing this because:

- The UI isn't particularly up-to-date and the inserts give us a lot more information about what was imported in each update
