### PR TITLE
HOTT-2226: Change Quota search URL and only display search button

### DIFF
--- a/app/views/quotas/new.html.erb
+++ b/app/views/quotas/new.html.erb
@@ -8,7 +8,7 @@
         <%= f.govuk_text_field :order_number, label: { text: "Enter the 6-digit quota order number ID to return the details of the quota's definitions,
         balance updates and other events." }, width: 'one-third' %>
 
-        <%= submit_and_back_buttons f, rollbacks_path %>
+        <%= f.govuk_submit 'Search' %>
     <% end %>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,7 +67,7 @@ Rails.application.routes.draw do
   resources :news_items, except: %i[show]
   resources :reports, only: %i[index show]
 
-  resources :quotas, only: %i[new] do
+  resources :quotas, only: %i[new], path: 'quota_search' do
     collection do
       get '/search', as: :perform_search, via: %i[get post], to: 'quotas#search'
     end


### PR DESCRIPTION
### Jira link

[Change Quota search URL and only display search button
](https://transformuk.atlassian.net/browse/HOTT-2226)

### What?

I have added/removed/altered:

- [ ] Change Quota search URL and only display search button

### Why?

I am doing this because:

- We needed to change how the content is displayed

<img width="547" alt="Screenshot 2022-11-21 at 15 05 34" src="https://user-images.githubusercontent.com/12201130/203089286-991dbcc5-f742-4633-9bee-fc1a4fb670bc.png">

