### PR TITLE
HOTT-4238: Fix issue with unset producline suffix value

### DIFF
--- a/app/controllers/references/search_references_controller.rb
+++ b/app/controllers/references/search_references_controller.rb
@@ -87,6 +87,7 @@ module References
     def build_search_reference
       search_reference_parent.search_references.build(title: normalised_title).tap do |reference|
         reference.referenced_id = search_reference_parent.id
+        reference.productline_suffix = search_reference_parent.producline_suffix
       end
     end
   end

--- a/spec/factories/chapter_factory.rb
+++ b/spec/factories/chapter_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
 
   factory :chapter do
     goods_nomenclature_item_id { 10.times.map { Random.rand(1..9) }.join }
+    producline_suffix { 80 }
     goods_nomenclature_sid { generate(:sid) }
     description { generate(:chapter_description) }
 

--- a/spec/factories/commodity_factory.rb
+++ b/spec/factories/commodity_factory.rb
@@ -6,6 +6,7 @@ FactoryBot.define do
 
       "#{referenced_id}-#{productline_suffix}"
     end
+    producline_suffix { 80 }
 
     referenced_class { 'Commodity' }
 

--- a/spec/factories/heading_factory.rb
+++ b/spec/factories/heading_factory.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :heading do
     goods_nomenclature_item_id { 10.times.map { Random.rand(1..9) }.join }
+    producline_suffix { 80 }
 
     description { 'Live Horses, Asses, Mules And Hinnies' }
 

--- a/spec/features/commodity_search_reference_spec.rb
+++ b/spec/features/commodity_search_reference_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe 'Commodity Search Reference management' do
       refute search_reference_created_for(commodity, title:)
 
       stub_api_for(Commodity::SearchReference) do |stub|
-        stub.post("/admin/commodities/#{commodity.to_param}/search_references") do |env|
+        stub.post("/admin/commodities/#{commodity.goods_nomenclature_item_id}-#{commodity.producline_suffix}/search_references") do |env|
           expect(env.body.dig(:data, :attributes, :title)).to eq('new title')
           api_created_response
         end


### PR DESCRIPTION
### Jira link

https://transformuk.atlassian.net/browse/HOTT-4238

### What?

I have added/removed/altered:

- [x] Added support for the producline suffix when creating subheadings/commodities references

### Why?

I am doing this because:

- This value is used to uniquely identify commodity search references when listing and creating them.
- This handles the fact that subheadings/commodities are managed under the same controller in the admin apis
