### PR TITLE
BAU: Fixes leaky test contexts leading to intermittent failures

### DIFF
--- a/app/views/quotas/_balance_events_chart.html.erb
+++ b/app/views/quotas/_balance_events_chart.html.erb
@@ -3,7 +3,7 @@
   width: "800",
   height: "450",
   data: {
-    measurementunitcode: @quota_definition.measurement_unit.abbreviation,
+    measurementunitcode: @quota_definition.measurement_unit.try(:abbreviation),
     importedamounts: @quota_definition.imported_amounts,
     newbalances: @quota_definition.new_balances,
     occurrencetimestamps: @quota_definition.occurrence_timestamps,

--- a/spec/support/shared_context/service_chooser.rb
+++ b/spec/support/shared_context/service_chooser.rb
@@ -1,20 +1,26 @@
 RSpec.shared_context 'with UK service' do
-  before do
-    allow(TradeTariffAdmin::ServiceChooser).to \
-      receive(:service_choice).and_return 'uk'
+  around do |example|
+    original = TradeTariffAdmin::ServiceChooser.service_choice
+    TradeTariffAdmin::ServiceChooser.service_choice = 'uk'
+    example.run
+    TradeTariffAdmin::ServiceChooser.service_choice = original
   end
 end
 
 RSpec.shared_context 'with XI service' do
-  before do
-    allow(TradeTariffAdmin::ServiceChooser).to \
-      receive(:service_choice).and_return 'xi'
+  around do |example|
+    original = TradeTariffAdmin::ServiceChooser.service_choice
+    TradeTariffAdmin::ServiceChooser.service_choice = 'xi'
+    example.run
+    TradeTariffAdmin::ServiceChooser.service_choice = original
   end
 end
 
 RSpec.shared_context 'with default service' do
-  before do
-    allow(TradeTariffAdmin::ServiceChooser).to \
-      receive(:service_choice).and_return nil
+  around do |example|
+    original = TradeTariffAdmin::ServiceChooser.service_choice
+    TradeTariffAdmin::ServiceChooser.service_choice = nil
+    example.run
+    TradeTariffAdmin::ServiceChooser.service_choice = original
   end
 end


### PR DESCRIPTION
### Jira link

BAU

### What?

```
WebMock::NetConnectNotAllowedError:
  Real HTTP connections are disabled. Unregistered request: GET http://localhost:3018/admin/news/collections/82 with headers {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'Authorization'=>'Bearer ******-api-test-token', 'User-Agent'=>'Faraday v1.10.2'}

  You can stub this request with the following snippet:

  stub_request(:get, "http://localhost:3018/admin/news/collections/82").
    with(
      headers: {
     'Accept'=>'*/*',
     'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
     'Authorization'=>'Bearer ******-api-test-token',
     'User-Agent'=>'Faraday v1.10.2'
      }).
    to_return(status: 200, body: "", headers: {})

  registered request stubs:

  stub_request(:get, "http://localhost:3019/admin/news/collections/82")

  ============================================================
```

I have added/removed/altered:

- [x] Fixes leaky service contexts

### Why?

I am doing this because:

- These randomly lead to failure scenarios for webmock <https://app.circleci.com/pipelines/github/trade-tariff/trade-tariff-admin/1513/workflows/c1bb58f7-fc7e-4161-9b04-b6f69f69f39d/jobs/4287>
