### PR TITLE
GL-458: Add admin UI to remove overrides

### DIFF
--- a/app/controllers/green_lanes/exempting_certificate_overrides_controller.rb
+++ b/app/controllers/green_lanes/exempting_certificate_overrides_controller.rb
@@ -20,6 +20,13 @@ module GreenLanes
       end
     end
 
+    def destroy
+      @exempting_certificate_override = GreenLanes::ExemptingCertificateOverride.find(params[:id])
+      @exempting_certificate_override.destroy
+
+      redirect_to green_lanes_exempting_certificate_overrides_path, notice: 'Exempting Certificate Override removed'
+    end
+
     private
 
     def eco_params

--- a/app/views/green_lanes/exempting_certificate_overrides/index.html.erb
+++ b/app/views/green_lanes/exempting_certificate_overrides/index.html.erb
@@ -11,6 +11,7 @@
       <th>ID</th>
       <th>Certificate Type Code</th>
       <th>Certificate Code</th>
+      <th>Action</th>
     </tr>
     </thead>
     <tbody>
@@ -19,6 +20,13 @@
         <td><%= eco.id %></td>
         <td><%= eco.certificate_type_code %></td>
         <td><%= eco.certificate_code %></td>
+        <td>
+          <%= link_to 'Remove',
+                      green_lanes_exempting_certificate_override_path(eco),
+                      method: :delete,
+                      class: 'govuk-button govuk-button--warning',
+                      data: { confirm: "Are you sure?", disable: 'Working ...' } %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/spec/requests/green_lanes/exempting_certificate_overrides_controller_spec.rb
+++ b/spec/requests/green_lanes/exempting_certificate_overrides_controller_spec.rb
@@ -53,4 +53,18 @@ RSpec.describe GreenLanes::ExemptingCertificateOverridesController do
       it { is_expected.not_to include 'div.current-service' }
     end
   end
+
+  describe 'DELETE #destroy' do
+    before do
+      stub_api_request("/admin/green_lanes/exempting_certificate_overrides/#{exempting_certificate_override.id}")
+        .and_return jsonapi_response(:exempting_certificate_override, exempting_certificate_override.attributes)
+
+      stub_api_request("/admin/green_lanes/exempting_certificate_overrides/#{exempting_certificate_override.id}", :delete)
+        .and_return webmock_response :no_content
+    end
+
+    let(:make_request) { delete green_lanes_exempting_certificate_override_path(exempting_certificate_override) }
+
+    it { is_expected.to redirect_to green_lanes_exempting_certificate_overrides_path }
+  end
 end


### PR DESCRIPTION
### Jira link

[GL-458](https://transformuk.atlassian.net/browse/GL-458)

### What?

I have added/removed/altered:

- [ ] Added Admin UI to  remove an Override 

### Why?

I am doing this because:

- Admin user should be able to manage exemption certificate overrides
