### PR TITLE
HOTT-1555 Corrected column headings for search references

### DIFF
--- a/app/views/synonyms/chapters/headings/index.html.erb
+++ b/app/views/synonyms/chapters/headings/index.html.erb
@@ -9,7 +9,7 @@
       <th>Heading</th>
       <th>Commodities</th>
       <th>Title</th>
-      <th class="hott-actions-col">References</th>
+      <th class="hott-actions-col">Search references</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/synonyms/headings/commodities/index.html.erb
+++ b/app/views/synonyms/headings/commodities/index.html.erb
@@ -10,7 +10,7 @@
       <th>Title</th>
       <th>Productline Suffix</th>
       <th>Declarable</th>
-      <th class="actions_col">References</th>
+      <th class="hott-actions-col">Search references</th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/synonyms/sections/chapters/index.html.erb
+++ b/app/views/synonyms/sections/chapters/index.html.erb
@@ -9,7 +9,7 @@
       <th>Chapter</th>
       <th>Headings</th>
       <th>Title</th>
-      <th class="hott-actions-col">References</th>
+      <th class="hott-actions-col">Search references</th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
### Jira link

HOTT-1555

### What?

I have added/removed/altered:

- [x] Updated the column headings from **References** to **Search References**

### Why?

I am doing this because:

- I'd misread the ticket