### PR TITLE
HOTT-1478: Bump brakeman and tweak rubocop rules

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,7 +47,5 @@ Style/FrozenStringLiteralComment:
   Enabled: false
 Style/GuardClause:
   MinBodyLength: 2
-Style/HashSyntax:
-  EnforcedShorthandSyntax: never
 Style/StringLiterals:
   EnforcedStyle: single_quotes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,7 +79,7 @@ GEM
     ast (2.4.2)
     bootsnap (1.11.1)
       msgpack (~> 1.2)
-    brakeman (5.2.1)
+    brakeman (5.2.2)
     builder (3.2.4)
     byebug (11.1.3)
     capybara (3.36.0)

--- a/app/controllers/synonyms/search_references_controller.rb
+++ b/app/controllers/synonyms/search_references_controller.rb
@@ -3,7 +3,7 @@ module Synonyms
     before_action :authorize_user
 
     def index
-      @search_references = search_reference_parent.search_references.all(page: page, per_page: per_page)
+      @search_references = search_reference_parent.search_references.all(page:, per_page:)
       @search_references = Kaminari.paginate_array(@search_references, total_count: @search_references.metadata[:pagination][:total]).page(page).per(per_page)
     end
 

--- a/app/helpers/govuk_helper.rb
+++ b/app/helpers/govuk_helper.rb
@@ -1,6 +1,6 @@
 module GovukHelper
   def govuk_breadcrumbs(breadcrumbs)
-    render GovukComponent::BreadcrumbsComponent.new(breadcrumbs: breadcrumbs)
+    render GovukComponent::BreadcrumbsComponent.new(breadcrumbs:)
   end
 
   def govuk_form_for(*args, **options, &block)

--- a/app/services/search_reference/export_all_service.rb
+++ b/app/services/search_reference/export_all_service.rb
@@ -8,7 +8,7 @@ class SearchReference
 
     def collection
       'a'.upto('z').inject([]) do |memo, letter|
-        search_references = SearchReference.all(query: { letter: letter }).fetch
+        search_references = SearchReference.all(query: { letter: }).fetch
         memo.concat(search_references)
       end
     end

--- a/spec/features/chapter_search_reference_spec.rb
+++ b/spec/features/chapter_search_reference_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe 'Chapter Search Reference management' do
         end
       end
 
-      refute search_reference_created_for(chapter, title: title)
+      refute search_reference_created_for(chapter, title:)
 
       stub_api_for(Chapter::SearchReference) do |stub|
         stub.post("/admin/chapters/#{chapter.to_param}/search_references") do |_env|
@@ -37,7 +37,7 @@ RSpec.describe 'Chapter Search Reference management' do
       end
       create_search_reference_for chapter, 'Synonym' => title
 
-      verify search_reference_created_for(chapter, title: title)
+      verify search_reference_created_for(chapter, title:)
     end
   end
 

--- a/spec/features/commodity_search_reference_spec.rb
+++ b/spec/features/commodity_search_reference_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Commodity Search Reference management' do
         end
       end
 
-      refute search_reference_created_for(commodity, title: title)
+      refute search_reference_created_for(commodity, title:)
 
       stub_api_for(Commodity::SearchReference) do |stub|
         stub.post("/admin/commodities/#{commodity.to_param}/search_references") do |_env|
@@ -37,7 +37,7 @@ RSpec.describe 'Commodity Search Reference management' do
 
       create_search_reference_for commodity, 'Synonym' => title
 
-      verify search_reference_created_for(commodity, title: title)
+      verify search_reference_created_for(commodity, title:)
     end
   end
 

--- a/spec/features/heading_search_reference_spec.rb
+++ b/spec/features/heading_search_reference_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe 'Heading Search Reference management' do
         end
       end
 
-      refute search_reference_created_for(heading, title: title)
+      refute search_reference_created_for(heading, title:)
 
       stub_api_for(Heading::SearchReference) do |stub|
         stub.post("/admin/headings/#{heading.to_param}/search_references") do |_env|
@@ -37,7 +37,7 @@ RSpec.describe 'Heading Search Reference management' do
 
       create_search_reference_for heading, 'Synonym' => title
 
-      verify search_reference_created_for(heading, title: title)
+      verify search_reference_created_for(heading, title:)
     end
   end
 

--- a/spec/features/section_search_reference_spec.rb
+++ b/spec/features/section_search_reference_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Section Search Reference management' do
         end
       end
 
-      refute search_reference_created_for(section, title: title)
+      refute search_reference_created_for(section, title:)
 
       stub_api_for(Section::SearchReference) do |stub|
         stub.post("/admin/sections/#{section.to_param}/search_references") do |_env|
@@ -45,7 +45,7 @@ RSpec.describe 'Section Search Reference management' do
 
       create_search_reference_for section, 'Synonym' => title
 
-      verify search_reference_created_for(section, title: title)
+      verify search_reference_created_for(section, title:)
     end
   end
 

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -28,13 +28,13 @@ RSpec.describe TariffUpdate do
 
   describe '#rollback?' do
     shared_examples_for 'a tariff update that rolls back' do |state, _will_rollback|
-      subject(:tariff_update) { build(:tariff_update, state: state) }
+      subject(:tariff_update) { build(:tariff_update, state:) }
 
       it { is_expected.to be_rollback }
     end
 
     shared_examples_for 'a tariff update that does not rollback' do |state, _will_rollback|
-      subject(:tariff_update) { build(:tariff_update, state: state) }
+      subject(:tariff_update) { build(:tariff_update, state:) }
 
       it { is_expected.not_to be_rollback }
     end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1478

### What?

I have added/removed/altered:

- [x] Bump brakeman
- [x] Update hash syntax rules

### Why?

I am doing this because:

- Brakeman now supports ruby 3.1.x syntax
