### PR TITLE
HOTT-1351 Use orb to generate + publish release notes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -216,100 +216,10 @@ jobs:
           space: "production"
           environment_key: "production"
       - sentry-release
-
-  create_production_release:
-    docker:
-      - image: cimg/ruby:3.1.0-node
-    environment:
-      IMAGE_NAME: tariff-admin
-    steps:
-      - checkout
-      - setup_remote_docker:
-          version: 20.10.11
-          docker_layer_caching: false
-      - aws-cli/install
-      - run:
-          name: Generate release notes
-          command: |
-            mkdir release-details
-
-            NEW_RELEASE=$(date +"%Y%m%d-%H%M")
-            echo "${NEW_RELEASE}" > release-details/name.txt
-            echo "export NEW_RELEASE='${NEW_RELEASE}'" >> $BASH_ENV
-
-            LAST_RELEASE=$(git tag --list 'release-202*-*' | sort | tail -n 1)
-            if [[ -z "${LAST_RELEASE}" ]]; then
-              echo "First release" > release-details/notes.txt
-            else
-              git log --merges --format=format:"* %b" $LAST_RELEASE..HEAD > release-details/notes.txt
-
-              if [[ ! -s release-details/notes.txt ]]; then
-                echo "No merged changes - possible re-release" > release-details/notes.txt
-              fi
-            fi
-      - run:
-          command: cat release-details/notes.txt
-      - run:
-          name: Tag Docker Image as production release
-          command: |
-            aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin $ECR_REPO
-            docker pull "${ECR_REPO}/${IMAGE_NAME}:${CIRCLE_SHA1}"
-            docker tag "${ECR_REPO}/${IMAGE_NAME}:${CIRCLE_SHA1}" "${ECR_REPO}/${IMAGE_NAME}:release-${NEW_RELEASE}"
-            docker push "${ECR_REPO}/${IMAGE_NAME}:release-${NEW_RELEASE}"
-      - gh/setup
-      - run:
-          name: Create GitHub release
-          command: |
-            gh release create release-$NEW_RELEASE \
-              --notes-file release-details/notes.txt \
-              --title "Release $NEW_RELEASE" \
-              --target "${CIRCLE_SHA1}"
-
-  notify_production_release:
-    docker:
-      - image: cimg/ruby:3.1.0-node
-    steps:
-      - run:
-          name: Read release name
-          command: |
-            RELEASE_NAME=$(echo "${CIRCLE_TAG}" | sed 's/^release-//')
-            echo "export RELEASE_NAME='${RELEASE_NAME}'" >> $BASH_ENV
-      - run:
-          name: Fetch release notes
-          command: |
-            REPO_API_URL=$(echo "${CIRCLE_REPOSITORY_URL}/" | sed 's|.git/$||' | sed 's|git@github.com:|https://api.github.com/repos/|')
-            curl --silent --show-error "${REPO_API_URL}/releases/tags/${CIRCLE_TAG}" | jq -ar .body > release-notes.txt
-      - run:
-          name: Clean up notes
-          command: |
-            sed -i 's/\\"//g' release-notes.txt
-            sed -i "s/\\'//g" release-notes.txt
-            sed -i 's/"//g' release-notes.txt
-            sed -i "s/'//g" release-notes.txt
-            echo 'export RELEASE_NOTES="$(< release-notes.txt)"' >> $BASH_ENV
-      - slack/notify:
-          channel: trade_tariff
-          event: pass
-          custom: |
-            {
-              "blocks": [
-                {
-                  "type": "header",
-                  "text": {
-                    "type": "plain_text",
-                    "text": "New release ${RELEASE_NAME} for Admin :tada:",
-                    "emoji": true
-                  }
-                },
-                {
-                  "type": "section",
-                  "text": {
-                    "type": "mrkdwn",
-                    "text": "${RELEASE_NOTES}"
-                  }
-                }
-              ]
-            }
+      - tariff/notify-production-release:
+          app-name: Admin
+          slack-channel: trade_tariff
+          release-tag: $CIRCLE_TAG
 
 workflows:
   version: 2
@@ -365,8 +275,9 @@ workflows:
                 - main
           requires:
             - deploy_staging
-      - create_production_release:
+      - tariff/create-production-release:
           context: trade-tariff
+          image-name: tariff-admin
           filters:
             branches:
               only:
@@ -380,12 +291,3 @@ workflows:
               only: /^release-202[\d-]+/
             branches:
               ignore: /.*/
-      - notify_production_release:
-          context: trade-tariff
-          filters:
-            tags:
-              only: /^release-202[\d-]+/
-            branches:
-              ignore: /.*/
-          requires:
-            - deploy_production


### PR DESCRIPTION
### Jira link

[HOTT-1351](https://transformuk.atlassian.net/browse/HOTT-1351)

### What?

I have added/removed/altered:

- [x] Use orb versions of release notes code
- [x] Drop internal versions

### Why?

I am doing this because:

- We want to share this code with our other projects