### PR TITLE
Disable RSpec dsl in main

### DIFF
--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe NewsItem do
+RSpec.describe NewsItem do
   subject(:news_item) { build :news_item, :home_page, :updates_page, :banner }
 
   it { is_expected.to respond_to :id }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,6 +20,7 @@ RSpec.configure do |config|
   config.infer_base_class_for_anonymous_controllers = false
   config.filter_run focus: true
   config.run_all_when_everything_filtered = true
+  config.expose_dsl_globally = false
 
   config.include Rails.application.routes.url_helpers
   config.include ApiResponsesHelper

--- a/spec/requests/govspeak_controller_spec.rb
+++ b/spec/requests/govspeak_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe GovspeakController do
+RSpec.describe GovspeakController do
   subject(:rendered_page) { response }
 
   before { create :user, permissions: ['signin', 'HMRC Editor'] }

--- a/spec/requests/news_items_controller_spec.rb
+++ b/spec/requests/news_items_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe NewsItemsController do
+RSpec.describe NewsItemsController do
   subject(:rendered_page) { create_user && make_request && response }
 
   let(:news_item) { build :news_item }

--- a/spec/views/news_items/_form.html.erb_spec.rb
+++ b/spec/views/news_items/_form.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'news_items/form' do
+RSpec.describe 'news_items/form' do
   subject(:form) { render_partial && rendered }
 
   let(:render_partial) { render 'news_items/form', news_item: news_item }

--- a/spec/views/news_items/index.html.erb_spec.rb
+++ b/spec/views/news_items/index.html.erb_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe 'news_items/index' do
+RSpec.describe 'news_items/index' do
   subject { render && rendered }
 
   before { assign :news_items, news_items }


### PR DESCRIPTION
### Jira link

HOTT-<TODO>

### What?

I have added/removed/altered:

- [x] Avoid monkey patched rspec dsl

### Why?

I am doing this because:

- This is consistent with the rails generators and it is generally more desirable to do things in one way, only: https://github.com/rspec/rspec-rails/commit/ca0d249858903949052e06884e8e7f9d596cdc79
