### PR TITLE
GL-495: Add admin UI to remove pseudo exemptions

### DIFF
--- a/app/controllers/green_lanes/exemptions_controller.rb
+++ b/app/controllers/green_lanes/exemptions_controller.rb
@@ -37,6 +37,13 @@ module GreenLanes
       end
     end
 
+    def destroy
+      @exemption = GreenLanes::Exemption.find(params[:id])
+      @exemption.destroy
+
+      redirect_to green_lanes_exemptions_path, notice: 'Exemption removed'
+    end
+
     private
 
     def ex_params

--- a/spec/requests/green_lanes/exemptions_controller_spec.rb
+++ b/spec/requests/green_lanes/exemptions_controller_spec.rb
@@ -96,4 +96,18 @@ RSpec.describe GreenLanes::ExemptionsController do
       it { is_expected.not_to include 'div.current-service' }
     end
   end
+
+  describe 'DELETE #destroy' do
+    before do
+      stub_api_request("/admin/green_lanes/exemptions/#{exemption.id}")
+        .and_return jsonapi_response(:exemption, exemption.attributes)
+
+      stub_api_request("/admin/green_lanes/exemptions/#{exemption.id}", :delete)
+        .and_return webmock_response :no_content
+    end
+
+    let(:make_request) { delete green_lanes_exemption_path(exemption) }
+
+    it { is_expected.to redirect_to green_lanes_exemptions_path }
+  end
 end


### PR DESCRIPTION
### Jira link

[GL-495](https://transformuk.atlassian.net/browse/GL-495)

### What?

I have added/removed/altered:

- [ ] Added Admin UI screen to remove exemptions

### Why?

I am doing this because:

- Admin user should be able to manage exemption
