### PR TITLE
HOTT-2980: Quota UI enhancements and bug fixes

### DIFF
--- a/app/helpers/quotas_helper.rb
+++ b/app/helpers/quotas_helper.rb
@@ -1,9 +1,15 @@
 module QuotasHelper
-  def format_quota_dates(quota)
+  def formatted_initial_volume(quota_definition)
+    volume = number_with_precision quota_definition.initial_volume, precision: 3, delimiter: ','
+
+    "#{volume} #{quota_definition.formatted_measurement_unit}"
+  end
+
+  def format_quota_dates(quota_definition)
     dates = []
 
-    dates << "from #{quota.validity_start_date&.to_date&.to_formatted_s(:govuk)}" if quota.validity_start_date
-    dates << "to #{quota.validity_end_date&.to_date&.to_formatted_s(:govuk)}" if quota.validity_end_date
+    dates << "from #{quota_definition.validity_start_date&.to_date&.to_formatted_s(:govuk)}" if quota_definition.validity_start_date
+    dates << "to #{quota_definition.validity_end_date&.to_date&.to_formatted_s(:govuk)}" if quota_definition.validity_end_date
 
     safe_join dates, ' '
   end

--- a/app/models/quota_order_numbers/measurement_unit.rb
+++ b/app/models/quota_order_numbers/measurement_unit.rb
@@ -1,0 +1,7 @@
+module QuotaOrderNumbers
+  class MeasurementUnit
+    include Her::JsonApi::Model
+
+    attributes :description, :measurement_unit_code, :abbreviation
+  end
+end

--- a/app/models/quota_order_numbers/quota_definition.rb
+++ b/app/models/quota_order_numbers/quota_definition.rb
@@ -1,5 +1,6 @@
 module QuotaOrderNumbers
   class QuotaDefinition
+    include ActionView::Helpers::NumberHelper
     include Her::JsonApi::Model
 
     resource_path '/admin/quota_order_numbers/:quota_order_number_id/quota_definitions/:id'
@@ -12,11 +13,12 @@ module QuotaOrderNumbers
                :validity_start_date,
                :validity_end_date,
                :initial_volume,
-               :measurement_unit,
+               :formatted_measurement_unit,
                :quota_type,
                :critical_state,
                :critical_threshold
 
+    has_one :measurement_unit
     has_one :quota_order_number
     has_many :quota_balance_events
     has_many :quota_order_number_origins
@@ -25,6 +27,24 @@ module QuotaOrderNumbers
     has_many :quota_reopening_events
     has_many :quota_unblocking_events
     has_many :quota_critical_events
+
+    def formatted_initial_volume
+      volume = number_with_precision initial_volume, precision: 3, delimiter: ','
+
+      "#{volume} #{formatted_measurement_unit}"
+    end
+
+    def last_balance_row_heading
+      "Last balance (#{measurement_unit.abbreviation})"
+    end
+
+    def imported_amount_row_heading
+      "Imported amount (#{measurement_unit.abbreviation})"
+    end
+
+    def new_balance_row_heading
+      "New balance (#{measurement_unit.abbreviation})"
+    end
 
     def occurrence_timestamps
       chart_data[:occurrence_timestamps]

--- a/app/models/quota_order_numbers/quota_definition.rb
+++ b/app/models/quota_order_numbers/quota_definition.rb
@@ -1,6 +1,5 @@
 module QuotaOrderNumbers
   class QuotaDefinition
-    include ActionView::Helpers::NumberHelper
     include Her::JsonApi::Model
 
     resource_path '/admin/quota_order_numbers/:quota_order_number_id/quota_definitions/:id'
@@ -28,21 +27,15 @@ module QuotaOrderNumbers
     has_many :quota_unblocking_events
     has_many :quota_critical_events
 
-    def formatted_initial_volume
-      volume = number_with_precision initial_volume, precision: 3, delimiter: ','
-
-      "#{volume} #{formatted_measurement_unit}"
-    end
-
-    def last_balance_row_heading
+    def formatted_last_balance
       "Last balance (#{measurement_unit.abbreviation})"
     end
 
