### PR TITLE
Hott 1551 update menubar

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -28,13 +28,13 @@
       <%= header.navigation_item text: "Section & chapter notes",
                                  href: root_path,
                                  active: active_nav_link?(/\/notes|trade-tariff-admin$/) %>
-      <%= header.navigation_item text: "Search Synonyms",
+      <%= header.navigation_item text: "Search references",
                                  href: synonyms_sections_path,
                                  active: active_nav_link?(/\/synonyms/) %>
       <%= header.navigation_item text: "News",
                                  href: news_items_path,
                                  active: active_nav_link?(/\/news_items/) %>
-      <%= header.navigation_item text: "Tariff Updates",
+      <%= header.navigation_item text: "Updates",
                                  href: tariff_updates_path,
                                  active: active_nav_link?(/\/tariff_updates/) %>
       <%= header.navigation_item text: "Rollbacks",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,7 +30,7 @@
                                  active: active_nav_link?(/\/notes|trade-tariff-admin$/) %>
       <%= header.navigation_item text: "Search references",
                                  href: synonyms_sections_path,
-                                 active: active_nav_link?(/\/synonyms/) %>
+                                 active: active_nav_link?(/\/search_references/) %>
       <%= header.navigation_item text: "News",
                                  href: news_items_path,
                                  active: active_nav_link?(/\/news_items/) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,7 +23,7 @@ Rails.application.routes.draw do
     end
   end
 
-  namespace :synonyms, module: :synonyms do
+  namespace :synonyms, module: :synonyms, path: 'search_references' do
     resource :import, only: %i[show create]
     resource :export, only: [:create]
 


### PR DESCRIPTION
### Jira link

[HOTT-1551](https://transformuk.atlassian.net/browse/HOTT-1551)

### What?

I have added/removed/altered:

- [x] Updated the menu bar labels
- [x] Changed the URL segment for search synonyms from `/synonyms` to `/search_references'

### Why?

I am doing this because:

- We are in the process of renaming synonyms to search references

