### PR TITLE
HOTT-1634 Fixed typo

### DIFF
--- a/app/views/synonyms/chapters/headings/index.html.erb
+++ b/app/views/synonyms/chapters/headings/index.html.erb
@@ -22,7 +22,7 @@
         <td><%= heading.description.titleize %></td>
         <td class="hott-link-group">
           <div>
-            <%= pluralize heading.search_references_count, "refence" %>
+            <%= pluralize heading.search_references_count, "reference" %>
           </div>
           <%= link_to 'Edit', synonyms_heading_search_references_path(heading) %>
           <% if heading.search_references_count > 0 %>


### PR DESCRIPTION
### Jira link

[HOTT-1634](https://transformuk.atlassian.net/browse/HOTT-1634)

### What?

I have added/removed/altered:

- [x] Fixed incorrect spelling of reference

### Why?

I am doing this because:

- I typo'd my original search and replace

