### PR TITLE
HOTT-4437: Set Secure Flag on Cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,7 @@
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_trade-tariff-admin_app_session'
+Rails.application.config.session_store(
+  :cookie_store,
+  key: '_trade-tariff-admin_app_session',
+  secure: Rails.env.production?,
+)


### PR DESCRIPTION
### Jira link

[HOTT-4437](https://transformuk.atlassian.net/browse/HOTT-4437)

### What?

I have added/removed/altered:

- Set `secure` on the session store cookie when `Rails.env` is `production`.

### Why?

I am doing this because:

- This was identified in the security review.
