### PR TITLE
HOTT-2312 Use pagination for news items

### DIFF
--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -2,6 +2,7 @@ module News
   class Item
     include Her::JsonApi::Model
     use_api Her::UK_API
+    extend HerPaginatable
 
     DISPLAY_STYLE_REGULAR = 0
     MAX_SLUG_LENGTH = 254

--- a/app/views/kaminari/_first_page.html.erb
+++ b/app/views/kaminari/_first_page.html.erb
@@ -6,6 +6,8 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="first">
-  <%= link_to_unless current_page.first?, t('views.pagination.first').html_safe, url, remote: remote %>
-</span>
+<li class="govuk-pagination__item">
+  <%= link_to t('views.pagination.first').html_safe,
+              remote: remote,
+              class: "govuk-pagination__link" %>
+</li>

--- a/app/views/kaminari/_gap.html.erb
+++ b/app/views/kaminari/_gap.html.erb
@@ -5,4 +5,4 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page gap"><%= t('views.pagination.truncate').html_safe %></span>
+<li class="govuk-pagination__item govuk-pagination__item--ellipses">&ctdot;</li>

--- a/app/views/kaminari/_last_page.html.erb
+++ b/app/views/kaminari/_last_page.html.erb
@@ -6,6 +6,8 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="last">
-  <%= link_to_unless current_page.last?, t('views.pagination.last').html_safe, url, remote: remote %>
-</span>
+<li class="govuk-pagination__item">
+  <%= link_to t('views.pagination.last').html_safe,
+              remote: remote,
+              class: "govuk-pagination__link" %>
+</li>

--- a/app/views/kaminari/_next_page.html.erb
+++ b/app/views/kaminari/_next_page.html.erb
@@ -6,6 +6,18 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="next">
-  <%= link_to_unless current_page.last?, t('views.pagination.next').html_safe, url, rel: 'next', remote: remote %>
-</span>
+<div class="govuk-pagination__next">
+  <%= link_to url, rel: 'next', remote: remote do %>
+    <span class="govuk-pagination__link-title">Next</span>
+
+    <svg class="govuk-pagination__icon govuk-pagination__icon--next"
+         xmlns="http://www.w3.org/2000/svg"
+         height="13"
+         width="15"
+         aria-hidden="true"
+         focusable="false"
+         viewBox="0 0 15 13">
+      <path d="m8.107-0.0078125-1.4136 1.414 4.2926 4.293h-12.986v2h12.896l-4.1855 3.9766 1.377 1.4492 6.7441-6.4062-6.7246-6.7266z"></path>
+    </svg>
+  <% end %>
+</div>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -7,6 +7,8 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="page<%= ' current' if page.current? %>">
-  <%= link_to_unless page.current?, page, url, {remote: remote, rel: page.rel} %>
-</span>
+<li class="govuk-pagination__item <%= 'govuk-pagination__item--current' if page.current? %>">
+  <%= link_to page, url, { rel: page.rel,
+                           class: "govuk-pagination__link",
+                           aria: { label: "Page #{page.number}" } } %>
+</li>

--- a/app/views/kaminari/_paginator.html.erb
+++ b/app/views/kaminari/_paginator.html.erb
@@ -7,8 +7,9 @@
     paginator:     the paginator that renders the pagination tags inside
 -%>
 <%= paginator.render do -%>
-  <nav class="pagination" role="navigation" aria-label="pager">
+  <nav class="govuk-pagination" role="navigation" aria-label="results">
     <%= prev_page_tag unless current_page.first? %>
+    <ul class="govuk-pagination__list">
     <% each_page do |page| -%>
       <% if page.display_tag? -%>
         <%= page_tag page %>
@@ -16,6 +17,7 @@
         <%= gap_tag %>
       <% end -%>
     <% end -%>
+    </ul>
     <% unless current_page.out_of_range? %>
       <%= next_page_tag unless current_page.last? %>
     <% end %>

--- a/app/views/kaminari/_prev_page.html.erb
+++ b/app/views/kaminari/_prev_page.html.erb
@@ -6,6 +6,18 @@
     per_page:      number of items to fetch per page
     remote:        data-remote
 -%>
-<span class="prev">
-  <%= link_to_unless current_page.first?, t('views.pagination.previous').html_safe, url, rel: 'prev', remote: remote %>
-</span>
+<div class="govuk-pagination__prev">
+  <%= link_to url, rel: 'prev', remote: remote do %>
+    <svg class="govuk-pagination__icon govuk-pagination__icon--prev"
+         xmlns="http://www.w3.org/2000/svg"
+         height="13"
+         width="15"
+         aria-hidden="true"
+         focusable="false"
+         viewBox="0 0 15 13">
+      <path d="m6.5938-0.0078125-6.7266 6.7266 6.7441 6.4062 1.377-1.449-4.1856-3.9768h12.896v-2h-12.984l4.2931-4.293-1.414-1.414z"></path>
+    </svg>
+
+    <span class="govuk-pagination__link-title">Previous</span></a>
+  <% end %>
+</div>

--- a/app/views/news_items/index.html.erb
+++ b/app/views/news_items/index.html.erb
@@ -36,6 +36,8 @@
       <% end %>
     </tbody>
   </table>
+
+  <%= paginate @news_items %>
 <% else %>
   <div class="govuk-inset-text">
     <p>No News stories</p>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,12 @@
+Kaminari.configure do |config|
+  # config.default_per_page = 25
+  # config.max_per_page = nil
+  config.window = 3
+  config.outer_window = 1
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/spec/support/api_responses_helper.rb
+++ b/spec/support/api_responses_helper.rb
@@ -52,6 +52,13 @@ module ApiResponsesHelper
     when Array
       {
         data: response.map { |r| format_jsonapi_item(type, r) },
+        meta: {
+          pagination: {
+            page: 1,
+            per_page: response.length,
+            total_count: response.length * 5,
+          },
+        },
       }
     else
       response

--- a/spec/views/news_items/index.html.erb_spec.rb
+++ b/spec/views/news_items/index.html.erb_spec.rb
@@ -12,7 +12,11 @@ RSpec.describe 'news_items/index' do
   end
 
   context 'with 3 news items' do
-    let(:news_items) { build_list :news_item, 3 }
+    let :news_items do
+      Kaminari.paginate_array(build_list(:news_item, 3), total_count: 3)
+              .page(1)
+              .per(10)
+    end
 
     it { is_expected.to have_css 'table tbody tr', count: 3 }
   end


### PR DESCRIPTION
### Jira link

HOTT-2312

### What?

I have added/removed/altered:

- [x] Added pagination to News Items admin

### Why?

I am doing this because:

- The api _is_ paginated so this meant users could only edit stories from the first page

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None
