### PR TITLE
HOTT-2242 Fixed preview of news precis field

### DIFF
--- a/app/models/chapter_note.rb
+++ b/app/models/chapter_note.rb
@@ -14,7 +14,7 @@ class ChapterNote
     self.class.build_request_path('/admin/chapters/:chapter_id/chapter_note', attributes.dup.merge('chapter_id' => chapter.reload.to_param))
   end
 
-  def preview
+  def preview(...)
     Govspeak::Document.new(content, sanitize: true).to_html.html_safe
   end
 end

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -31,8 +31,10 @@ module News
       super Array.wrap(ids).map(&:presence).compact.map(&:to_i).uniq
     end
 
-    def preview
-      GovspeakPreview.new(content).render
+    def preview(field_name = nil)
+      markdown = field_name.to_s == 'precis' ? precis : content
+
+      GovspeakPreview.new(markdown).render
     end
 
     private

--- a/app/models/section_note.rb
+++ b/app/models/section_note.rb
@@ -16,7 +16,7 @@ class SectionNote
 
   def section_title; end
 
-  def preview
+  def preview(...)
     Govspeak::Document.new(content, sanitize: true).to_html.html_safe
   end
 end

--- a/app/views/application/_markdown_field.html.erb
+++ b/app/views/application/_markdown_field.html.erb
@@ -16,7 +16,7 @@
       <div class="hott-markdown-preview"
         data-preview="govspeak"
         data-preview-for="#<%= "#{form.object_name}-#{field_name}-field".gsub('_', '-') %>">
-        <%= form.object.preview if form.object.respond_to?(:preview) %>
+        <%= form.object.preview(field_name) if form.object.respond_to?(:preview) %>
       </div>
     </div>
   </div>

--- a/spec/helpers/govuk_helper_spec.rb
+++ b/spec/helpers/govuk_helper_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe GovukHelper do
         'Person'
       end
 
-      def preview
+      def preview(...)
         '<p>preview content</p>'.html_safe
       end
     end

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe News::Item do
   describe '#preview' do
     subject { news_item.preview }
 
-    let(:news_item) { build :news_item, content: '# Hello world' }
+    let(:news_item) { build :news_item, content: '# Hello world', precis: 'precis test' }
 
     it { is_expected.to eql %(<h1 id="hello-world">Hello world</h1>\n) }
 
@@ -46,6 +46,12 @@ RSpec.describe News::Item do
       end
 
       it { is_expected.to eql %(<p><a href="/xi/browse">Browse</a></p>\n) }
+    end
+
+    context 'with precis field' do
+      subject { news_item.preview 'precis' }
+
+      it { is_expected.to eql "<p>precis test</p>\n" }
     end
   end
 


### PR DESCRIPTION
### Jira link

HOTT-2242

### What?

I have added/removed/altered:

- [x] Fixed preview of precis field

### Why?

I am doing this because:

- It currently shows the content preview for the precis field

