### PR TITLE
HOTT-1521 Always use latest v1 Ruby orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   aws-cli: circleci/aws-cli@2.0.3
-  ruby: circleci/ruby@1.4.0
+  ruby: circleci/ruby@1.4
   node: circleci/node@4.7.0
   cloudfoundry: circleci/cloudfoundry@1.0
   slack: circleci/slack@4.3.0


### PR DESCRIPTION
### Jira link

[HOTT-1521](https://transformuk.atlassian.net/browse/HOTT-1521)

### What?

I have added/removed/altered:

- [x] Change the CI config to always use the latest v1 version of the Ruby orb

### Why?

I am doing this because:

- Orbs follow semantic versioning, so it should be safe to upgrade minor and patch releases automatically since they wont include breaking changes.
- There are known problems with specs not being run for the old v1.4.0 version of the ruby orb we currently use.