### PR TITLE
GL-109: Add deletion of Category Assessments

### DIFF
--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -39,6 +39,13 @@ module GreenLanes
       end
     end
 
+    def destroy
+      @category_assessment = GreenLanes::CategoryAssessment.find(params[:id])
+      @category_assessment.destroy
+
+      redirect_to green_lanes_category_assessments_path, notice: 'Category Assessment removed'
+    end
+
     private
 
     def ca_params

--- a/app/views/green_lanes/category_assessments/edit.html.erb
+++ b/app/views/green_lanes/category_assessments/edit.html.erb
@@ -15,7 +15,7 @@
 </p>
 
 <%= link_to 'Remove',
-            green_lanes_category_assessments_path(@category_assessment),
+            green_lanes_category_assessment_path(@category_assessment),
             method: :delete,
             class: 'govuk-button govuk-button--warning',
             data: { confirm: "Are you sure?", disable: 'Working ...' } %>

--- a/app/views/green_lanes/category_assessments/edit.html.erb
+++ b/app/views/green_lanes/category_assessments/edit.html.erb
@@ -4,4 +4,18 @@
 
 <%= render 'form', category_assessment: @category_assessment %>
 
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
+<h3>
+  Remove Category Assessment
+</h3>
+
+<p>
+  Remove this Category Assessment
+</p>
+
+<%= link_to 'Remove',
+            green_lanes_category_assessments_path(@category_assessment),
+            method: :delete,
+            class: 'govuk-button govuk-button--warning',
+            data: { confirm: "Are you sure?", disable: 'Working ...' } %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,7 +63,7 @@ Rails.application.routes.draw do
   end
 
   namespace :green_lanes, path: 'green_lanes' do
-    resources :category_assessments, only: %i[index new create edit update]
+    resources :category_assessments, only: %i[index new create edit update destroy]
   end
 
   resources :tariff_updates, only: %i[index show] do

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -98,4 +98,18 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
       it { is_expected.not_to include 'div.current-service' }
     end
   end
+
+  describe 'DELETE #destroy' do
+    before do
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}")
+        .and_return jsonapi_response(:category_assessment, category_assessment.attributes)
+
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}", :delete)
+        .and_return webmock_response :no_content
+    end
+
+    let(:make_request) { delete green_lanes_category_assessment_path(category_assessment) }
+
+    it { is_expected.to redirect_to green_lanes_category_assessments_path }
+  end
 end


### PR DESCRIPTION
### Jira link

[GL-109](https://transformuk.atlassian.net/browse/GL-109)

### What?

I have added/removed/altered:

- [ ] Added remove a category assessment UI

### Why?

I am doing this because:

- So that we can keep the category assessment data up to date

