### PR TITLE
HOTT-2226: Fixed quota search URL and removed back button

### DIFF
--- a/app/controllers/quotas_controller.rb
+++ b/app/controllers/quotas_controller.rb
@@ -9,9 +9,9 @@ class QuotasController < AuthenticatedController
     if @quota_search.valid? && quota_definition
       render perform_search_quotas_path
     elsif !@quota_search.valid?
-      render new_quota_path
+      render quota_search_quotas_path
     elsif !quota_definition
-      redirect_to new_quota_path, alert: "Quota #{@quota_search.order_number} not found."
+      redirect_to quota_search_quotas_path, alert: "Quota #{@quota_search.order_number} not found."
     end
   end
 

--- a/app/controllers/quotas_controller.rb
+++ b/app/controllers/quotas_controller.rb
@@ -17,7 +17,7 @@ class QuotasController < AuthenticatedController
 
   def quota_definition
     @quota_definition = QuotaOrderNumbers::QuotaDefinition.find(@quota_search.order_number)
-  rescue Faraday::ResourceNotFound
+  rescue Faraday::ResourceNotFound, KeyError
     nil
   end
 

--- a/app/controllers/quotas_controller.rb
+++ b/app/controllers/quotas_controller.rb
@@ -17,7 +17,7 @@ class QuotasController < AuthenticatedController
 
   def quota_definition
     @quota_definition = QuotaOrderNumbers::QuotaDefinition.find(@quota_search.order_number)
-  rescue Faraday::ResourceNotFound, KeyError
+  rescue Faraday::ResourceNotFound
     nil
   end
 

--- a/app/controllers/quotas_controller.rb
+++ b/app/controllers/quotas_controller.rb
@@ -7,11 +7,11 @@ class QuotasController < AuthenticatedController
     @quota_search = QuotaSearch.new(quota_params)
 
     if @quota_search.valid? && quota_definition
-      render perform_search_quotas_path
+      render perform_quota_search_path
     elsif !@quota_search.valid?
-      render quota_search_quotas_path
+      render quota_search_path
     elsif !quota_definition
-      redirect_to quota_search_quotas_path, alert: "Quota #{@quota_search.order_number} not found."
+      redirect_to quota_search_path, alert: "Quota #{@quota_search.order_number} not found."
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
 
     <%= govuk_header(service_name: "Trade Tariff Admin") do |header| %>
       <%= header.navigation_item text: "Quotas",
-                                 href: quota_search_quotas_path,
+                                 href: quota_search_path,
                                  active: active_nav_link?(/\/quotas/) %>
       <%= header.navigation_item text: "Section & chapter notes",
                                  href: root_path,

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -26,7 +26,7 @@
 
     <%= govuk_header(service_name: "Trade Tariff Admin") do |header| %>
       <%= header.navigation_item text: "Quotas",
-                                 href: new_quota_path,
+                                 href: quota_search_quotas_path,
                                  active: active_nav_link?(/\/quotas/) %>
       <%= header.navigation_item text: "Section & chapter notes",
                                  href: root_path,

--- a/app/views/quotas/new.html.erb
+++ b/app/views/quotas/new.html.erb
@@ -2,7 +2,7 @@
 
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <%= govuk_form_for @quota_search, url: perform_search_quotas_path, method: :get do |f| %>
+    <%= govuk_form_for @quota_search, url: perform_quota_search_path, method: :get do |f| %>
       <%= f.govuk_text_field :order_number, label: { text: "Enter the 6-digit quota order number ID to return the details of the quota's definitions,
       balance updates and other events." }, width: 'one-third' %>
 

--- a/app/views/quotas/new.html.erb
+++ b/app/views/quotas/new.html.erb
@@ -6,7 +6,7 @@
       <%= f.govuk_text_field :order_number, label: { text: "Enter the 6-digit quota order number ID to return the details of the quota's definitions,
       balance updates and other events." }, width: 'one-third' %>
 
-      <%= submit_and_back_buttons f, rollbacks_path %>
+      <%= f.govuk_submit 'Search' %>
     <% end %>
   </div>
 </div>

--- a/app/views/quotas/search.html.erb
+++ b/app/views/quotas/search.html.erb
@@ -1,4 +1,4 @@
-<%= link_to 'Back', quota_search_quotas_path, class: 'govuk-back-link' %>
+<%= link_to 'Back', quota_search_path, class: 'govuk-back-link' %>
 
 <h1>Quota <%= @quota_definition.quota_order_number_id %></h1>
 

--- a/app/views/quotas/search.html.erb
+++ b/app/views/quotas/search.html.erb
@@ -1,4 +1,4 @@
-<%= link_to 'Back', new_quota_path, class: 'govuk-back-link' %>
+<%= link_to 'Back', quota_search_quotas_path, class: 'govuk-back-link' %>
 
 <h1>Quota <%= @quota_definition.quota_order_number_id %></h1>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,8 +67,9 @@ Rails.application.routes.draw do
   resources :news_items, except: %i[show]
   resources :reports, only: %i[index show]
 
-  resources :quotas, only: %i[new] do
+  resources :quotas do
     collection do
+      get '/quota_search', as: :quota_search, via: %i[get], to: 'quotas#new'
       get '/search', as: :perform_search, via: %i[get post], to: 'quotas#search'
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,12 +67,8 @@ Rails.application.routes.draw do
   resources :news_items, except: %i[show]
   resources :reports, only: %i[index show]
 
-  resources :quotas do
-    collection do
-      get '/quota_search', as: :quota_search, via: %i[get], to: 'quotas#new'
-      get '/search', as: :perform_search, via: %i[get post], to: 'quotas#search'
-    end
-  end
+  get '/quota_search', as: :quota_search, via: %i[get], to: 'quotas#new'
+  get '/quotas/search', as: :perform_quota_search, via: %i[get post], to: 'quotas#search'
 
   post 'govspeak' => 'govspeak#govspeak', as: :govspeak
   get  'healthcheck' => 'healthcheck#check', as: :healthcheck

--- a/spec/requests/quotas_controller_spec.rb
+++ b/spec/requests/quotas_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe QuotasController do
     subject(:do_request) do
       create(:user, :hmrc_editor)
 
-      get quota_search_quotas_path
+      get quota_search_path
 
       response
     end
@@ -13,7 +13,7 @@ RSpec.describe QuotasController do
 
   describe 'GET #search' do
     subject(:do_request) do
-      get perform_search_quotas_path(quota_search: { order_number: quota_definition.quota_order_number_id })
+      get perform_quota_search_path(quota_search: { order_number: quota_definition.quota_order_number_id })
 
       response
     end

--- a/spec/requests/quotas_controller_spec.rb
+++ b/spec/requests/quotas_controller_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe QuotasController do
     subject(:do_request) do
       create(:user, :hmrc_editor)
 
-      get new_quota_path
+      get quota_search_quotas_path
 
       response
     end


### PR DESCRIPTION
### Jira link

[HOTT-<TODO>](https://transformuk.atlassian.net/browse/HOTT-2226)

### What?

I have added/removed/altered:

- [ ] Changed the URL to quotas/quota_search from /quotas/new
- [ ] Removed the back button
- [ ] Renamed "create new quota" to "Search"

### Why?

I am doing this because:

- The quota search page was displaying as a "new quota" page and misleading users


<img width="632" alt="Screenshot 2023-01-10 at 11 29 09" src="https://user-images.githubusercontent.com/12201130/211540679-04d44f81-9917-4934-ab58-b1ce293a9683.png">

