### PR TITLE
HOTT-5060: Run database migrations in an init container

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ files: |
 
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.81.0
+    rev: v1.86.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -20,7 +20,7 @@ repos:
           - --hook-config=--create-file-if-not-exist=true
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,7 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.11.3 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.12.0 |
 
 ## Resources
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.11.3"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.12.0"
 
   region = var.region
 
@@ -33,6 +33,10 @@ module "service" {
   ]
 
   enable_ecs_exec = true
+
+  init_container            = true
+  init_container_entrypoint = [""]
+  init_container_command    = ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails data:migrate"]
 
   service_environment_config = [
     {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -36,7 +36,7 @@ module "service" {
 
   init_container            = true
   init_container_entrypoint = [""]
-  init_container_command    = ["/bin/sh", "-c", "bundle exec rails db:migrate && bundle exec rails data:migrate"]
+  init_container_command    = ["/bin/sh", "-c", "bundle exec rails db:migrate"]
 
   service_environment_config = [
     {


### PR DESCRIPTION
### Jira link

[HOTT-5060](https://transformuk.atlassian.net/browse/HOTT-5060)

### What?

I have added/removed/altered:

- Added an init container

### Why?

I am doing this because:

- We need to make sure the migrations run when the app starts