### PR TITLE
GL-106: Add Admin screen to list out all category assessments

### DIFF
--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -1,7 +1,16 @@
 module GreenLanes
   class CategoryAssessmentsController < AuthenticatedController
+    before_action :check_service
     def index
       @category_assessments = GreenLanes::CategoryAssessment.all(page: current_page).fetch
     end
+
+    private
+    def check_service
+      if TradeTariffAdmin::ServiceChooser.uk?
+        raise ActionController::RoutingError, 'Invalid service'
+      end
+    end
+
   end
 end

--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -6,11 +6,11 @@ module GreenLanes
     end
 
     private
+
     def check_service
       if TradeTariffAdmin::ServiceChooser.uk?
         raise ActionController::RoutingError, 'Invalid service'
       end
     end
-
   end
 end

--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -3,7 +3,5 @@ module GreenLanes
     def index
       @category_assessments = GreenLanes::CategoryAssessment.all(page: current_page).fetch
     end
-
-
   end
 end

--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -1,0 +1,9 @@
+module GreenLanes
+  class CategoryAssessmentsController < AuthenticatedController
+    def index
+      @category_assessments = GreenLanes::CategoryAssessment.all(page: current_page).fetch
+    end
+
+
+  end
+end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -12,6 +12,5 @@ module GreenLanes
                :updated_at
 
     collection_path '/admin/category_assessments'
-
   end
 end

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -1,0 +1,17 @@
+module GreenLanes
+  class CategoryAssessment
+    include Her::JsonApi::Model
+    use_api Her::XI_API
+    extend HerPaginatable
+
+    attributes :measure_type_id,
+               :regulation_id,
+               :regulation_role,
+               :theme_id,
+               :created_at,
+               :updated_at
+
+    collection_path '/admin/category_assessments'
+
+  end
+end

--- a/app/views/green_lanes/category_assessments/index.html.erb
+++ b/app/views/green_lanes/category_assessments/index.html.erb
@@ -1,0 +1,38 @@
+<h2>
+  Manage category assessments
+</h2>
+
+<% if @category_assessments.any? %>
+  <table>
+    <thead>
+    <tr>
+      <th>ID</th>
+      <th>Measure type id</th>
+      <th>Regulation id</th>
+      <th>Regulation role</th>
+      <th>Theme id</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @category_assessments.each do |category| %>
+      <tr id="<%= dom_id(category) %>">
+        <td><%= category.id %></td>
+        <td><%= category.measure_type_id %></td>
+        <td><%= category.regulation_id %></td>
+        <td><%= category.regulation_role %></td>
+        <td><%= category.theme_id %></td>
+
+        <td>
+          <%#= link_to 'Edit', edit_green_lanes_category_assessments_path(category) %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+
+  <%= paginate @category_assessments %>
+<% else %>
+  <div class="govuk-inset-text">
+    <p>No Category Assessments</p>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,9 +49,11 @@
       <%= header.with_navigation_item text: 'Reports',
                                       href: reports_path,
                                       active: active_nav_link?(/\/reports/) %>
-      <%= header.with_navigation_item text: 'Category assessments',
+      <% if TradeTariffAdmin::ServiceChooser.xi? %>
+        <%= header.with_navigation_item text: 'Category assessments',
                                       href: green_lanes_category_assessments_path,
                                       active: active_nav_link?(/\/category_assessments/) %>
+      <% end %>
     <% end %>
 
     <div class="govuk-width-container">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -49,6 +49,9 @@
       <%= header.with_navigation_item text: 'Reports',
                                       href: reports_path,
                                       active: active_nav_link?(/\/reports/) %>
+      <%= header.with_navigation_item text: 'Category assessments',
+                                      href: green_lanes_category_assessments_path,
+                                      active: active_nav_link?(/\/category_assessments/) %>
     <% end %>
 
     <div class="govuk-width-container">

--- a/config/initializers/exceptions.rb
+++ b/config/initializers/exceptions.rb
@@ -6,4 +6,5 @@ ActionDispatch::ExceptionWrapper.rescue_responses.merge!(
   'ActionController::UnknownFormat' => :not_found,
   'AbstractController::ActionNotFound' => :not_found,
   'URI::InvalidURIError' => :not_found,
+  'ActionController::RoutingError' => :not_found,
 )

--- a/config/initializers/her.rb
+++ b/config/initializers/her.rb
@@ -35,3 +35,18 @@ Her::UK_API.setup url: TradeTariffAdmin::ServiceChooser.service_choices['uk'] do
   # Adapter
   c.adapter Faraday::Adapter::NetHttp
 end