-    def imported_amount_row_heading
+    def formatted_imported_amount
       "Imported amount (#{measurement_unit.abbreviation})"
     end
 
-    def new_balance_row_heading
+    def formatted_new_balance
       "New balance (#{measurement_unit.abbreviation})"
     end
 

--- a/app/views/quotas/_balance_events.html.erb
+++ b/app/views/quotas/_balance_events.html.erb
@@ -9,9 +9,9 @@
     <tr>
       <th>Event date</th>
       <th>Last allocation date</th>
-      <th class="align-right">Last balance (KGM)</th>
-      <th class="align-right">Imported amount (KGM)</th>
-      <th class="align-right grey-background">New balance (KGM)</th>
+      <th class="align-right"><%= quota_definition.last_balance_row_heading %></th>
+      <th class="align-right"><%= quota_definition.imported_amount_row_heading %></th>
+      <th class="align-right grey-background"><%= quota_definition.new_balance_row_heading %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/quotas/_balance_events.html.erb
+++ b/app/views/quotas/_balance_events.html.erb
@@ -9,9 +9,9 @@
     <tr>
       <th>Event date</th>
       <th>Last allocation date</th>
-      <th class="align-right"><%= quota_definition.last_balance_row_heading %></th>
-      <th class="align-right"><%= quota_definition.imported_amount_row_heading %></th>
-      <th class="align-right grey-background"><%= quota_definition.new_balance_row_heading %></th>
+      <th class="align-right"><%= quota_definition.formatted_last_balance %></th>
+      <th class="align-right"><%= quota_definition.formatted_imported_amount %></th>
+      <th class="align-right grey-background"><%= quota_definition.formatted_new_balance %></th>
     </tr>
   </thead>
   <tbody>

