### PR TITLE
HOTT-1585: Add new tariff updates show page

### DIFF
--- a/app/controllers/tariff_updates_controller.rb
+++ b/app/controllers/tariff_updates_controller.rb
@@ -2,4 +2,8 @@ class TariffUpdatesController < AuthenticatedController
   def index
     @tariff_updates = TariffUpdate.all(page: current_page).fetch
   end
+
+  def show
+    @tariff_update = TariffUpdate.find(params[:id])
+  end
 end

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -30,11 +30,7 @@ class TariffUpdate
   end
 
   def parsed_inserts
-    parsed = JSON.parse(inserts.presence || '{}')
-
-    return '' if parsed.blank?
-
-    YAML.dump(parsed).strip
+    JSON.parse(inserts.presence || '{}')
   end
 
   def rollback?
@@ -50,6 +46,68 @@ class TariffUpdate
   end
 
   def id
-    created_at.to_s.parameterize
+    filename&.sub(/\.(xml|gzip)\Z/, '')
+  end
+
+  def updated_inserts?
+    parsed_inserts['total_duration'].present?
+  end
+
+  def total_duration_in_seconds
+    parsed_inserts.fetch('total_duration', 0) / 1000 # in milliseconds
+  end
+
+  def total_records_affected
+    parsed_inserts.fetch('total_count', 0)
+  end
+
+  def total_records_created
+    parsed_inserts.dig('operations', 'create', 'count').presence || 0
+  end
+
+  def total_records_updated
+    parsed_inserts.dig('operations', 'update', 'count').presence || 0
+  end
+
+  def total_records_destroyed
+    parsed_inserts.dig('operations', 'destroy', 'count').presence || 0
+  end
+
+  def total_records_destroyed_missing
+    parsed_inserts.dig('operations', 'destroy_missing', 'count').presence || 0
+  end
+
+  def total_records_destroyed_cascade
+    parsed_inserts.dig('operations', 'destroy_cascade', 'count').presence || 0
+  end
+
+  def entity_updates
+    creates = inserts_for('create')
+    updates = inserts_for('update')
+    destroys = inserts_for('destroy')
+    destroys_missing = inserts_for('destroy_missing')
+    destroys_cascade = inserts_for('destroy_cascade')
+
+    all_entities = Set.new
+    all_entities.merge(creates.keys)
+    all_entities.merge(updates.keys)
+    all_entities.merge(destroys.keys)
+    all_entities.merge(destroys_missing.keys)
+    all_entities.merge(destroys_cascade.keys)
+
+    all_entities.each_with_object([]) do |entity, entities|
+      # entity name, created, updated, destroyed, missing
+      entities << {
+        entity:,
+        creates: creates.dig(entity, 'count') || 0,
+        updates: updates.dig(entity, 'count') || 0,
+        destroys: destroys.dig(entity, 'count') || 0,
+        missing: destroys_missing.dig(entity, 'count') || 0,
+      }
+    end
+  end
+
+  def inserts_for(operation)
+    parsed_inserts.dig('operations', operation).except('duration', 'count', 'allocations')
   end
 end

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -29,10 +29,6 @@ class TariffUpdate
     STATES[super]
   end
 
-  def parsed_inserts
-    JSON.parse(inserts.presence || '{}')
-  end
-
   def rollback?
     attributes[:state].in?(ROLLBACK_APPLICABLE_STATES)
   end
@@ -49,65 +45,11 @@ class TariffUpdate
     filename&.sub(/\.(xml|gzip)\Z/, '')
   end
 
-  def updated_inserts?
-    parsed_inserts['total_duration'].present?
+  def formatted_update_type
+    update_type.sub(/\ATariffSynchronizer::/, '').titleize
   end
 
