### PR TITLE
HOTT-1381 Add banner news items

### DIFF
--- a/app/controllers/govspeak_controller.rb
+++ b/app/controllers/govspeak_controller.rb
@@ -5,11 +5,10 @@ class GovspeakController < AuthenticatedController
     flash.keep
 
     if params[:govspeak]
-      substituted_content = helpers.replace_service_tags(params[:govspeak].to_s)
-      doc = Govspeak::Document.new(substituted_content, sanitize: true)
+      @preview = GovspeakPreview.new(params[:govspeak])
 
       respond_to do |format|
-        format.json { render json: { govspeak: doc.to_html } }
+        format.json { render json: { govspeak: @preview.render } }
       end
     else
       render nothing: true, status: :no_content

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -52,6 +52,7 @@ class NewsItemsController < AuthenticatedController
       show_on_xi
       show_on_home_page
       show_on_updates_page
+      show_on_banner
       start_date
       end_date
     ]).reverse_merge(default_params)

--- a/app/helpers/news_items_helper.rb
+++ b/app/helpers/news_items_helper.rb
@@ -8,4 +8,15 @@ module NewsItemsHelper
   def news_item_bool(value)
     value ? 'Yes' : 'No'
   end
+
+  def format_news_item_pages(news_item)
+    pages = []
+
+    pages << 'Home' if news_item.show_on_home_page
+    pages << 'Updates' if news_item.show_on_updates_page
+    pages << 'Banner' if news_item.show_on_banner
+    pages << 'No pages' if pages.empty?
+
+    safe_join pages, ', '
+  end
 end

--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -1,4 +1,6 @@
 module ServiceHelper
+  module_function
+
   def switch_service_link(*args)
     if TradeTariffAdmin::ServiceChooser.uk?
       link_to('Switch to XI service', "/xi#{current_path}", *args)

--- a/app/models/govspeak_preview.rb
+++ b/app/models/govspeak_preview.rb
@@ -1,0 +1,19 @@
+class GovspeakPreview
+  def initialize(content)
+    @content = content.to_s
+  end
+
+  def render
+    govspeak.to_html.html_safe
+  end
+
+  private
+
+  def govspeak
+    Govspeak::Document.new(substituted_content, sanitize: true)
+  end
+
+  def substituted_content
+    ServiceHelper.replace_service_tags(@content)
+  end
+end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -15,8 +15,6 @@ class NewsItem
   validates :start_date, presence: true
 
   def preview
-    substituted_content = ApplicationController.helpers.replace_service_tags(content.to_s)
-
-    Govspeak::Document.new(substituted_content, sanitize: true).to_html.html_safe
+    GovspeakPreview.new(content).render
   end
 end

--- a/app/models/news_item.rb
+++ b/app/models/news_item.rb
@@ -7,7 +7,8 @@ class NewsItem
   collection_path '/admin/news_items'
 
   attributes :title, :content, :display_style, :show_on_uk, :show_on_xi,
-             :show_on_home_page, :show_on_updates_page, :start_date, :end_date
+             :show_on_home_page, :show_on_updates_page, :show_on_banner,
+             :start_date, :end_date
 
   validates :title, presence: true
   validates :content, presence: true

--- a/app/views/news_items/_form.html.erb
+++ b/app/views/news_items/_form.html.erb
@@ -70,5 +70,10 @@
                         multiple: false,
                         link_errors: true %>
 
+  <%= f.govuk_check_box :show_on_banner, 1, 0,
+                        label: { text: 'Show News story on the Banner' },
+                        multiple: false,
+                        link_errors: true %>
+
   <%= submit_and_back_buttons f, news_items_path %>
 <% end %>

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -14,8 +14,7 @@
         <th>End date</th>
         <th>UK</th>
         <th>XI</th>
-        <th>Home page</th>
-        <th>Updates page</th>
+        <th>Pages</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -28,8 +27,7 @@
           <td><%= news_item_date news_item.end_date %></td>
           <td><%= news_item_bool news_item.show_on_uk %></td>
           <td><%= news_item_bool news_item.show_on_xi %></td>
-          <td><%= news_item_bool news_item.show_on_home_page %></td>
-          <td><%= news_item_bool news_item.show_on_updates_page %></td>
+          <td><%= format_news_item_pages news_item %></td>
           <td>
             <%= link_to 'Edit',
                         edit_news_item_path(news_item) %>

--- a/config/initializers/govspeak_sanitizer.rb
+++ b/config/initializers/govspeak_sanitizer.rb
@@ -1,0 +1,16 @@
+# Govspeak sanitizer appears completely unconfigurable so resorting to monkey patching
+
+module TariffGovspeakSanitizer
+  def sanitize_config(...)
+    orig_config = super
+
+    Sanitize::Config.merge(
+      orig_config,
+      attributes: {
+        'a' => orig_config[:attributes]['a'] + %w[target],
+      },
+    )
+  end
+end
+
+Govspeak::HtmlSanitizer.prepend TariffGovspeakSanitizer

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -56,5 +56,6 @@ en:
         date: Should be in 'YYYY-MM-DD' format
 
       news_item:
+        title: Not shown on frontend for Banner stories
         start_date: 'YYYY/MM/DD'
         end_date: 'YYYY/MM/DD or leave blank for no end date'

