### PR TITLE
Match rubocop requirements to brakemans

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -141,7 +141,7 @@ jobs:
           name: Inspecting with Brakeman
           when: always
           # See https://github.com/presidentbeef/brakeman/issues/1664
-          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models --no-exit-on-error' 
+          command: 'bundle exec brakeman -o test-results/brakeman/brakeman.junit -o brakeman.html --no-progress --separate-models'
       - store_test_results:
           path: test-results/brakeman/
       - store_artifacts:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,5 +47,7 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GuardClause:
   MinBodyLength: 2
+Style/HashSyntax:
+  EnforcedShorthandSyntax: never
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/app/controllers/synonyms/search_references_controller.rb
+++ b/app/controllers/synonyms/search_references_controller.rb
@@ -3,7 +3,7 @@ module Synonyms
     before_action :authorize_user
 
     def index
-      @search_references = search_reference_parent.search_references.all(page:, per_page:)
+      @search_references = search_reference_parent.search_references.all(page: page, per_page: per_page)
       @search_references = Kaminari.paginate_array(@search_references, total_count: @search_references.metadata[:pagination][:total]).page(page).per(per_page)
     end
 

--- a/app/helpers/govuk_helper.rb
+++ b/app/helpers/govuk_helper.rb
@@ -1,6 +1,6 @@
 module GovukHelper
   def govuk_breadcrumbs(breadcrumbs)
-    render GovukComponent::BreadcrumbsComponent.new(breadcrumbs:)
+    render GovukComponent::BreadcrumbsComponent.new(breadcrumbs: breadcrumbs)
   end
 
   def govuk_form_for(*args, **options, &block)

--- a/app/services/search_reference/export_all_service.rb
+++ b/app/services/search_reference/export_all_service.rb
@@ -8,7 +8,7 @@ class SearchReference
 
     def collection
       'a'.upto('z').inject([]) do |memo, letter|
-        search_references = SearchReference.all(query: { letter: }).fetch
+        search_references = SearchReference.all(query: { letter: letter }).fetch
         memo.concat(search_references)
       end
     end

--- a/spec/features/chapter_search_reference_spec.rb
+++ b/spec/features/chapter_search_reference_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Chapter Search Reference management' do
         end
       end
 
-      refute search_reference_created_for(chapter, title:)
+      refute search_reference_created_for(chapter, title: title)
 
       stub_api_for(Chapter::SearchReference) do |stub|
         stub.post("/admin/chapters/#{chapter.to_param}/search_references") do |_env|
@@ -37,7 +37,7 @@ RSpec.describe 'Chapter Search Reference management' do
       end
       create_search_reference_for chapter, 'Synonym' => title
 
-      verify search_reference_created_for(chapter, title:)
+      verify search_reference_created_for(chapter, title: title)
     end
   end
 

--- a/spec/features/commodity_search_reference_spec.rb
+++ b/spec/features/commodity_search_reference_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Commodity Search Reference management' do
         end
       end
 
-      refute search_reference_created_for(commodity, title:)
+      refute search_reference_created_for(commodity, title: title)
 
       stub_api_for(Commodity::SearchReference) do |stub|
         stub.post("/admin/commodities/#{commodity.to_param}/search_references") do |_env|
@@ -37,7 +37,7 @@ RSpec.describe 'Commodity Search Reference management' do
 
       create_search_reference_for commodity, 'Synonym' => title
 
-      verify search_reference_created_for(commodity, title:)
+      verify search_reference_created_for(commodity, title: title)
     end
   end
 

--- a/spec/features/heading_search_reference_spec.rb
+++ b/spec/features/heading_search_reference_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Heading Search Reference management' do
         end
       end
 
-      refute search_reference_created_for(heading, title:)
+      refute search_reference_created_for(heading, title: title)
 
       stub_api_for(Heading::SearchReference) do |stub|
         stub.post("/admin/headings/#{heading.to_param}/search_references") do |_env|
@@ -37,7 +37,7 @@ RSpec.describe 'Heading Search Reference management' do
 
       create_search_reference_for heading, 'Synonym' => title
 
-      verify search_reference_created_for(heading, title:)
+      verify search_reference_created_for(heading, title: title)
     end
   end
 

--- a/spec/features/section_search_reference_spec.rb
+++ b/spec/features/section_search_reference_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Section Search Reference management' do
         end
       end
 
-      refute search_reference_created_for(section, title:)
+      refute search_reference_created_for(section, title: title)
 
       stub_api_for(Section::SearchReference) do |stub|
         stub.post("/admin/sections/#{section.to_param}/search_references") do |_env|
@@ -45,7 +45,7 @@ RSpec.describe 'Section Search Reference management' do
 
       create_search_reference_for section, 'Synonym' => title
 
-      verify search_reference_created_for(section, title:)
+      verify search_reference_created_for(section, title: title)
     end
   end
 

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe TariffUpdate do
 
   describe '#rollback?' do
     shared_examples_for 'a tariff update that rolls back' do |state, _will_rollback|
-      subject(:tariff_update) { build(:tariff_update, state:) }
+      subject(:tariff_update) { build(:tariff_update, state: state) }
 
       it { is_expected.to be_rollback }
     end
 
     shared_examples_for 'a tariff update that does not rollback' do |state, _will_rollback|
-      subject(:tariff_update) { build(:tariff_update, state:) }
+      subject(:tariff_update) { build(:tariff_update, state: state) }
 
       it { is_expected.not_to be_rollback }
     end


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Re-enabled brakeman
- [x] Changed rubocop to prevent rather then require Ruby 3.1 short hash literals
- [x] Removed usage of short hash literals from existing code

### Why?

I am doing this because:

- Brakeman is more important than utilising Ruby 3.1 hash syntax
- its trivial to convert back at a future point
- for now it reduces noise in PRs because rubocop isn't insisting on an syntax change to existing code