-  def total_duration_in_seconds
-    parsed_inserts.fetch('total_duration', 0) / 1000 # in milliseconds
-  end
-
-  def total_records_affected
-    parsed_inserts.fetch('total_count', 0)
-  end
-
-  def total_records_created
-    parsed_inserts.dig('operations', 'create', 'count').presence || 0
-  end
-
-  def total_records_updated
-    parsed_inserts.dig('operations', 'update', 'count').presence || 0
-  end
-
-  def total_records_destroyed
-    parsed_inserts.dig('operations', 'destroy', 'count').presence || 0
-  end
-
-  def total_records_destroyed_missing
-    parsed_inserts.dig('operations', 'destroy_missing', 'count').presence || 0
-  end
-
-  def total_records_destroyed_cascade
-    parsed_inserts.dig('operations', 'destroy_cascade', 'count').presence || 0
-  end
-
-  def entity_updates
-    creates = inserts_for('create')
-    updates = inserts_for('update')
-    destroys = inserts_for('destroy')
-    destroys_missing = inserts_for('destroy_missing')
-    destroys_cascade = inserts_for('destroy_cascade')
-
-    all_entities = Set.new
-    all_entities.merge(creates.keys)
-    all_entities.merge(updates.keys)
-    all_entities.merge(destroys.keys)
-    all_entities.merge(destroys_missing.keys)
-    all_entities.merge(destroys_cascade.keys)
-
-    all_entities.each_with_object([]) do |entity, entities|
-      # entity name, created, updated, destroyed, missing
-      entities << {
-        entity:,
-        creates: creates.dig(entity, 'count') || 0,
-        updates: updates.dig(entity, 'count') || 0,
-        destroys: destroys.dig(entity, 'count') || 0,
-        missing: destroys_missing.dig(entity, 'count') || 0,
-      }
-    end
-  end
-
-  def inserts_for(operation)
-    parsed_inserts.dig('operations', operation).except('duration', 'count', 'allocations')
+  def inserts
+    attributes[:inserts] ? TariffUpdate::Inserts.new(attributes[:inserts]) : nil
   end
 end

--- a/app/models/tariff_update.rb
+++ b/app/models/tariff_update.rb
@@ -29,8 +29,12 @@ class TariffUpdate
     STATES[super]
   end
 
-  def inserts
-    JSON.parse(attributes[:inserts].presence || '{}')
+  def parsed_inserts
+    parsed = JSON.parse(inserts.presence || '{}')
+
+    return '' if parsed.blank?
+
+    YAML.dump(parsed).strip
   end
 
   def rollback?

--- a/app/models/tariff_update/inserts.rb
+++ b/app/models/tariff_update/inserts.rb
@@ -1,0 +1,74 @@
+class TariffUpdate
+  class Inserts
+    def initialize(attributes)
+      @attributes = attributes
+    end
+
+    def total_duration_in_seconds
+      parsed_inserts.fetch('total_duration', 0) / 1000 # in milliseconds
+    end
+
+    def total_records_affected
+      parsed_inserts.fetch('total_count', 0)
+    end
+
+    def total_records_created
+      parsed_inserts.dig('operations', 'create', 'count').presence || 0
+    end
+
+    def total_records_updated
+      parsed_inserts.dig('operations', 'update', 'count').presence || 0
+    end
+
+    def total_records_destroyed
+      parsed_inserts.dig('operations', 'destroy', 'count').presence || 0
+    end
+
+    def total_records_destroyed_missing
+      parsed_inserts.dig('operations', 'destroy_missing', 'count').presence || 0
+    end
+
+    def total_records_destroyed_cascade
+      parsed_inserts.dig('operations', 'destroy_cascade', 'count').presence || 0
+    end
+
+    def entity_updates
+      creates = inserts_for('create')
+      updates = inserts_for('update')
+      destroys = inserts_for('destroy')
+      destroys_missing = inserts_for('destroy_missing')
+      destroys_cascade = inserts_for('destroy_cascade')
+
+      all_entities = Set.new
+      all_entities.merge(creates.keys)
+      all_entities.merge(updates.keys)
+      all_entities.merge(destroys.keys)
+      all_entities.merge(destroys_missing.keys)
+      all_entities.merge(destroys_cascade.keys)
+
+      all_entities.each_with_object([]) do |entity, entities|
+        entities << {
+          entity:,
+          creates: creates.dig(entity, 'count') || 0,
+          updates: updates.dig(entity, 'count') || 0,
+          destroys: destroys.dig(entity, 'count') || 0,
+          missing: destroys_missing.dig(entity, 'count') || 0,
+        }
+      end
+    end
+
+    def updated_inserts?
+      parsed_inserts['total_duration'].present?
+    end
+
+    def parsed_inserts
+      @parsed_inserts ||= JSON.parse(@attributes.presence || '{}')
+    end
+
+    private
+
+    def inserts_for(operation)
+      parsed_inserts.dig('operations', operation).except('duration', 'count', 'allocations')
+    end
+  end
+end

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -30,7 +30,7 @@
         <td><%= number_to_human_size(tariff_update.filesize) %></td>
         <td>
           <a class="govuk-link" href="#">
