### PR TITLE
HOTT-2465: Adds transfer events skipped ui

### DIFF
--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -105,6 +105,7 @@
         <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Updated</th>
         <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Destroyed</th>
         <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Missing</th>
+        <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Skipped</th>
       </tr>
     </thead>
     <tbody class="govuk-table__body">
@@ -115,6 +116,7 @@
           <td class="govuk-table__cell"><%= entity[:updates] %></td>
           <td class="govuk-table__cell"><%= entity[:destroys] %></td>
           <td class="govuk-table__cell"><%= entity[:missing] %></td>
+          <td class="govuk-table__cell"><%= entity[:skipped] %></td>
         </tr>
       <% end %>
     </tbody>
@@ -147,6 +149,44 @@
                 <summary class="govuk-details__summary">
                   <span class="govuk-details__summary-text">
                     Review Missing Inserts
+                  </span>
+                </summary>
+                <div class="govuk-details__text">
+  <pre><%= entity[:records] %></pre>
+                </div>
+              </details>
+            </td>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  <% end %>
+
+  <% if @tariff_update.inserts.any_skipped? %>
+    <table class="govuk-table">
+      <caption class="govuk-table__caption govuk-table__caption--m">Skipped entities</caption>
+
+      <p class="govuk-body">
+        Skipped entities are not imported because of a known protocol failure from CDS/Taric
+      </p>
+
+      <thead class="govuk-table__head">
+        <tr class="govuk-table__row">
+          <th scope="col" class="govuk-table__header govuk-!-width-one-half">Entity</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Skipped</th>
+          <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Identifiers</th>
+        </tr>
+      </thead>
+      <tbody class="govuk-table__body">
+        <% @tariff_update.inserts.skipped_entities.each do |entity| %>
+          <tr class="govuk-table__row">
+            <th scope="row" class="govuk-table__header"><%= entity[:entity] %></th>
+            <td class="govuk-table__cell"><%= entity[:skipped] %></td>
+            <td class="govuk-table__cell">
+              <details class="govuk-details" data-module="govuk-details">
+                <summary class="govuk-details__summary">
+                  <span class="govuk-details__summary-text">
+                    Review Skipped Inserts
                   </span>
                 </summary>
                 <div class="govuk-details__text">

--- a/spec/factories/tariff_update_factory.rb
+++ b/spec/factories/tariff_update_factory.rb
@@ -63,6 +63,20 @@ FactoryBot.define do
                 "records": [{ "oid": 1, "measure_sid": 123, "geographical_area_id": 'IT' }],
               },
             },
+            "skipped": {
+              'count' => 30,
+              'duration' => 0.0830078125,
+              'QuotaClosedAndTransferredEvent' => {
+                'count' => 30,
+                'duration' => 0.0830078125,
+                'mapping_path' => 'quotaClosedAndTransferredEvent',
+                'records' => [
+                  { 'oid' => nil, 'quota_definition_sid' => 21_322, 'occurrence_timestamp' => '2022-05-03T13:04:00.000Z' },
+                  { 'oid' => nil, 'quota_definition_sid' => 21_744, 'occurrence_timestamp' => '2022-10-28T16:17:00.000Z' },
+                  { 'oid' => nil, 'quota_definition_sid' => 21_264, 'occurrence_timestamp' => '2022-10-28T16:17:00.000Z' },
+                ],
+              },
+            },
           },
           "total_count": 3002,
           "total_duration": 5197.715087890625,
@@ -79,6 +93,7 @@ FactoryBot.define do
             "destroy": { "count": 0, "duration": 0 },
             "destroy_cascade": { "count": 0, "duration": 0 },
             "destroy_missing": { "count": 0, "duration": 0 },
+            "skipped": { "count": 0, "duration": 0 },
           },
           "total_count": 0,
           "total_duration": 0,

--- a/spec/models/tariff_update/inserts_spec.rb
+++ b/spec/models/tariff_update/inserts_spec.rb
@@ -46,15 +46,16 @@ RSpec.describe TariffUpdate::Inserts do
 
     let(:expected_updated_entities) do
       [
-        { entity: 'QuotaBalanceEvent', creates: 2869, updates: 0, destroys: 0, missing: 0 },
-        { entity: 'QuotaAssociation', creates: 12, updates: 0, destroys: 0, missing: 0 },
-        { entity: 'QuotaCriticalEvent', creates: 12, updates: 0, destroys: 0, missing: 0 },
-        { entity: 'QuotaReopeningEvent', creates: 5, updates: 0, destroys: 0, missing: 0 },
-        { entity: 'QuotaExhaustionEvent', creates: 10, updates: 0, destroys: 0, missing: 0 },
-        { entity: 'MeasureExcludedGeographicalArea', creates: 1, updates: 0, destroys: 0, missing: 1 },
-        { entity: 'QuotaDefinition', creates: 0, updates: 57, destroys: 0, missing: 0 },
-        { entity: 'Measure', creates: 0, updates: 18, destroys: 0, missing: 0 },
-        { entity: 'MeasureComponent', creates: 0, updates: 18, destroys: 0, missing: 0 },
+        { entity: 'QuotaBalanceEvent', creates: 2869, updates: 0, destroys: 0, missing: 0, skipped: 0 },
+        { entity: 'QuotaAssociation', creates: 12, updates: 0, destroys: 0, missing: 0, skipped: 0 },
+        { entity: 'QuotaCriticalEvent', creates: 12, updates: 0, destroys: 0, missing: 0, skipped: 0 },
+        { entity: 'QuotaReopeningEvent', creates: 5, updates: 0, destroys: 0, missing: 0, skipped: 0 },
+        { entity: 'QuotaExhaustionEvent', creates: 10, updates: 0, destroys: 0, missing: 0, skipped: 0 },
+        { entity: 'MeasureExcludedGeographicalArea', creates: 1, updates: 0, destroys: 0, missing: 1, skipped: 0 },
+        { entity: 'QuotaDefinition', creates: 0, updates: 57, destroys: 0, missing: 0, skipped: 0 },
+        { entity: 'Measure', creates: 0, updates: 18, destroys: 0, missing: 0, skipped: 0 },
+        { entity: 'MeasureComponent', creates: 0, updates: 18, destroys: 0, missing: 0, skipped: 0 },
+        { entity: 'QuotaClosedAndTransferredEvent', creates: 0, updates: 0, destroys: 0, missing: 0, skipped: 30 },
       ]
     end
 


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2465

### What?

With some skipped events:

![image](https://user-images.githubusercontent.com/8156884/212101273-a41c1102-660a-448f-88bc-7331423c6c04.png)

With no skipped events:

![image](https://user-images.githubusercontent.com/8156884/212101635-c72da37e-e0d4-40a5-b596-445c063ad983.png)

I have added/removed/altered:

- [x] Added UI for showing skipped imports of transfer events

### Why?

I am doing this because:

- This is new functionality that it would be great to be able to review