--- a/spec/factories/news_item_factory.rb
+++ b/spec/factories/news_item_factory.rb
@@ -6,21 +6,24 @@ FactoryBot.define do
     display_style { NewsItem::DISPLAY_STYLE_REGULAR }
     show_on_uk { true }
     show_on_xi { true }
-    show_on_home_page { true }
+    show_on_home_page { false }
     show_on_updates_page { false }
+    show_on_banner { false }
     start_date { Time.zone.yesterday }
     end_date { nil }
     created_at { 2.days.ago.to_date }
     updated_at { nil }
 
     trait :updates_page do
-      show_on_home_page { false }
       show_on_updates_page { true }
     end
 
-    trait :all_pages do
+    trait :home_page do
       show_on_home_page { true }
-      show_on_updates_page { true }
+    end
+
+    trait :banner do
+      show_on_banner { true }
     end
 
     trait :no_uk do

--- a/spec/helpers/news_items_helper_spec.rb
+++ b/spec/helpers/news_items_helper_spec.rb
@@ -38,4 +38,38 @@ RSpec.describe NewsItemsHelper do
       it { is_expected.to eql 'No' }
     end
   end
+
+  describe '#format_news_item_pages' do
+    subject { format_news_item_pages news_item }
+
+    context 'with home page' do
+      let(:news_item) { build :news_item, :home_page }
+
+      it { is_expected.to eql 'Home' }
+    end
+
+    context 'with updates page' do
+      let(:news_item) { build :news_item, :updates_page }
+
+      it { is_expected.to eql 'Updates' }
+    end
+
+    context 'with banner' do
+      let(:news_item) { build :news_item, :banner }
+
+      it { is_expected.to eql 'Banner' }
+    end
+
+    context 'with no pages' do
+      let(:news_item) { build :news_item }
+
+      it { is_expected.to eql 'No pages' }
+    end
+
+    context 'with multiple pages' do
+      let(:news_item) { build :news_item, :home_page, :updates_page, :banner }
+
+      it { is_expected.to eql 'Home, Updates, Banner' }
+    end
+  end
 end

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.describe ServiceHelper, type: :helper do
   describe '.service_update_type' do
-    subject { helper.service_update_type }
+    subject { service_update_type }
 
     context 'with UK service' do
       include_context 'with UK service'

--- a/spec/models/govspeak_preview_spec.rb
+++ b/spec/models/govspeak_preview_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe GovspeakPreview do
+  subject(:preview) { described_class.new content }
+
+  let :content do
+    <<~EOCONTENT
+      # Heading
+
+      This is content for [[SERVICE_NAME]]
+
+      This is a <a href="/" target="_blank">link</a>
+    EOCONTENT
+  end
+
+  describe '#render' do
+    subject(:rendered) { preview.render }
+
+    it 'converts markdown' do
+      expect(rendered).to match '<h1 id="heading">Heading</h1>'
+    end
+
+    it 'replaces service tags' do
+      expect(rendered).to match 'content for UK'
+    end
+
+    it 'supports links to new windows' do
+      expect(rendered).to match '<a href="/" target="_blank">link</a>'
+    end
+  end
+end

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe NewsItem do
-  subject(:news_item) { build :news_item }
+  subject(:news_item) { build :news_item, :home_page, :updates_page, :banner }
 
   it { is_expected.to respond_to :id }
   it { is_expected.to respond_to :title }
@@ -11,6 +11,7 @@ describe NewsItem do
   it { is_expected.to respond_to :show_on_xi }
   it { is_expected.to respond_to :show_on_home_page }
   it { is_expected.to respond_to :show_on_updates_page }
+  it { is_expected.to respond_to :show_on_banner }
   it { is_expected.to respond_to :start_date }
   it { is_expected.to respond_to :end_date }
   it { is_expected.to respond_to :created_at }
@@ -24,6 +25,7 @@ describe NewsItem do
   it { is_expected.to have_attributes show_on_xi: news_item.show_on_xi }
   it { is_expected.to have_attributes show_on_home_page: news_item.show_on_home_page }
   it { is_expected.to have_attributes show_on_updates_page: news_item.show_on_updates_page }
+  it { is_expected.to have_attributes show_on_banner: news_item.show_on_banner }
   it { is_expected.to have_attributes start_date: news_item.start_date }
   it { is_expected.to have_attributes end_date: news_item.end_date }
   it { is_expected.to have_attributes created_at: news_item.created_at }

--- a/spec/requests/govspeak_controller_spec.rb
+++ b/spec/requests/govspeak_controller_spec.rb
@@ -12,5 +12,9 @@ describe GovspeakController do
 
     it { is_expected.to have_http_status :success }
     it { is_expected.to have_attributes media_type: /json/ }
+
+    it 'converts markdown to html' do
+      expect(rendered_page).to have_attributes body: /h1/
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1381](https://transformuk.atlassian.net/browse/HOTT-1381)

### What?

I have added/removed/altered:

- [x] Added Banner news items 
- [x] Support setting `target="_blank"` in govspeak content

### Why?

I am doing this because:

- We want to edit the header banner on the frontend from the admin area