-            <%= link_to "Review inserts", tariff_update_path(tariff_update, target: "_blank", title: tariff_update.filename) %>
+            <%= link_to "Review inserts", tariff_update_path(tariff_update) %>
           </a>
         </td>
         <td><%= render "actions", tariff_update: tariff_update %></td>

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -29,7 +29,7 @@
         <td><%= l(tariff_update.applied_at, format: :tariff) if tariff_update.applied_at %></td>
         <td><%= number_to_human_size(tariff_update.filesize) %></td>
         <td>
-          <% if tariff_update.inserts.present? %>
+          <% if tariff_update.parsed_inserts.present? %>
             <details class="govuk-details" data-module="govuk-details">
               <summary class="govuk-details__summary">
                 <span class="govuk-details__summary-text">
@@ -37,11 +37,9 @@
                 </span>
               </summary>
               <div class="govuk-details__text">
-                <% tariff_update.inserts.each_with_index do |(key, value), index| %>
-                  <%= tag.br if index.positive? %>
-
-                  <%= key.sub('::Operation', '') %>: <%= value %>
-                <% end %>
+                <pre>
+                  <%= tariff_update.parsed_inserts %>
+                </pre>
               </div>
             </details>
           <% end %>

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -29,20 +29,9 @@
         <td><%= l(tariff_update.applied_at, format: :tariff) if tariff_update.applied_at %></td>
         <td><%= number_to_human_size(tariff_update.filesize) %></td>
         <td>
-          <% if tariff_update.parsed_inserts.present? %>
-            <details class="govuk-details" data-module="govuk-details">
-              <summary class="govuk-details__summary">
-                <span class="govuk-details__summary-text">
-                  Review inserts
-                </span>
-              </summary>
-              <div class="govuk-details__text">
-                <pre>
-                  <%= tariff_update.parsed_inserts %>
-                </pre>
-              </div>
-            </details>
-          <% end %>
+          <a class="govuk-link" href="#">
+            <%= link_to "Review inserts", tariff_update_path(tariff_update, target: "_blank", title: tariff_update.filename) %>
+          </a>
         </td>
         <td><%= render "actions", tariff_update: tariff_update %></td>
       </tr>

--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -11,7 +11,7 @@
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" href="#">
-        <%= link_to "Download", sanitize(@tariff_update.file_presigned_url), target: "_blank", title: @tariff_update.filename %>
+        <%= link_to "Download", @tariff_update.file_presigned_url, target: "_blank", title: @tariff_update.filename %>
       </a>
     </dd>
   </div>

--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -71,7 +71,7 @@
         Review Inserts
       </dt>
       <dd class="govuk-summary-list__value">
-        <% if @tariff_update.inserts && @tariff_update.inserts.parsed_inserts.present? %>
+        <% if @tariff_update.inserts&.parsed_inserts.present? %>
           <% @tariff_update.inserts.parsed_inserts.each_with_index do |(key, value), index| %>
             <%= tag.br if index.positive? %>
 
@@ -80,7 +80,6 @@
         <% elsif @tariff_update.inserts.nil? %>
           No insert information for this file
         <% else %>
-
           This file was empty
         <% end %>
       </dd>

--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -1,4 +1,4 @@
-<h1><%= "#{@tariff_update.update_type} update #{}" %></h1>
+<h1><%= @tariff_update.formatted_update_type %></h1>
 
 <dl class="govuk-summary-list">
   <div class="govuk-summary-list__row">
@@ -25,42 +25,31 @@
     <dd class="govuk-summary-list__actions">
     </dd>
   </div>
-  <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">
-      Issued on
-    </dt>
-    <dd class="govuk-summary-list__value">
-      <%= l(@tariff_update.issue_date.to_date, format: :tariff) %>
-    </dd>
-    <dd class="govuk-summary-list__actions">
-    </dd>
-  </div>
-  <% if @tariff_update.updated_inserts? %>
-
+  <% if @tariff_update.inserts&.updated_inserts? %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">
         Records changed
       </dt>
       <dd class="govuk-summary-list__value">
-        <p class="govuk-body"><%= @tariff_update.total_records_affected %> total</p>
-        <% if @tariff_update.total_records_created.positive? %>
-          <p class="govuk-body"><%= @tariff_update.total_records_created %> created</p>
+        <p class="govuk-body"><%= @tariff_update.inserts.total_records_affected %> total</p>
+        <% if @tariff_update.inserts.total_records_created.positive? %>
+          <p class="govuk-body"><%= @tariff_update.inserts.total_records_created %> created</p>
         <% end %>
 
-        <% if @tariff_update.total_records_updated.positive? %>
-          <p class="govuk-body"><%= @tariff_update.total_records_updated %> updated</p>
+        <% if @tariff_update.inserts.total_records_updated.positive? %>
+          <p class="govuk-body"><%= @tariff_update.inserts.total_records_updated %> updated</p>
         <% end %>
 