--- a/app/views/quotas/_balance_events_chart.html.erb
+++ b/app/views/quotas/_balance_events_chart.html.erb
@@ -3,7 +3,7 @@
   width: "800",
   height: "450",
   data: {
-    measurementunitcode: @quota_definition.measurement_unit,
+    measurementunitcode: @quota_definition.measurement_unit.abbreviation,
     importedamounts: @quota_definition.imported_amounts,
     newbalances: @quota_definition.new_balances,
     occurrencetimestamps: @quota_definition.occurrence_timestamps,

--- a/app/views/quotas/_quota_definition.html.erb
+++ b/app/views/quotas/_quota_definition.html.erb
@@ -36,10 +36,10 @@
       </div>
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">
-        Initial volume
+          Initial volume
         </dt>
         <dd class="govuk-summary-list__value">
-        <%= quota_definition.initial_volume %> <%= quota_definition.measurement_unit %>
+          <%= quota_definition.formatted_initial_volume %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/app/views/quotas/_quota_definition.html.erb
+++ b/app/views/quotas/_quota_definition.html.erb
@@ -39,7 +39,7 @@
           Initial volume
         </dt>
         <dd class="govuk-summary-list__value">
-          <%= quota_definition.formatted_initial_volume %>
+          <%= formatted_initial_volume(quota_definition) %>
         </dd>
       </div>
       <div class="govuk-summary-list__row">

--- a/app/views/quotas/show.html.erb
+++ b/app/views/quotas/show.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Initial volume is <%= @quota_definition.initial_volume %> <%= @quota_definition.measurement_unit %>
+  Initial volume is <%= @quota_definition.formatted_initial_volume %>
 </p>
 
 <%= render 'balance_events_chart' %>

--- a/app/views/quotas/show.html.erb
+++ b/app/views/quotas/show.html.erb
@@ -7,7 +7,7 @@
 </p>
 
 <p>
-  Initial volume is <%= @quota_definition.formatted_initial_volume %>
+  Initial volume is <%= formatted_initial_volume(@quota_definition) %>
 </p>
 
 <%= render 'balance_events_chart' %>

--- a/spec/factories/measurement_unit_factory.rb
+++ b/spec/factories/measurement_unit_factory.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :measurement_unit, class: 'QuotaOrderNumbers::MeasurementUnit' do
+    description { 'Kilogram (kg)' }
+    measurement_unit_code { 'KGM' }
+    measurement_unit_qualifier_code { 'kg' }
+    abbreviation { 'kg' }
+  end
+end

--- a/spec/factories/quota_definition_factory.rb
+++ b/spec/factories/quota_definition_factory.rb
@@ -5,10 +5,12 @@ FactoryBot.define do
     validity_start_date { '2022-01-01T00:00:00.000Z' }
     validity_end_date { '2022-12-31T23:59:59.000Z' }
     initial_volume { '18181000.0' }
-    measurement_unit { 'Kilogram (kg)' }
+    formatted_measurement_unit { 'Kilogram (kg)' }
     quota_type { 'First Come First Served' }
     critical_state { 'N' }
     critical_threshold { '90' }
+
+    measurement_unit { build(:measurement_unit) }
 
     trait :with_quota_order_number do
       quota_order_number { build(:quota_order_number) }

--- a/spec/helpers/quotas_helper_spec.rb
+++ b/spec/helpers/quotas_helper_spec.rb
@@ -1,6 +1,14 @@
 require 'rails_helper'
 
 RSpec.describe QuotasHelper do
+  describe '#formatted_initial_volume' do
+    subject(:formatted_initial_volume) { helper.formatted_initial_volume(quota_definition) }
+
+    let(:quota_definition) { build(:quota_definition) }
+
+    it { is_expected.to eq('18,181,000.000 Kilogram (kg)') }
+  end
+
   describe '#format_quota_dates' do
     subject { format_quota_dates quota_order_number_origin }
 

--- a/spec/models/quota_order_numbers/quota_definition_spec.rb
+++ b/spec/models/quota_order_numbers/quota_definition_spec.rb
@@ -206,26 +206,20 @@ RSpec.describe QuotaOrderNumbers::QuotaDefinition do
     end
   end
 
-  describe '#formatted_initial_volume' do
-    subject(:formatted_initial_volume) { build(:quota_definition).formatted_initial_volume }
-
-    it { is_expected.to eq('18,181,000.000 Kilogram (kg)') }
-  end
-
-  describe '#last_balance_row_heading' do
-    subject(:last_balance_row_heading) { build(:quota_definition).last_balance_row_heading }
+  describe '#formatted_last_balance' do
+    subject(:formatted_last_balance) { build(:quota_definition).formatted_last_balance }
 
     it { is_expected.to eq('Last balance (kg)') }
   end
 
-  describe '#imported_amount_row_heading' do
-    subject(:imported_amount_row_heading) { build(:quota_definition).imported_amount_row_heading }
+  describe '#formatted_imported_amount' do
+    subject(:formatted_imported_amount) { build(:quota_definition).formatted_imported_amount }
 
     it { is_expected.to eq('Imported amount (kg)') }
   end
 
-  describe '#new_balance_row_heading' do
-    subject(:new_balance_row_heading) { build(:quota_definition).new_balance_row_heading }
+  describe '#formatted_new_balance' do
+    subject(:formatted_new_balance) { build(:quota_definition).formatted_new_balance }
 
     it { is_expected.to eq('New balance (kg)') }
   end

--- a/spec/models/quota_order_numbers/quota_definition_spec.rb
+++ b/spec/models/quota_order_numbers/quota_definition_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe QuotaOrderNumbers::QuotaDefinition do
         quota_order_number_id: '051822',
         validity_start_date: '2022-01-01T00:00:00.000Z',
         validity_end_date: '2022-12-31T23:59:59.000Z',
-        measurement_unit: 'Kilogram (kg)',
+        formatted_measurement_unit: 'Kilogram (kg)',
         initial_volume: '18181000.0',
         quota_type: 'First Come First Served',
         critical_state: 'N',
@@ -204,5 +204,29 @@ RSpec.describe QuotaOrderNumbers::QuotaDefinition do
 
       it { expect(quota_definition.additional_events).to eq([]) }
     end
+  end
+
+  describe '#formatted_initial_volume' do
+    subject(:formatted_initial_volume) { build(:quota_definition).formatted_initial_volume }
+
+    it { is_expected.to eq('18,181,000.000 Kilogram (kg)') }
+  end
+
+  describe '#last_balance_row_heading' do
+    subject(:last_balance_row_heading) { build(:quota_definition).last_balance_row_heading }
+
+    it { is_expected.to eq('Last balance (kg)') }
+  end
+
+  describe '#imported_amount_row_heading' do
+    subject(:imported_amount_row_heading) { build(:quota_definition).imported_amount_row_heading }
+
+    it { is_expected.to eq('Imported amount (kg)') }
+  end
+
+  describe '#new_balance_row_heading' do
+    subject(:new_balance_row_heading) { build(:quota_definition).new_balance_row_heading }
+
+    it { is_expected.to eq('New balance (kg)') }
   end
 end

--- a/spec/views/quotas/_quota_definition.html.erb_spec.rb
+++ b/spec/views/quotas/_quota_definition.html.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'quotas/_quota_definitions' do
 
     it { is_expected.to have_css 'dd', text: quota_definition.validity_end_date&.to_date&.to_formatted_s(:govuk) }
 
-    it { is_expected.to have_css 'dd', text: quota_definition.formatted_initial_volume }
+    it { is_expected.to have_css 'dd', text: '18,181,000.000 Kilogram (kg)' }
 
     it { is_expected.to have_css 'dd', text: quota_definition.critical_state }
 

--- a/spec/views/quotas/_quota_definition.html.erb_spec.rb
+++ b/spec/views/quotas/_quota_definition.html.erb_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'quotas/_quota_definitions' do
 
     it { is_expected.to have_css 'dd', text: quota_definition.validity_end_date&.to_date&.to_formatted_s(:govuk) }
 
-    it { is_expected.to have_css 'dd', text: "#{quota_definition.initial_volume} #{quota_definition.measurement_unit}" }
+    it { is_expected.to have_css 'dd', text: quota_definition.formatted_initial_volume }
 
     it { is_expected.to have_css 'dd', text: quota_definition.critical_state }
 

--- a/spec/views/quotas/show.html.erb_spec.rb
+++ b/spec/views/quotas/show.html.erb_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe 'quotas/show' do
 
     it { is_expected.to have_css 'p', text: 'from 1 January 2022 to 31 December 2022' }
 
-    it { is_expected.to have_css 'p', text: "#{quota_definition.initial_volume} #{quota_definition.measurement_unit}" }
+    it { is_expected.to have_css 'p', text: quota_definition.formatted_initial_volume }
   end
 end

--- a/spec/views/quotas/show.html.erb_spec.rb
+++ b/spec/views/quotas/show.html.erb_spec.rb
@@ -14,6 +14,6 @@ RSpec.describe 'quotas/show' do
 
     it { is_expected.to have_css 'p', text: 'from 1 January 2022 to 31 December 2022' }
 
-    it { is_expected.to have_css 'p', text: quota_definition.formatted_initial_volume }
+    it { is_expected.to have_css 'p', text: '18,181,000.000 Kilogram (kg)' }
   end
 end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-2980

![image](https://user-images.githubusercontent.com/8156884/230075540-8f41ddbd-6324-4e6d-b745-080a1b36e872.png)
![image](https://user-images.githubusercontent.com/8156884/230075164-18700289-5e46-4eb9-b113-83135f6946ca.png)


### What?

I have added/removed/altered:

- [x] Fixes formatting of various volume numbers
- [x] Adds support for measurement units to be displayed properly
- [x] Refactor title methods to pull on models and add test coverage

### Why?

I am doing this because:

- This was kicked off by the fact that Matt noticed that certain quota order numbers had definition tables that showed the wrong measurement unit
