### PR TITLE
HOTT-2130 add new news item fields

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -7,6 +7,7 @@ class NewsItemsController < AuthenticatedController
 
   def new
     @news_item = News::Item.new
+    @collections = News::Collection.all.fetch
   end
 
   def create
@@ -15,12 +16,14 @@ class NewsItemsController < AuthenticatedController
     if @news_item.valid? && @news_item.save
       redirect_to news_items_path, notice: 'News item created'
     else
+      @collections = News::Collection.all.fetch
       render :new
     end
   end
 
   def edit
     @news_item = News::Item.find(params[:id])
+    @collections = News::Collection.all.fetch
   end
 
   def update
@@ -30,6 +33,7 @@ class NewsItemsController < AuthenticatedController
     if @news_item.valid? && @news_item.save
       redirect_to news_items_path, notice: 'News item updated'
     else
+      @collections = News::Collection.all.fetch
       render :edit
     end
   end
@@ -46,7 +50,9 @@ class NewsItemsController < AuthenticatedController
   def news_item_params
     params.require(:news_item).permit(%i[
       title
+      slug
       content
+      precis
       display_style
       show_on_uk
       show_on_xi
@@ -55,7 +61,7 @@ class NewsItemsController < AuthenticatedController
       show_on_banner
       start_date
       end_date
-    ]).reverse_merge(default_params)
+    ], collection_ids: []).reverse_merge(default_params)
   end
 
   def default_params

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -1,0 +1,14 @@
+module News
+  class Collection
+    include Her::JsonApi::Model
+    use_api Her::UK_API
+
+    collection_path '/admin/news/collections'
+
+    attributes :id, :name
+
+    def id
+      super.to_i
+    end
+  end
+end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -4,6 +4,7 @@ module News
     use_api Her::UK_API
 
     DISPLAY_STYLE_REGULAR = 0
+    MAX_SLUG_LENGTH = 254
 
     collection_path '/admin/news/items'
 
@@ -23,12 +24,28 @@ module News
 
     after_initialize { self.collection_ids = [] unless collection_ids }
 
+    before_validation :generate_or_normalise_slug!
+
     def collection_ids=(ids)
       super Array.wrap(ids).map(&:presence).compact.map(&:to_i).uniq
     end
 
     def preview
       GovspeakPreview.new(content).render
+    end
+
+    private
+
+    def generate_or_normalise_slug!
+      current_slug = slug.presence || title.presence
+      return unless current_slug
+
+      normalised_slug = normalise_slug(slug.presence || title)
+      self.slug = normalised_slug if slug != normalised_slug
+    end
+
+    def normalise_slug(slug)
+      slug.downcase.gsub(/\s+/, '-').gsub(/[^a-z0-9-]/, '').first(MAX_SLUG_LENGTH)
     end
   end
 end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -8,6 +8,8 @@ module News
     collection_path '/admin/news/items'
 
     attributes :title,
+               :slug,
+               :precis,
                :content,
                :display_style,
                :show_on_uk,
@@ -16,7 +18,14 @@ module News
                :show_on_updates_page,
                :show_on_banner,
                :start_date,
-               :end_date
+               :end_date,
+               :collection_ids
+
+    after_initialize { self.collection_ids = [] unless collection_ids }
+
+    def collection_ids=(ids)
+      super Array.wrap(ids).map(&:presence).compact.map(&:to_i).uniq
+    end
 
     def preview
       GovspeakPreview.new(content).render

--- a/app/views/news_items/_form.html.erb
+++ b/app/views/news_items/_form.html.erb
@@ -1,6 +1,10 @@
 <%= govuk_form_for news_item do |f| %>
   <%= f.govuk_text_field :title, width: 'one-half' %>
 
+  <%= f.govuk_text_field :slug, width: 'one-half' %>
+
+  <%= govuk_markdown_area f, :precis, rows: 6 %>
+
   <%= govuk_markdown_area f, :content, rows: 12 %>
 
   <details class="govuk-details" data-module="govuk-details">
@@ -50,30 +54,38 @@
   <%= f.govuk_text_field :start_date, width: 'one-third' %>
   <%= f.govuk_text_field :end_date, width: 'one-third' %>
 