-        <% if @tariff_update.total_records_destroyed.positive? %>
-          <p class="govuk-body"><%= @tariff_update.total_records_destroyed %> destroyed</p>
+        <% if @tariff_update.inserts.total_records_destroyed.positive? %>
+          <p class="govuk-body"><%= @tariff_update.inserts.total_records_destroyed %> destroyed</p>
         <% end %>
 
-        <% if @tariff_update.total_records_destroyed_missing.positive? %>
-          <p class="govuk-body"><%= @tariff_update.total_records_destroyed_missing %> destroyed because now missing</p>
+        <% if @tariff_update.inserts.total_records_destroyed_missing.positive? %>
+          <p class="govuk-body"><%= @tariff_update.inserts.total_records_destroyed_missing %> destroyed because now missing</p>
         <% end %>
 
-        <% if @tariff_update.total_records_destroyed_cascade.positive? %>
-          <p class="govuk-body"><%= @tariff_update.total_records_destroyed_cascade %> destroyed because cascade deletion</p>
+        <% if @tariff_update.inserts.total_records_destroyed_cascade.positive? %>
+          <p class="govuk-body"><%= @tariff_update.inserts.total_records_destroyed_cascade %> destroyed because cascade deletion</p>
         <% end %>
       </dd>
       <dd class="govuk-summary-list__actions">
@@ -71,7 +60,7 @@
         Import duration
       </dt>
       <dd class="govuk-summary-list__value">
-        <p class="govuk-body"><%= @tariff_update.total_duration_in_seconds.round %> seconds</p>
+        <p class="govuk-body"><%= @tariff_update.inserts.total_duration_in_seconds.round %> seconds</p>
       </dd>
       <dd class="govuk-summary-list__actions">
       </dd>
@@ -82,8 +71,8 @@
         Review Inserts
       </dt>
       <dd class="govuk-summary-list__value">
-        <% if @tariff_update.parsed_inserts.present? %>
-          <% @tariff_update.parsed_inserts.each_with_index do |(key, value), index| %>
+        <% if @tariff_update.inserts && @tariff_update.inserts.parsed_inserts.present? %>
+          <% @tariff_update.inserts.parsed_inserts.each_with_index do |(key, value), index| %>
             <%= tag.br if index.positive? %>
 
             <%= key.sub('::Operation', '') %>: <%= value %>
@@ -101,7 +90,7 @@
   <% end %>
 </dl>
 
-<% if @tariff_update.updated_inserts? && @tariff_update.total_records_affected.positive? %>
+<% if @tariff_update.inserts&.updated_inserts? && @tariff_update.inserts.total_records_affected.positive? %>
   <p class="govuk-body">
     As part of the CDS/Taric (UK/EU) import process we extract, transform and load various tariff records.
     The following table indicates the specific rows that got inserted and the operation that was specified in the file that triggered this update.
@@ -119,7 +108,7 @@
       </tr>
     </thead>
     <tbody class="govuk-table__body">
-      <% @tariff_update.entity_updates.each do |entity| %>
+      <% @tariff_update.inserts.entity_updates.each do |entity| %>
         <tr class="govuk-table__row">
           <th scope="row" class="govuk-table__header"><%= entity[:entity] %></th>
           <td class="govuk-table__cell"><%= entity[:creates] %></td>

--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -11,7 +11,7 @@
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" href="#">
-        <%= link_to "Download", @tariff_update.file_presigned_url, target: "_blank", title: @tariff_update.filename %>
+        <%= link_to "Download", safe_url(@tariff_update.file_presigned_url), target: "_blank", title: @tariff_update.filename %>
       </a>
     </dd>
   </div>

