### PR TITLE
HOTT-3815: Admin app title change

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" class="govuk-template ">
   <head>
-    <title>TradeTariffAdmin</title>
+    <title>Trade Tariff Admin</title>
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-3815

### What?

I have added/removed/altered:

- [ ] Admin app title change

### Why?

I am doing this because:

- We need to make the title easier to read


<img width="393" alt="Screenshot 2023-09-04 at 11 37 28" src="https://github.com/trade-tariff/trade-tariff-admin/assets/12201130/f732f811-25c1-43c0-a64e-cf414895b1e7">
