### PR TITLE
BAU: Fix image-name parameter in production release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ workflows:
       - tariff/create-production-release:
           name: create-production-release
           context: trade-tariff-releases
-          image-name: tariff-admin
+          image-name: tariff-admin-production
           requires:
             - promote-to-production?
           <<: *filter-main


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Fixed broken `image-name` parameter in release job

### Why?

I am doing this because:

- It's wrong and blocking releases