--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -1,0 +1,133 @@
+<h1><%= "#{@tariff_update.update_type} update #{}" %></h1>
+
+<dl class="govuk-summary-list">
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Filename
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <p class="govuk-body"><%= @tariff_update.filename %></p>
+      <p class="govuk-body"><%= number_to_human_size(@tariff_update.filesize) %></p>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+      <a class="govuk-link" href="#">
+        <%= link_to "Download", @tariff_update.file_presigned_url, target: "_blank", title: @tariff_update.filename %>
+      </a>
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Imported on
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= l(@tariff_update.created_at.to_date, format: :tariff) %>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+    </dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">
+      Issued on
+    </dt>
+    <dd class="govuk-summary-list__value">
+      <%= l(@tariff_update.issue_date.to_date, format: :tariff) %>
+    </dd>
+    <dd class="govuk-summary-list__actions">
+    </dd>
+  </div>
+  <% if @tariff_update.updated_inserts? %>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Records changed
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body"><%= @tariff_update.total_records_affected %> total</p>
+        <% if @tariff_update.total_records_created.positive? %>
+          <p class="govuk-body"><%= @tariff_update.total_records_created %> created</p>
+        <% end %>
+
+        <% if @tariff_update.total_records_updated.positive? %>
+          <p class="govuk-body"><%= @tariff_update.total_records_updated %> updated</p>
+        <% end %>
+
+        <% if @tariff_update.total_records_destroyed.positive? %>
+          <p class="govuk-body"><%= @tariff_update.total_records_destroyed %> destroyed</p>
+        <% end %>
+
+        <% if @tariff_update.total_records_destroyed_missing.positive? %>
+          <p class="govuk-body"><%= @tariff_update.total_records_destroyed_missing %> destroyed because now missing</p>
+        <% end %>
+
+        <% if @tariff_update.total_records_destroyed_cascade.positive? %>
+          <p class="govuk-body"><%= @tariff_update.total_records_destroyed_cascade %> destroyed because cascade deletion</p>
+        <% end %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+      </dd>
+    </div>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Import duration
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body"><%= @tariff_update.total_duration_in_seconds.round %> seconds</p>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+      </dd>
+    </div>
+  <% else %>
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">
+        Review Inserts
+      </dt>
+      <dd class="govuk-summary-list__value">
+        <% if @tariff_update.parsed_inserts.present? %>
+          <% @tariff_update.parsed_inserts.each_with_index do |(key, value), index| %>
+            <%= tag.br if index.positive? %>
+
+            <%= key.sub('::Operation', '') %>: <%= value %>
+          <% end %>
+        <% elsif @tariff_update.inserts.nil? %>
+          No insert information for this file
+        <% else %>
+
+          This file was empty
+        <% end %>
+      </dd>
+      <dd class="govuk-summary-list__actions">
+      </dd>
+    </div>
+  <% end %>
+</dl>
+
+<% if @tariff_update.updated_inserts? && @tariff_update.total_records_affected.positive? %>
+  <p class="govuk-body">
+    As part of the CDS/Taric (UK/EU) import process we extract, transform and load various tariff records.
+    The following table indicates the specific rows that got inserted and the operation that was specified in the file that triggered this update.
+  </p>
+
+  <table class="govuk-table">
+    <caption class="govuk-table__caption govuk-table__caption--m">Imported entities</caption>
+    <thead class="govuk-table__head">
+      <tr class="govuk-table__row">
+        <th scope="col" class="govuk-table__header govuk-!-width-one-half">Entity</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Created</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Updated</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Destroyed</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Missing</th>
+      </tr>
+    </thead>
+    <tbody class="govuk-table__body">
+      <% @tariff_update.entity_updates.each do |entity| %>
+        <tr class="govuk-table__row">
+          <th scope="row" class="govuk-table__header"><%= entity[:entity] %></th>
+          <td class="govuk-table__cell"><%= entity[:creates] %></td>
+          <td class="govuk-table__cell"><%= entity[:updates] %></td>
+          <td class="govuk-table__cell"><%= entity[:destroys] %></td>
+          <td class="govuk-table__cell"><%= entity[:missing] %></td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+<% end %>

--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -11,7 +11,7 @@
     </dd>
     <dd class="govuk-summary-list__actions">
       <a class="govuk-link" href="#">
-        <%= link_to "Download", safe_url(@tariff_update.file_presigned_url), target: "_blank", title: @tariff_update.filename %>
+        <%= link_to "Download", sanitize(@tariff_update.file_presigned_url), target: "_blank", title: @tariff_update.filename %>
       </a>
     </dd>
   </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,0 +1,37 @@
+{
+  "ignored_warnings": [
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "ba185af4c1e0b5851c3fa1dc92738e7febd10c84b9a72ab96a6bcc0fc9e37fee",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/tariff_updates/show.html.erb",
+      "line": 14,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Download\", TariffUpdate.find(params[:id]).file_presigned_url, :target => \"_blank\", :title => TariffUpdate.find(params[:id]).filename)",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "TariffUpdatesController",
+          "method": "show",
+          "line": 8,
+          "file": "app/controllers/tariff_updates_controller.rb",
+          "rendered": {
+            "name": "tariff_updates/show",
+            "file": "app/views/tariff_updates/show.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "tariff_updates/show"
+      },
+      "user_input": "TariffUpdate.find(params[:id]).file_presigned_url",
+      "confidence": "Weak",
+      "note": ""
+    }
+  ],
+  "updated": "2022-05-30 15:54:11 +0100",
+  "brakeman_version": "5.2.3"
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,7 +60,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :tariff_updates, only: %i[index]
+  resources :tariff_updates, only: %i[index show]
   resources :rollbacks, only: %i[index new create]
   resources :footnotes, only: %i[index edit update]
   resources :measure_types, only: %i[index edit update]

