### PR TITLE
Avoid double error messages on quota search

### DIFF
--- a/app/views/quotas/new.html.erb
+++ b/app/views/quotas/new.html.erb
@@ -3,12 +3,10 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_form_for @quota_search, url: perform_search_quotas_path, method: :get do |f| %>
-        <%= f.govuk_error_summary %>
+      <%= f.govuk_text_field :order_number, label: { text: "Enter the 6-digit quota order number ID to return the details of the quota's definitions,
+      balance updates and other events." }, width: 'one-third' %>
 
-        <%= f.govuk_text_field :order_number, label: { text: "Enter the 6-digit quota order number ID to return the details of the quota's definitions,
-        balance updates and other events." }, width: 'one-third' %>
-
-        <%= submit_and_back_buttons f, rollbacks_path %>
+      <%= submit_and_back_buttons f, rollbacks_path %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
### Jira link

HOTT-????

### What?

I have added/removed/altered:

- [x] Removed the double error message

### Why?

I am doing this because:

- It is confusing
- It is caused by both `govuk_form_helper` and the html page each rendering their own error summary

### Before

![image](https://user-images.githubusercontent.com/10818/205259548-0e80a05e-3fdc-448c-a72f-f174df6ae514.png)

### After

![image](https://user-images.githubusercontent.com/10818/205261645-ef981265-aff0-4f2a-812f-41607a2d0894.png)

