### PR TITLE
HOTT-3200: Fixed bug on admin quota graphs

### DIFF
--- a/app/models/quota_order_numbers/quota_definition.rb
+++ b/app/models/quota_order_numbers/quota_definition.rb
@@ -70,7 +70,7 @@ module QuotaOrderNumbers
     private
 
     def chart_data
-      @chart_data ||= quota_balance_events.each_with_object(occurrence_timestamps: [], imported_amounts: [], new_balances: []) do |event, acc|
+      @chart_data ||= quota_balance_events.reverse.each_with_object(occurrence_timestamps: [], imported_amounts: [], new_balances: []) do |event, acc|
         acc[:occurrence_timestamps] << event.occurrence_timestamp.to_date.to_formatted_s(:govuk_short)
         acc[:imported_amounts] << event.imported_amount
         acc[:new_balances] << event.new_balance


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3200

### What?

I have added/removed/altered:

- [ ] Reversed the dates and data displayed on admin quota graphs

### Why?

I am doing this because:

- The graphs were displaying incorrectly


<img width="1231" alt="Screenshot 2023-05-18 at 10 46 43" src="https://github.com/trade-tariff/trade-tariff-admin/assets/12201130/081e6d7d-4694-4a9a-8d2e-bbe0ba0944d1">