--- a/spec/factories/tariff_update_factory.rb
+++ b/spec/factories/tariff_update_factory.rb
@@ -20,10 +20,6 @@ FactoryBot.define do
       update_type { 'TariffSynchronizer::CdsUpdate' }
     end
 
-    trait :with_inserts do
-      inserts { '{"something": "parseable"}' }
-    end
-
     trait :with_exception do
       exception_class { 'CdsImporter::ImportException' }
       exception_queries { "(Sequel::Mysql2::Database) BEGIN \n(Sequel::Mysql2::Database) SELECT * FROM `measures` LIMIT 1 \n(Sequel::Mysql2::Database) ROLLBACK \n(Sequel::Mysql2::Database) UPDATE `tariff_updates` SET `state` = 'F', `updated_at` = '2014-07-22 16:16:15' WHERE ((`tariff_updates`.`update_type` IN ('TariffSynchronizer::TaricUpdate')) AND (`filename` = '2014-07-22_TGB14203.xml')) LIMIT 1 " }
@@ -32,6 +28,55 @@ FactoryBot.define do
 
     trait :missing do
       state { 'M' }
+    end
+
+    trait :with_inserts do
+      inserts do
+        {
+          "operations": {
+            "create": {
+              "count": 2909,
+              "duration": 4863.6220703125,
+              "allocations": 0,
+              "QuotaBalanceEvent": { "count": 2869, "allocations": 0, "duration": 4745.491455078125, "mapping_path": 'quotaBalanceEvent' },
+              "QuotaAssociation": { "count": 12, "allocations": 0, "duration": 26.2646484375, "mapping_path": 'quotaAssociation' },
+              "QuotaCriticalEvent": { "count": 12, "allocations": 0, "duration": 40.99951171875, "mapping_path": 'quotaCriticalEvent' },
+              "QuotaReopeningEvent": { "count": 5, "allocations": 0, "duration": 14.496337890625, "mapping_path": 'quotaReopeningEvent' },
+              "QuotaExhaustionEvent": { "count": 10, "allocations": 0, "duration": 25.343017578125, "mapping_path": 'quotaExhaustionEvent' },
+              "MeasureExcludedGeographicalArea": { "count": 1, "allocations": 0, "duration": 11.027099609375, "mapping_path": 'measureExcludedGeographicalArea' },
+            },
+            "update": {
+              "count": 93,
+              "duration": 334.093017578125,
+              "allocations": 0,
+              "QuotaDefinition": { "count": 57, "allocations": 0, "duration": 192.965576171875, "mapping_path": nil },
+              "Measure": { "count": 18, "allocations": 0, "duration": 87.497802734375, "mapping_path": nil },
+              "MeasureComponent": { "count": 18, "allocations": 0, "duration": 53.629638671875, "mapping_path": 'measureComponent' },
+            },
+            "destroy": { "count": 4, "duration": 0, "allocations": 0 },
+            "destroy_cascade": { "count": 5, "duration": 0, "allocations": 0 },
+            "destroy_missing": { "count": 7, "duration": 0, "allocations": 0 },
+          },
+          "total_count": 3002,
+          "total_duration": 5197.715087890625,
+          "total_allocations": 0,
+        }.to_json
+      end
+    end
+
+    trait :with_old_inserts do
+      inserts do
+        {
+          "FootnoteType::Operation": 1,
+          "FootnoteTypeDescription::Operation": 1,
+          "QuotaDefinition::Operation": 59,
+          "QuotaBalanceEvent::Operation": 2581,
+          "QuotaCriticalEvent::Operation": 13,
+          "QuotaAssociation::Operation": 13,
+          "QuotaReopeningEvent::Operation": 4,
+          "QuotaExhaustionEvent::Operation": 9,
+        }.to_json
+      end
     end
   end
 end