+
+Her::XI_API = Her::API.new
+Her::XI_API.setup url: TradeTariffAdmin::ServiceChooser.service_choices['xi'] do |c|
+  # Request
+  c.use Faraday::Request::UrlEncoded
+  c.use FaradayMiddleware::BearerTokenAuthentication, ENV['BEARER_TOKEN'] || 'tariff-api-test-token'
+
+  # Response
+  c.use Her::Middleware::HeaderMetadataParse
+  c.use Her::Middleware::TariffJsonapiParser
+  c.use Her::Middleware::RaiseError
+
+  # Adapter
+  c.adapter Faraday::Adapter::NetHttp
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,10 @@ Rails.application.routes.draw do
     end
   end
 
+  namespace :green_lanes, path: 'green_lanes' do
+    resources :category_assessments, only: %i[index]
+  end
+
   resources :tariff_updates, only: %i[index show] do
     collection do
       post '/clear_cache', to: 'tariff_updates#clear_cache'

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -1,0 +1,11 @@
+FactoryBot.define do
+  factory :category_assessment, class: 'GreenLanes::CategoryAssessment' do
+    sequence(:id) { |n| n }
+    measure_type_id { '464' }
+    regulation_id { 'R9700880' }
+    regulation_role { '3' }
+    theme_id { '1' }
+    created_at { 2.days.ago.to_date }
+    updated_at { nil }
+  end
+end

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -19,7 +19,6 @@ RSpec.describe GreenLanes::CategoryAssessment do
   it { is_expected.to have_attributes created_at: category_assessment.created_at }
   it { is_expected.to have_attributes updated_at: category_assessment.updated_at }
 
-
   describe '#all' do
     subject { described_class.all }
 

--- a/spec/models/green_lanes/category_assessment_spec.rb
+++ b/spec/models/green_lanes/category_assessment_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe GreenLanes::CategoryAssessment do
+  subject(:category_assessment) { build :category_assessment }
+
+  it { is_expected.to respond_to :id }
+  it { is_expected.to respond_to :measure_type_id }
+  it { is_expected.to respond_to :regulation_id }
+  it { is_expected.to respond_to :regulation_role }
+  it { is_expected.to respond_to :theme_id }
+  it { is_expected.to respond_to :created_at }
+  it { is_expected.to respond_to :updated_at }
+
+  it { is_expected.to have_attributes id: category_assessment.id }
+  it { is_expected.to have_attributes measure_type_id: category_assessment.measure_type_id }
+  it { is_expected.to have_attributes regulation_id: category_assessment.regulation_id }
+  it { is_expected.to have_attributes regulation_role: category_assessment.regulation_role }
+  it { is_expected.to have_attributes theme_id: category_assessment.theme_id }
+  it { is_expected.to have_attributes created_at: category_assessment.created_at }
+  it { is_expected.to have_attributes updated_at: category_assessment.updated_at }
+
+
+  describe '#all' do
+    subject { described_class.all }
+
+    before do
+      allow(TradeTariffAdmin::ServiceChooser).to \
+        receive(:service_choice).and_return service_choice
+
+      stub_api_request('/admin/category_assessments', backend: 'xi').to_return \
+        jsonapi_response(:category_assessment, attributes_for_list(:category_assessment, 2))
+    end
+
+    context 'with UK service' do
+      let(:service_choice) { 'uk' }
+
+      it { is_expected.to have_attributes length: 2 }
+    end
+
+    context 'with XI service' do
+      let(:service_choice) { 'xi' }
+
+      it { is_expected.to have_attributes length: 2 }
+    end
+  end
+end

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
 
   describe 'GET #index' do
     before do
-      stub_api_request('/admin/category_assessments?page=1').and_return \
+      stub_api_request('/admin/category_assessments?page=1', backend: 'xi').and_return \
         jsonapi_response :category_assessments, attributes_for_list(:category_assessment, 3)
     end
 

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -1,0 +1,17 @@
+RSpec.describe GreenLanes::CategoryAssessmentsController do
+  subject(:rendered_page) { create_user && make_request && response }
+
+  let(:category_assessment) { build :category_assessment }
+  let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
+
+  describe 'GET #index' do
+    before do
+      stub_api_request('/admin/category_assessments?page=1').and_return \
+        jsonapi_response :category_assessments, attributes_for_list(:category_assessment, 3)
+    end
+
+    let(:make_request) { get green_lanes_category_assessments_path }
+
+    it { is_expected.to have_http_status :success }
+  end
+end

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
   let(:category_assessment) { build :category_assessment }
   let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
 
+  before do
+    allow(TradeTariffAdmin::ServiceChooser).to receive(:service_choice).and_return 'xi'
+  end
+
   describe 'GET #index' do
     before do
       stub_api_request('/admin/category_assessments?page=1', backend: 'xi').and_return \


### PR DESCRIPTION
### Jira link

[GL-106](https://transformuk.atlassian.net/browse/GL-106)

### What?

I have added/removed/altered:

- [ ] Added an admin screen to list all category assessments


### Why?

I am doing this because:

- We can see what is in the category assessments table and manage them
-
-

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