-  <%= f.govuk_check_box :show_on_uk, 1, 0,
-                        label: { text: 'Show on UK service' },
-                        multiple: false,
-                        link_errors: true %>
+  <%= f.govuk_check_boxes_fieldset :display do %>
 
-  <%= f.govuk_check_box :show_on_xi, 1, 0,
-                        label: { text: 'Show on XI service' },
-                        multiple: false,
-                        link_errors: true %>
+    <%= f.govuk_check_box :show_on_uk, 1, 0,
+                          label: { text: 'Show on UK service' },
+                          multiple: false,
+                          link_errors: true %>
 
-  <%= f.govuk_check_box :show_on_home_page, 1, 0,
-                        label: { text: 'Show News story on the Home page' },
-                        multiple: false,
-                        link_errors: true %>
+    <%= f.govuk_check_box :show_on_xi, 1, 0,
+                          label: { text: 'Show on XI service' },
+                          multiple: false,
+                          link_errors: true %>
 
-  <%= f.govuk_check_box :show_on_updates_page, 1, 0,
-                        label: { text: 'Show News story on the Updates page' },
-                        multiple: false,
-                        link_errors: true %>
+    <%= f.govuk_check_box :show_on_home_page, 1, 0,
+                          label: { text: 'Show News story on the Home page' },
+                          multiple: false,
+                          link_errors: true %>
 
-  <%= f.govuk_check_box :show_on_banner, 1, 0,
-                        label: { text: 'Show News story on the Banner' },
-                        multiple: false,
-                        link_errors: true %>
+    <%= f.govuk_check_box :show_on_updates_page, 1, 0,
+                          label: { text: 'Show News story on the Updates page' },
+                          multiple: false,
+                          link_errors: true %>
+
+    <%= f.govuk_check_box :show_on_banner, 1, 0,
+                          label: { text: 'Show News story on the Banner' },
+                          multiple: false,
+                          link_errors: true %>
+  <% end %>
+
+  <%= f.govuk_collection_check_boxes :collection_ids,
+                                     collections,
+                                     :id,
+                                     :name if collections.any? %>
 
   <%= submit_and_back_buttons f, news_items_path %>
 <% end %>

--- a/app/views/news_items/_form.html.erb
+++ b/app/views/news_items/_form.html.erb
@@ -1,7 +1,7 @@
 <%= govuk_form_for news_item do |f| %>
   <%= f.govuk_text_field :title, width: 'one-half' %>
 
-  <%= f.govuk_text_field :slug, width: 'one-half' %>
+  <%= f.govuk_text_field :slug, width: 'one-half' if f.object.persisted? || f.object.slug.present? %>
 
   <%= govuk_markdown_area f, :precis, rows: 6 %>
 

--- a/app/views/news_items/edit.html.erb
+++ b/app/views/news_items/edit.html.erb
@@ -2,7 +2,7 @@
 
 <h2>Edit News story</h2>
 
-<%= render 'form', news_item: @news_item %>
+<%= render 'form', news_item: @news_item, collections: @collections %>
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 

--- a/app/views/news_items/new.html.erb
+++ b/app/views/news_items/new.html.erb
@@ -2,4 +2,4 @@
 
 <h2>New News story</h2>
 
-<%= render 'form', news_item: @news_item %>
+<%= render 'form', news_item: @news_item, collections: @collections %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,10 @@ en:
       rollback:
         keep: Keep
 
+      news_item:
+        collection_ids: Show in News collections
+        display: Pages to include on
+
     hint:
       rollback:
         keep: Keeps update files and records since specified date and just mark them pending
@@ -57,10 +61,14 @@ en:
 
       news_item:
         title: Not shown on frontend for Banner stories
+        slug: Leave blank to automatically assign
         start_date: 'YYYY/MM/DD'
         end_date: 'YYYY/MM/DD or leave blank for no end date'
 
   activemodel:
+    attributes:
+      news/item:
+        collection_ids: Collections
     errors:
       models:
         quota_search:

--- a/spec/factories/news/collection_factory.rb
+++ b/spec/factories/news/collection_factory.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :news_collection, class: 'News::Collection' do
+    sequence(:id, &:to_s)
+    sequence(:name) { |n| "Collection #{n}" }
+  end
+end

