### PR TITLE
HOTT-1567: Remove Gem redis-activesupport.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,6 @@ gem 'oj'
 
 # Cache
 gem 'redis'
-gem 'redis-activesupport'
 
 # Authorization / SSO
 gem 'gds-sso'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -345,11 +345,6 @@ GEM
     raindrops (0.20.0)
     rake (13.0.6)
     redis (4.6.0)
-    redis-activesupport (5.3.0)
-      activesupport (>= 3, < 8)
-      redis-store (>= 1.3, < 2)
-    redis-store (1.9.1)
-      redis (>= 4, < 5)
     regexp_parser (2.4.0)
     request_store (1.5.1)
       rack (>= 1.4)
@@ -519,7 +514,6 @@ DEPENDENCIES
   pundit
   rails (~> 7.0)
   redis
-  redis-activesupport
   responders
   routing-filter!
   rspec-rails


### PR DESCRIPTION
### Jira link
[HOTT-1567](https://transformuk.atlassian.net/browse/HOTT-1567)

### What?
Remove Gem redis-activesupport.
No need to change cache_store type, it is already using `:redis_cache_store`.

### Why?
the gem redis-activesupport is not maintained, and it is unnecessary.
