### PR TITLE
GL-108: Add Edit screens for Category Assessments

### DIFF
--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -39,6 +39,13 @@ module GreenLanes
       end
     end
 
+    def destroy
+      @category_assessment = GreenLanes::CategoryAssessment.find(params[:id])
+      @category_assessment.destroy
+
+      redirect_to green_lanes_category_assessments_path, notice: 'Category Assessment removed'
+    end
+
     private
 
     def ca_params

--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -22,6 +22,23 @@ module GreenLanes
       end
     end
 
+    def edit
+      @category_assessment = GreenLanes::CategoryAssessment.find(params[:id])
+      @themes = GreenLanes::Theme.all.fetch
+    end
+
+    def update
+      @category_assessment = GreenLanes::CategoryAssessment.find(params[:id])
+      @category_assessment.attributes = ca_params
+
+      if @category_assessment.valid? && @category_assessment.save
+        redirect_to green_lanes_category_assessments_path, notice: 'Category Assessment updated'
+      else
+        @themes = GreenLanes::Theme.all.fetch
+        render :edit
+      end
+    end
+
     private
 
     def ca_params

--- a/app/models/green_lanes/theme.rb
+++ b/app/models/green_lanes/theme.rb
@@ -14,7 +14,7 @@ module GreenLanes
     collection_path '/admin/green_lanes/themes'
 
     def label
-      formatted_label.length > MAX_LENGTH ? "#{formatted_label[0...MAX_LENGTH]}..." : formatted_label
+      formatted_label.length > MAX_LENGTH ? formatted_label.truncate(MAX_LENGTH).to_s : formatted_label
     end
 
     private

--- a/app/models/green_lanes/theme.rb
+++ b/app/models/green_lanes/theme.rb
@@ -14,7 +14,7 @@ module GreenLanes
     collection_path '/admin/green_lanes/themes'
 
     def label
-      formatted_label.length > MAX_LENGTH ? formatted_label.truncate(MAX_LENGTH).to_s : formatted_label
+      formatted_label.truncate(MAX_LENGTH).to_s
     end
 
     private

--- a/app/views/green_lanes/category_assessments/edit.html.erb
+++ b/app/views/green_lanes/category_assessments/edit.html.erb
@@ -1,0 +1,7 @@
+<%= govuk_breadcrumbs 'Category Assessments': green_lanes_category_assessments_path %>
+
+<h2>Edit Category Assessment</h2>
+
+<%= render 'form', category_assessment: @category_assessment %>
+
+

--- a/app/views/green_lanes/category_assessments/edit.html.erb
+++ b/app/views/green_lanes/category_assessments/edit.html.erb
@@ -4,4 +4,18 @@
 
 <%= render 'form', category_assessment: @category_assessment %>
 
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
+<h3>
+  Remove Category Assessment
+</h3>
+
+<p>
+  Remove this Category Assessment
+</p>
+
+<%= link_to 'Remove',
+            green_lanes_category_assessment_path(@category_assessment),
+            method: :delete,
+            class: 'govuk-button govuk-button--warning',
+            data: { confirm: "Are you sure?", disable: 'Working ...' } %>

--- a/app/views/green_lanes/category_assessments/index.html.erb
+++ b/app/views/green_lanes/category_assessments/index.html.erb
@@ -13,6 +13,7 @@
       <th>Regulation id</th>
       <th>Regulation role</th>
       <th>Theme id</th>
+      <th>Action</th>
     </tr>
     </thead>
     <tbody>
@@ -23,9 +24,9 @@
         <td><%= category.regulation_id %></td>
         <td><%= category.regulation_role %></td>
         <td><%= category.theme_id %></td>
-
         <td>
-          <%#= link_to 'Edit', edit_green_lanes_category_assessments_path(category) %>
+          <%= link_to 'Edit',
+                      edit_green_lanes_category_assessment_path(category) %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
   end
 
   namespace :green_lanes, path: 'green_lanes' do
-    resources :category_assessments, only: %i[index new create]
+    resources :category_assessments, only: %i[index new create edit update]
   end
 
   resources :tariff_updates, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
   end
 
   namespace :green_lanes, path: 'green_lanes' do