--- a/spec/models/tariff_update/inserts_spec.rb
+++ b/spec/models/tariff_update/inserts_spec.rb
@@ -1,0 +1,97 @@
+RSpec.describe TariffUpdate::Inserts do
+  describe '#total_duration_in_seconds' do
+    subject(:total_duration_in_seconds) { build(:tariff_update, :with_inserts).inserts.total_duration_in_seconds }
+
+    it { is_expected.to eq(5.197715087890625) }
+  end
+
+  describe '#total_records_affected' do
+    subject(:total_records_affected) { build(:tariff_update, :with_inserts).inserts.total_records_affected }
+
+    it { is_expected.to eq(3002) }
+  end
+
+  describe '#total_records_created' do
+    subject(:total_records_created) { build(:tariff_update, :with_inserts).inserts.total_records_created }
+
+    it { is_expected.to eq(2909) }
+  end
+
+  describe '#total_records_updated' do
+    subject(:total_records_updated) { build(:tariff_update, :with_inserts).inserts.total_records_updated }
+
+    it { is_expected.to eq(93) }
+  end
+
+  describe '#total_records_destroyed' do
+    subject(:total_records_destroyed) { build(:tariff_update, :with_inserts).inserts.total_records_destroyed }
+
+    it { is_expected.to eq(4) }
+  end
+
+  describe '#total_records_destroyed_missing' do
+    subject(:total_records_destroyed_missing) { build(:tariff_update, :with_inserts).inserts.total_records_destroyed_missing }
+
+    it { is_expected.to eq(7) }
+  end
+
+  describe '#total_records_destroyed_cascade' do
+    subject(:total_records_destroyed_cascade) { build(:tariff_update, :with_inserts).inserts.total_records_destroyed_cascade }
+
+    it { is_expected.to eq(5) }
+  end
+
+  describe '#entity_updates' do
+    subject(:entity_updates) { build(:tariff_update, :with_inserts).inserts.entity_updates }
+
+    let(:expected_entity_updates) do
+      [
+        { entity: 'QuotaBalanceEvent', creates: 2869, updates: 0, destroys: 0, missing: 0 },
+        { entity: 'QuotaAssociation', creates: 12, updates: 0, destroys: 0, missing: 0 },
+        { entity: 'QuotaCriticalEvent', creates: 12, updates: 0, destroys: 0, missing: 0 },
+        { entity: 'QuotaReopeningEvent', creates: 5, updates: 0, destroys: 0, missing: 0 },
+        { entity: 'QuotaExhaustionEvent', creates: 10, updates: 0, destroys: 0, missing: 0 },
+        { entity: 'MeasureExcludedGeographicalArea', creates: 1, updates: 0, destroys: 0, missing: 0 },
+        { entity: 'QuotaDefinition', creates: 0, updates: 57, destroys: 0, missing: 0 },
+        { entity: 'Measure', creates: 0, updates: 18, destroys: 0, missing: 0 },
+        { entity: 'MeasureComponent', creates: 0, updates: 18, destroys: 0, missing: 0 },
+      ]
+    end
+
+    it { is_expected.to eq(entity_updates) }
+  end
+
+  describe '#updated_inserts?' do
+    context 'when the new format of inserts are present' do
+      subject(:inserts) { build(:tariff_update, :with_inserts).inserts }
+
+      it { is_expected.to be_updated_inserts }
+    end
+
+    context 'when the old format of inserts are present' do
+      subject(:inserts) { build(:tariff_update, :with_old_inserts).inserts }
+
+      it { is_expected.not_to be_updated_inserts }
+    end
+  end
+
+  describe '#parsed_inserts' do
+    subject(:parsed_inserts) { build(:tariff_update, inserts:).inserts.parsed_inserts }
+
+    context 'when there are inserts' do
+      let(:inserts) { '{"foo":"bar"}' }
+
+      it { is_expected.to eq('foo' => 'bar') }
+    end
+
+    context 'when there are no inserts' do
+      let(:inserts) { '{}' }
+
+      it { is_expected.to eq({}) }
+    end
+  end
+end
+
+# Get to a point where Madhu can review the impact of the changes
+# Update the importer so that when we soft delete missing and cascading rows we use the updates filename rather than the previous rows filename
+# Roll back to just before the file where the condition was present in thefile/ roll forward to the current day -< should fix the broken conditions

--- a/spec/models/tariff_update/inserts_spec.rb
+++ b/spec/models/tariff_update/inserts_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe TariffUpdate::Inserts do
       ]
     end
 
-    it { is_expected.to eq(entity_updates) }
+    it { is_expected.to eq(expected_entity_updates) }
   end
 
   describe '#updated_inserts?' do
@@ -91,7 +91,3 @@ RSpec.describe TariffUpdate::Inserts do
     end
   end
 end
