### PR TITLE
HOTT-1654 Support LOCALE service tags

### DIFF
--- a/app/helpers/service_helper.rb
+++ b/app/helpers/service_helper.rb
@@ -25,15 +25,27 @@ module ServiceHelper
     TradeTariffAdmin::ServiceChooser.uk? ? 'the UK' : 'Northern Ireland'
   end
 
+  def service_path_prefix
+    TradeTariffAdmin::ServiceChooser.xi? ? '/xi' : ''
+  end
+
+  def locale_path_prefix
+    I18n.locale == I18n.default_locale ? '' : "/#{I18n.locale}"
+  end
+
   def replace_service_tags(content)
-    content.gsub %r{\[\[SERVICE_[A-Z_]+\]\]} do |match|
+    content.gsub %r{\[\[[A-Z]+_[A-Z_]+\]\]} do |match|
       case match
       when '[[SERVICE_NAME]]'
         service_name
       when '[[SERVICE_PATH]]'
-        TradeTariffAdmin::ServiceChooser.uk? ? '' : '/xi'
+        service_path_prefix
       when '[[SERVICE_REGION]]'
         service_region
+      when '[[LOCALE_PATH]]'
+        ''
+      when '[[PREFIX_PATH]]'
+        service_path_prefix
       else
         match
       end

--- a/app/views/news_items/_form.html.erb
+++ b/app/views/news_items/_form.html.erb
@@ -43,6 +43,26 @@
             <pre>[Browse]([[SERVICE_PATH]]/browse)</pre>
           </dd>
         </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            [[LOCALE_PATH]]
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Useful for links that work for both English and Welsh translations, eg
+            <pre>[Browse]([[LOCALE_PATH]]/browse)</pre>
+          </dd>
+        </div>
+
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">
+            [[PREFIX_PATH]]
+          </dt>
+          <dd class="govuk-summary-list__value">
+            Useful for links that work for both UK and XI services and with English and Welsh translations, eg
+            <pre>[Browse]([[PREFIX_PATH]]/browse)</pre>
+          </dd>
+        </div>
       </dl>
     </div>
   </details>

--- a/spec/helpers/service_helper_spec.rb
+++ b/spec/helpers/service_helper_spec.rb
@@ -203,5 +203,27 @@ RSpec.describe ServiceHelper, type: :helper do
         it { is_expected.to eql expected }
       end
     end
+
+    context 'with LOCALE_PATH' do
+      let(:content) { '[Browse]([[LOCALE_PATH]]/browse)' }
+
+      it { is_expected.to eql '[Browse](/browse)' }
+    end
+
+    context 'with PREFIX_PATH' do
+      let(:content) { '[Browse]([[PREFIX_PATH]]/browse)' }
+
+      context 'with UK service' do
+        include_context 'with UK service'
+
+        it { is_expected.to eql '[Browse](/browse)' }
+      end
+
+      context 'with XI service' do
+        include_context 'with XI service'
+
+        it { is_expected.to eql '[Browse](/xi/browse)' }
+      end
+    end
   end
 end


### PR DESCRIPTION
### Jira link

[HOTT-1654](https://transformuk.atlassian.net/browse/HOTT-1654)

### What?

I have added/removed/altered:

- [x] Added `LOCALE_PATH` and `PREFIX_PATH` service tags 

### Why?

I am doing this because:

- The Welsh support requires them and without adding them to the admin they don't get previewed correctly