### PR TITLE
Add a second confirmation step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,7 +267,7 @@ workflows:
                 - main
           requires:
             - build_live
-      - hold_production:
+      - hold_create_release:
           type: approval
           filters:
             branches:
@@ -283,7 +283,14 @@ workflows:
               only:
                 - main
           requires:
-            - hold_production
+            - hold_create_release
+      - hold_deploy_production:
+          type: approval
+          filters:
+            tags:
+              only: /^release-202[\d-]+/
+            branches:
+              ignore: /.*/
       - deploy_production:
           context: trade-tariff
           filters:
@@ -291,3 +298,5 @@ workflows:
               only: /^release-202[\d-]+/
             branches:
               ignore: /.*/
+          requires:
+            - hold_deploy_production


### PR DESCRIPTION
This allows a developer to create a release, and check the release notes prior to rolling it out

And removes the risk of accidentally releasing and older release to prod