-
-# Get to a point where Madhu can review the impact of the changes
-# Update the importer so that when we soft delete missing and cascading rows we use the updates filename rather than the previous rows filename
-# Roll back to just before the file where the condition was present in thefile/ roll forward to the current day -< should fix the broken conditions

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -47,9 +47,17 @@ RSpec.describe TariffUpdate do
   end
 
   describe '#id' do
-    subject(:id) { build(:tariff_update, created_at: '2022-01-01T12:13Z').id }
+    context 'when the filename contains an gzip suffix' do
+      subject(:id) { build(:tariff_update, filename: 'foo.gzip').id }
 
-    it { is_expected.to eq('2022-01-01t12-13z') }
+      it { is_expected.to eq('foo') }
+    end
+
+    context 'when the filename contains an xml suffix' do
+      subject(:id) { build(:tariff_update, filename: 'foo.xml').id }
+
+      it { is_expected.to eq('foo') }
+    end
   end
 
   describe '#parsed_inserts' do
@@ -58,13 +66,13 @@ RSpec.describe TariffUpdate do
     context 'when there are inserts' do
       let(:inserts) { '{"foo":"bar"}' }
 
-      it { is_expected.to eq("---\nfoo: bar") }
+      it { is_expected.to eq('foo' => 'bar') }
     end
 
     context 'when there are no inserts' do
-      let(:inserts) { nil }
+      let(:inserts) { '{}' }
 
-      it { is_expected.to eq('') }
+      it { is_expected.to eq({}) }
     end
   end
 end

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -60,19 +60,19 @@ RSpec.describe TariffUpdate do
     end
   end
 
-  describe '#parsed_inserts' do
-    subject(:parsed_inserts) { build(:tariff_update, inserts:).parsed_inserts }
+  describe '#formatted_update_type' do
+    subject(:parsed_inserts) { build(:tariff_update, update_type:).formatted_update_type }
 
-    context 'when there are inserts' do
-      let(:inserts) { '{"foo":"bar"}' }
+    context 'when the update type is TariffSynchronizer::TaricUpdate' do
+      let(:update_type) { 'TariffSynchronizer::TaricUpdate' }
 
-      it { is_expected.to eq('foo' => 'bar') }
+      it { is_expected.to eq('Taric Update') }
     end
 
-    context 'when there are no inserts' do
-      let(:inserts) { '{}' }
+    context 'when the update type is TariffSynchronizer::CdsUpdate' do
+      let(:update_type) { 'TariffSynchronizer::CdsUpdate' }
 
-      it { is_expected.to eq({}) }
+      it { is_expected.to eq('Cds Update') }
     end
   end
 end

--- a/spec/models/tariff_update_spec.rb
+++ b/spec/models/tariff_update_spec.rb
@@ -12,20 +12,6 @@ RSpec.describe TariffUpdate do
     it_behaves_like 'a tariff update state', 'X', nil
   end
 
-  describe '#inserts' do
-    context 'when the inserts are supplied' do
-      subject(:inserts) { build(:tariff_update, :with_inserts).inserts }
-
-      it { is_expected.to eq('something' => 'parseable') }
-    end
-
-    context 'when the inserts are not supplied' do
-      subject(:inserts) { build(:tariff_update).inserts }
-
-      it { is_expected.to eq({}) }
-    end
-  end
-
   describe '#rollback?' do
     shared_examples_for 'a tariff update that rolls back' do |state, _will_rollback|
       subject(:tariff_update) { build(:tariff_update, state:) }
@@ -64,5 +50,21 @@ RSpec.describe TariffUpdate do
     subject(:id) { build(:tariff_update, created_at: '2022-01-01T12:13Z').id }
 
     it { is_expected.to eq('2022-01-01t12-13z') }
+  end
+
+  describe '#parsed_inserts' do
+    subject(:parsed_inserts) { build(:tariff_update, inserts:).parsed_inserts }
+
+    context 'when there are inserts' do
+      let(:inserts) { '{"foo":"bar"}' }
+
+      it { is_expected.to eq("---\nfoo: bar") }
+    end
+
+    context 'when there are no inserts' do
+      let(:inserts) { nil }
+
+      it { is_expected.to eq('') }
+    end
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-1585

### What?

I have added/removed/altered:

- [x] Added a show page to enable a table view of the inserts for a given CDS file

![image](https://user-images.githubusercontent.com/8156884/170999089-4f1b6c1f-9717-4535-9ead-289f35892e76.png)

### Why?

I am doing this because:

- This is much easier to review than the old method and supports richer data that was recently added, here: https://github.com/trade-tariff/trade-tariff-backend/pull/604