--- a/spec/factories/news/item_factory.rb
+++ b/spec/factories/news/item_factory.rb
@@ -2,6 +2,8 @@ FactoryBot.define do
   factory :news_item, class: 'News::Item' do
     sequence(:id) { |n| n }
     title { "News item #{id}" }
+    slug { "news-item-#{id}" }
+    precis { 'precis content' }
     content { 'Lorem **ipsum**' }
     display_style { News::Item::DISPLAY_STYLE_REGULAR }
     show_on_uk { true }

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe News::Collection do
+  subject(:collection) { build :news_collection }
+
+  it { is_expected.to respond_to :id }
+  it { is_expected.to respond_to :name }
+end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -72,4 +72,10 @@ RSpec.describe News::Item do
       it { is_expected.to have_attributes length: 2 }
     end
   end
+
+  describe '#collection_ids' do
+    subject { described_class.new.collection_ids }
+
+    it { is_expected.to be_instance_of Array }
+  end
 end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -78,4 +78,24 @@ RSpec.describe News::Item do
 
     it { is_expected.to be_instance_of Array }
   end
+
+  describe 'slug generation' do
+    subject { news_item.slug }
+
+    let(:news_item) { build :news_item, slug: nil }
+
+    it { is_expected.to be_blank }
+
+    context 'when after validation called' do
+      before { news_item.valid? }
+
+      it { is_expected.to be_present }
+
+      context 'with manually assigned slug' do
+        let(:news_item) { build :news_item, slug: 'some-test-slug' }
+
+        it { is_expected.to eql 'some-test-slug' }
+      end
+    end
+  end
 end

--- a/spec/requests/news_items_controller_spec.rb
+++ b/spec/requests/news_items_controller_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe NewsItemsController do
   subject(:rendered_page) { create_user && make_request && response }
 
+  before do
+    stub_api_request('/news/collections').and_return \
+      jsonapi_response :news_collection, attributes_for_pair(:news_collection)
+  end
+
   let(:news_item) { build :news_item }
   let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
 

--- a/spec/views/news_items/_form.html.erb_spec.rb
+++ b/spec/views/news_items/_form.html.erb_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe 'news_items/form' do
     let(:news_item) { News::Item.new }
 
     it { is_expected.to have_css 'form input' }
+    it { is_expected.not_to have_css 'input[name="news_item[slug]"]' }
     it { is_expected.to have_css 'fieldset legend', text: /News collections/ }
 
     context 'without collections available' do
@@ -21,6 +22,8 @@ RSpec.describe 'news_items/form' do
 
   context 'with valid news item' do
     let(:news_item) { build :news_item }
+
+    it { is_expected.to have_css 'input[name="news_item[slug]"]' }
 
     it 'populates fields' do
       expect(form).to have_css \

--- a/spec/views/news_items/_form.html.erb_spec.rb
+++ b/spec/views/news_items/_form.html.erb_spec.rb
@@ -3,12 +3,20 @@ require 'rails_helper'
 RSpec.describe 'news_items/form' do
   subject(:form) { render_partial && rendered }
 
-  let(:render_partial) { render 'news_items/form', news_item: }
+  let(:render_partial) { render 'news_items/form', news_item:, collections: }
+  let(:collections) { build_pair :news_collection }
 
   context 'with new news item' do
     let(:news_item) { News::Item.new }
 
     it { is_expected.to have_css 'form input' }
+    it { is_expected.to have_css 'fieldset legend', text: /News collections/ }
+
+    context 'without collections available' do
+      let(:collections) { [] }
+
+      it { is_expected.not_to have_css 'fieldset legend', text: /News collections/ }
+    end
   end
 
   context 'with valid news item' do


### PR DESCRIPTION
### Jira link

HOTT-2130

### What?

I have added/removed/altered:

- [x] Added a News::Collections api client
- [x] Changed the News::Item form to allow setting collections, slug and precis
- [x] Auto assign the slug if not set

### Why?

I am doing this because:

- We want to be able to edit the new fields from the admin area

### Deployment risks (optional)

- Low, admin area
