### PR TITLE
HOTT-2006 convert to sentry rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,7 @@ gem 'sidekiq-scheduler'
 # Misc
 gem 'bootsnap', require: false
 gem 'nokogiri', '>= 1.10.10'
+gem 'sentry-rails'
 
 group :development, :test do
   gem 'brakeman'
@@ -78,8 +79,4 @@ group :test do
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'webmock'
-end
-
-group :production do
-  gem 'sentry-raven'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -429,8 +429,6 @@ GEM
     sentry-rails (5.4.2)
       railties (>= 5.0)
       sentry-ruby (~> 5.4.2)
-    sentry-raven (3.1.2)
-      faraday (>= 1.0)
     sentry-ruby (5.4.2)
       concurrent-ruby (~> 1.0, >= 1.0.2)
     shoulda-matchers (5.2.0)
@@ -534,7 +532,7 @@ DEPENDENCIES
   rspec-rails
   rspec_junit_formatter
   rubocop-govuk
-  sentry-raven
+  sentry-rails
   shoulda-matchers
   shrine
   sidekiq

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,7 +1,0 @@
-if defined?(Raven) && ENV['VCAP_APPLICATION'].present?
-  tags = JSON.parse(ENV['VCAP_APPLICATION'])
-             .except('application_uris', 'host', 'application_name', 'space_id', 'port', 'uris', 'application_version')
-             .merge({ server_name: ENV['GOVUK_APP_DOMAIN'] })
-
-  Raven.configure { |config| config.tags = tags }
-end

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,7 @@
+Sentry.init do |config|
+  config.breadcrumbs_logger = [:active_support_logger]
+
+  config.excluded_exceptions += %w[
+    Faraday::ResourceNotFound
+  ]
+end


### PR DESCRIPTION
### Jira link

HOTT-2006

### What?

I have added/removed/altered:

- [x] Convert to Sentry-Rails gem
- [x] Ignore Faraday::ResourceNotFound exceptions

### Why?

I am doing this because:

- sentry-ruby is no longer supported

### Deployment risks (optional)

- Changes error reporting behaviour
