### PR TITLE
HOTT-1388: Show filename when downloading current file

### DIFF
--- a/app/views/tariff_updates/_actions.html.erb
+++ b/app/views/tariff_updates/_actions.html.erb
@@ -7,5 +7,5 @@
 <% end %>
 
 <% if tariff_update.filename.present? %>
-  <%= link_to 'Download', tariff_update.file_presigned_url, target: "_blank", title: tariff_update.filename %>
+  <%= link_to "Download #{tariff_update.filename}", tariff_update.file_presigned_url, target: "_blank", title: tariff_update.filename %>
 <% end %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1388

### What?

I have added/removed/altered:

- [x] Added filename to download link in actions partial

### Why?

I am doing this because:

- This is so that we can easily see which filename is being downloaded for which day
