### PR TITLE
BAU: Don't log healthchecks in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -87,6 +87,11 @@ Rails.application.configure do
     { domain: ENV['GOVUK_APP_DOMAIN'] }
   end
 
+  config.lograge.ignore_actions = [
+    'HealthcheckController#index',
+    'HealthcheckController#checkz',
+  ]
+
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 end


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Ignored `checkz` action of the healthcheck controller in lograge options.

### Why?

I am doing this because:

- We don't need this to be logged in production mode, it's just noise.