### PR TITLE
Fix 'export all search references' button

### DIFF
--- a/app/views/references/_shared_actions.html.erb
+++ b/app/views/references/_shared_actions.html.erb
@@ -13,7 +13,8 @@
     Export all search references as a CSV file
   </p>
 
-  <%= link_to references_export_path, class: 'govuk-button', method: :post do %>
-    Export all search references as CSV
-  <% end %>
+  <%= button_to 'Export all search references as CSV',
+                 references_export_path,
+                 method: :post, class: 'govuk-button'
+  %>
 </div>


### PR DESCRIPTION
### Jira link
https://transformuk.atlassian.net/browse/HOTT-4865

### What?

Change link_to to button_to to use the POST method.
Also, it is a bad practice to use links to make POST calls.
 