### PR TITLE
Fix: NameError uninitialized constant Subheading

### DIFF
--- a/app/models/subheading.rb
+++ b/app/models/subheading.rb
@@ -1,0 +1,2 @@
+class Subheading
+end


### PR DESCRIPTION
### What?


This PR fixes:
NameError uninitialized constant Subheading (NameError)

which is caused by "constantize" a "subheading" string. The error is present in Sentry, and it started 4 months ago.

### Sentry Error:

https://engine-le.sentry.io/issues/4538644179/?project=5738286&query=release%3A08416c1&referrer=release-issue-stream

### Jira link
https://transformuk.atlassian.net/browse/HOTT-4865

### Why?

I am doing this to fix the bug.
