### PR TITLE
HOTT-2808: Quota definitions sort order, thousands separator and CSS changes

### DIFF
--- a/app/views/quotas/_balance_events.html.erb
+++ b/app/views/quotas/_balance_events.html.erb
@@ -9,9 +9,9 @@
     <tr>
       <th>Event date</th>
       <th>Last allocation date</th>
-      <th>Last balance (KGM)</th>
-      <th>Imported amount (KGM)</th>
-      <th>New balance (KGM)</th>
+      <th class="align-right">Last balance (KGM)</th>
+      <th class="align-right">Imported amount (KGM)</th>
+      <th class="align-right grey-background">New balance (KGM)</th>
     </tr>
   </thead>
   <tbody>
@@ -19,9 +19,9 @@
     <tr>
       <td><%= balance_event.occurrence_timestamp&.to_date&.to_formatted_s(:govuk_short) %></td>
       <td><%= balance_event.last_import_date_in_allocation&.to_date&.to_formatted_s(:govuk_short) %></td>
-      <td><%= balance_event.old_balance %></td>
-      <td><%= balance_event.imported_amount %></td>
-      <td><%= balance_event.new_balance %></td>
+      <td class="align-right mono-font"><%= number_with_precision balance_event.old_balance, precision: 3, delimiter: ',' %></td>
+      <td class="align-right mono-font"><%= number_with_precision balance_event.imported_amount, precision: 3, delimiter: ',' %></td>
+      <td class="align-right mono-font grey-background"><%= number_with_precision balance_event.new_balance, precision: 3, delimiter: ',' %></td>
     </tr>
   <% end %>
   </tbody>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -66,3 +66,15 @@ $govuk-image-url-function: frontend-image-url;
     @extend .govuk-list--number;
   }
 }
+
+.align-right {
+  text-align: right !important;
+}
+
+.grey-background {
+  background-color: govuk-colour("light-grey");
+}
+
+.mono-font {
+  font-family:courier, monospace;
+}

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -67,14 +67,16 @@ $govuk-image-url-function: frontend-image-url;
   }
 }
 
-.align-right {
-  text-align: right !important;
-}
-
-.grey-background {
-  background-color: govuk-colour("light-grey");
-}
-
-.mono-font {
-  font-family:courier, monospace;
+.table {
+  .align-right {
+    text-align: right;
+  }
+  
+  .grey-background {
+    background-color: govuk-colour("light-grey");
+  }
+  
+  .mono-font {
+    font-family:courier, monospace;
+  }
 }

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -74,6 +74,8 @@ $govuk-image-url-function: frontend-image-url;
   
   .grey-background {
     background-color: govuk-colour("light-grey");
+    padding-right: 1em !important;
+    padding-left: 1em;
   }
   
   .mono-font {

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -75,7 +75,6 @@ $govuk-image-url-function: frontend-image-url;
   .grey-background {
     background-color: govuk-colour("light-grey");
     padding-right: 1em !important;
-    padding-left: 1em;
   }
   
   .mono-font {

--- a/spec/views/quotas/_balance_events.html.erb_spec.rb
+++ b/spec/views/quotas/_balance_events.html.erb_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe 'quotas/_balance_events' do
 
     it { is_expected.to have_css 'td', text: balance_event.last_import_date_in_allocation&.to_date&.to_formatted_s(:govuk_short) }
 
-    it { is_expected.to have_css 'td', text: balance_event.old_balance }
+    it { is_expected.to have_css 'td', text: number_with_precision(balance_event.old_balance, precision: 3, delimiter: ',') }
 
-    it { is_expected.to have_css 'td', text: balance_event.imported_amount }
+    it { is_expected.to have_css 'td', text: number_with_precision(balance_event.imported_amount, precision: 3, delimiter: ',') }
 
-    it { is_expected.to have_css 'td', text: balance_event.new_balance }
+    it { is_expected.to have_css 'td', text: number_with_precision(balance_event.new_balance, precision: 3, delimiter: ',') }
 
     it { is_expected.to have_css 'a', text: 'See the graph of quota balance events' }
   end


### PR DESCRIPTION
### Jira link

[HOTT-<2808>](https://transformuk.atlassian.net/browse/HOTT-2808)

### What?

I have added/removed/altered:

- [ ] Displayed balances using thousands separator
- [ ] Sorted Quota balance events by occurrence timestamp
- [ ]  Improved the CSS

### Why?

I am doing this because:

- This provides a better user experience for Admin users


<img width="1497" alt="Screenshot 2023-03-13 at 13 42 45" src="https://user-images.githubusercontent.com/12201130/224719992-a5182d6a-f074-4fda-8603-c03bb8b56554.png">