-    resources :category_assessments, only: %i[index new create edit update]
+    resources :category_assessments, only: %i[index new create edit update destroy]
   end
 
   resources :tariff_updates, only: %i[index show] do

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -98,4 +98,18 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
       it { is_expected.not_to include 'div.current-service' }
     end
   end
+
+  describe 'DELETE #destroy' do
+    before do
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}")
+        .and_return jsonapi_response(:category_assessment, category_assessment.attributes)
+
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}", :delete)
+        .and_return webmock_response :no_content
+    end
+
+    let(:make_request) { delete green_lanes_category_assessment_path(category_assessment) }
+
+    it { is_expected.to redirect_to green_lanes_category_assessments_path }
+  end
 end

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
 
   before do
     allow(TradeTariffAdmin::ServiceChooser).to receive(:service_choice).and_return 'xi'
+    stub_api_request('/admin/green_lanes/themes', backend: 'xi').and_return \
+      jsonapi_response :themes, attributes_for_list(:green_lanes_theme, 3)
   end
 
   describe 'GET #index' do
@@ -21,11 +23,6 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
   end
 
   describe 'GET #new' do
-    before do
-      stub_api_request('/admin/green_lanes/themes', backend: 'xi').and_return \
-        jsonapi_response :themes, attributes_for_list(:green_lanes_theme, 3)
-    end
-
     let(:make_request) { get new_green_lanes_category_assessment_path }
 
     it { is_expected.to have_http_status :ok }
@@ -35,8 +32,6 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
   describe 'POST #create' do
     before do
       stub_api_request('/admin/green_lanes/category_assessments', :post).to_return create_response
-      stub_api_request('/admin/green_lanes/themes', backend: 'xi').and_return \
-        jsonapi_response :themes, attributes_for_list(:green_lanes_theme, 3)
     end
 
     let :make_request do
@@ -54,6 +49,49 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
     context 'with invalid item' do
       let(:ca_params) { category_assessment.attributes.without(:id, :measure_type_id) }
       let(:create_response) { webmock_response(:error, measure_type_id: "can't be blank'") }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to have_attributes body: /can.+t be blank/ }
+      it { is_expected.not_to include 'div.current-service' }
+    end
+  end
+
+  describe 'GET #edit' do
+    before do
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}")
+        .and_return jsonapi_response(:category_assessment, category_assessment.attributes)
+    end
+
+    let(:make_request) { get edit_green_lanes_category_assessment_path(category_assessment) }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.not_to include 'div.current-service' }
+  end
+
+  describe 'PATCH #update' do
+    before do
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}")
+        .and_return jsonapi_response(:category_assessment, category_assessment.attributes)
+
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}", :patch)
+        .and_return patch_response
+    end
+
+    let :make_request do
+      patch green_lanes_category_assessment_path(category_assessment),
+            params: { category_assessment: category_assessment.attributes.merge(regulation_role: new_role) }
+    end
+
+    context 'with valid change' do
+      let(:new_role) { '2' }
+      let(:patch_response) { webmock_response :updated, "/admin/news/item/#{category_assessment.id}" }
+
+      it { is_expected.to redirect_to green_lanes_category_assessments_path }
+    end
+
+    context 'with invalid change' do
+      let(:new_role) { '' }
+      let(:patch_response) { webmock_response :error, regulation_role: "can't be blank" }
 
       it { is_expected.to have_http_status :ok }
       it { is_expected.to have_attributes body: /can.+t be blank/ }

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
 
     context 'with valid change' do
       let(:new_role) { '2' }
-      let(:patch_response) { webmock_response :updated, "/admin/news/item/#{category_assessment.id}" }
+      let(:patch_response) { webmock_response :updated, "/admin/green_lanes/category_assessments/#{category_assessment.id}" }
 
       it { is_expected.to redirect_to green_lanes_category_assessments_path }
     end


### PR DESCRIPTION
### Jira link

[GL-108](https://transformuk.atlassian.net/browse/GL-108)

### What?

I have added/removed/altered:

- [ ] Added category assessments edit UI

### Why?

I am doing this because:

- So that we can maintain the list of valid category assessments

