### PR TITLE
GL-384: Add deleting pseudo measures

### DIFF
--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -26,7 +26,7 @@ module GreenLanes
 
     def edit
       @category_assessment = GreenLanes::CategoryAssessment.find(params[:id])
-      prepare_edit(@category_assessment)
+      prepare_edit
     end
 
     def update
@@ -36,7 +36,7 @@ module GreenLanes
       if @category_assessment.valid? && @category_assessment.save
         redirect_to green_lanes_category_assessments_path, notice: 'Category Assessment updated'
       else
-        prepare_edit(@category_assessment)
+        prepare_edit
         render :edit
       end
     end
@@ -50,8 +50,50 @@ module GreenLanes
       if category_assessment_exemption.valid? && category_assessment_exemption.add_exemption
         redirect_to edit_green_lanes_category_assessment_path(id: params[:id]), notice: 'Exemption assigned successfully'
       else
-        prepare_edit(@category_assessment)
+        prepare_edit
         @category_assessment_exemption = category_assessment_exemption
+        render :edit
+      end
+    end
+
+    def remove_exemption
+      @category_assessment = GreenLanes::CategoryAssessment.find(params[:id])
+
+      exemption_id = params[:exemption_id]
+      category_assessment_exemption = GreenLanes::CategoryAssessmentExemption.new(category_assessment_id: @category_assessment.id, exemption_id:)
+
+      if category_assessment_exemption.valid? && category_assessment_exemption.remove_exemption
+        redirect_to edit_green_lanes_category_assessment_path(id: params[:id]), notice: 'Exemption removed successfully'
+      else
+        prepare_edit
+        @category_assessment_exemption = category_assessment_exemption
+        render :edit
+      end
+    end
+
+    def add_measure
+      measure = GreenLanes::Measure.new(measure_params)
+      category_assessment_id = measure_params[:category_assessment_id]
+      @category_assessment = GreenLanes::CategoryAssessment.find(category_assessment_id)
+
+      if measure.valid?
+        begin
+          if measure.save
+            redirect_to edit_green_lanes_category_assessment_path(id: category_assessment_id), notice: 'Goods Nomenclature assigned successfully'
+          else
+            prepare_edit
+            @measure = measure
+            render :edit
+          end
+        rescue Faraday::ResourceNotFound
+          prepare_edit
+          @measure = measure
+          @measure.errors.add(:goods_nomenclature_item_id, 'Goods Nomenclature is not valid')
+          render :edit
+        end
+      else
+        prepare_edit
+        @measure = measure
         render :edit
       end
     end
@@ -65,20 +107,16 @@ module GreenLanes
 
     private
 
-    def prepare_edit(category_assessment)
+    def prepare_edit
       @themes = GreenLanes::Theme.all.fetch
 
       all_exemptions = GreenLanes::Exemption.all.fetch
-      existing_exemptions = category_assessment.has_exemptions? ? category_assessment.exemptions.map(&:code) : []
+      existing_exemptions = @category_assessment.has_exemptions? ? @category_assessment.exemptions.map(&:code) : []
       @exemptions = all_exemptions.reject { |exemption| existing_exemptions.include?(exemption.code) }
 
       @category_assessment_exemption = GreenLanes::CategoryAssessmentExemption.new(category_assessment_id: @category_assessment.id)
 
       @measure = GreenLanes::Measure.new(category_assessment_id: @category_assessment.id)
-      if session[:measures_errors]
-        @measure.errors.add(:base, session[:measures_errors])
-        session.delete(:measures_errors)
-      end
     end
 
     def ca_params
@@ -87,6 +125,14 @@ module GreenLanes
         :regulation_role,
         :measure_type_id,
         :theme_id,
+      )
+    end
+
+    def measure_params
+      params.require(:measure).permit(
+        :category_assessment_id,
+        :goods_nomenclature_item_id,
+        :productline_suffix,
       )
     end
 

--- a/app/controllers/green_lanes/measures_controller.rb
+++ b/app/controllers/green_lanes/measures_controller.rb
@@ -19,6 +19,14 @@ module GreenLanes
       redirect_to edit_green_lanes_category_assessment_path(id: category_assessment_id), notice: 'Goods Nomenclature assigned successfully'
     end
 
+    def destroy
+      @measure = GreenLanes::Measure.find(params[:id])
+      category_assessment_id = @measure.category_assessment.id
+      @measure.destroy
+
+      redirect_to edit_green_lanes_category_assessment_path(id: category_assessment_id), notice: 'Goods Nomenclature removed successfully'
+    end
+
     def measure_params
       params.require(:measure).permit(
         :category_assessment_id,

--- a/app/controllers/green_lanes/measures_controller.rb
+++ b/app/controllers/green_lanes/measures_controller.rb
@@ -8,31 +8,16 @@ module GreenLanes
       @measures = GreenLanes::Measure.all(page: current_page).fetch
     end
 
-    def create
-      measures = GreenLanes::Measure.new(measure_params)
-      category_assessment_id = measure_params[:category_assessment_id]
-
-      unless measures.valid? && measures.save
-        session[:measures_errors] = measures.errors.full_messages
-      end
-
-      redirect_to edit_green_lanes_category_assessment_path(id: category_assessment_id), notice: 'Goods Nomenclature assigned successfully'
-    end
-
     def destroy
       @measure = GreenLanes::Measure.find(params[:id])
-      category_assessment_id = @measure.category_assessment.id
+      category_assessment_id = params[:category_assessment_id]
       @measure.destroy
 
-      redirect_to edit_green_lanes_category_assessment_path(id: category_assessment_id), notice: 'Goods Nomenclature removed successfully'
-    end
-
-    def measure_params
-      params.require(:measure).permit(
-        :category_assessment_id,
-        :goods_nomenclature_item_id,
-        :productline_suffix,
-      )
+      if category_assessment_id.present?
+        redirect_to edit_green_lanes_category_assessment_path(id: category_assessment_id), notice: 'Goods Nomenclature removed successfully'
+      else
+        redirect_to green_lanes_measures_path, notice: 'Measure removed'
+      end
     end
   end
 end

--- a/app/models/green_lanes/category_assessment_exemption.rb
+++ b/app/models/green_lanes/category_assessment_exemption.rb
@@ -5,11 +5,15 @@ module GreenLanes
 
     attributes :category_assessment_id, :exemption_id
 
-    validates :exemption_id, presence: true
+    validates :exemption_id, presence: { message: 'Exemption cannot be blank' }
     validates :category_assessment_id, presence: true
 
     def add_exemption
       self.class.post_raw("/admin/green_lanes/category_assessments/#{category_assessment_id}/exemptions", exemption_id:)
+    end
+
+    def remove_exemption
+      self.class.delete_raw("/admin/green_lanes/category_assessments/#{category_assessment_id}/exemptions", exemption_id:)
     end
   end
 end

--- a/app/models/green_lanes/measure.rb
+++ b/app/models/green_lanes/measure.rb
@@ -9,9 +9,16 @@ module GreenLanes
     has_one :category_assessment
     has_one :goods_nomenclature
 
-    validates :productline_suffix, presence: true
-    validates :goods_nomenclature_item_id, presence: true
+    validates :productline_suffix, presence: { message: 'Product Line Suffix cannot be blank' }
+    validates :goods_nomenclature_item_id, presence: { message: 'Goods Nomenclature Item Id cannot be blank' }
 
     collection_path '/admin/green_lanes/measures'
+
+    def initialize(attributes = {})
+      super
+      @has_goods_nomenclature = attributes[:goods_nomenclature].present?
+    end
+
+    attr_reader :has_goods_nomenclature
   end
 end

--- a/app/views/green_lanes/category_assessments/_exemptions.html.erb
+++ b/app/views/green_lanes/category_assessments/_exemptions.html.erb
@@ -4,6 +4,7 @@
     <tr>
       <th>Code</th>
       <th>Description</th>
+      <th>Action</th>
     </tr>
     </thead>
     <tbody>
@@ -11,6 +12,13 @@
       <tr id="<%= dom_id(ex) %>">
         <td><%= ex.code %></td>
         <td><%= ex.description %></td>
+        <td>
+          <%= link_to 'Remove',
+                      remove_exemption_green_lanes_category_assessment_path(@category_assessment, exemption_id: ex.id),
+                      method: :delete,
+                      class: 'govuk-button govuk-button--warning',
+                      data: { confirm: "Are you sure?", disable: 'Working ...' } %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/green_lanes/category_assessments/_measure_form.html.erb
+++ b/app/views/green_lanes/category_assessments/_measure_form.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_form_for measure, as: :measure do |f| %>
+<%= govuk_form_for @measure, url: add_measure_green_lanes_category_assessment_path(@category_assessment), method: :post, as: :measure do |f| %>
 
   <%= f.hidden_field :category_assessment_id, value: measure.category_assessment_id %>
 

--- a/app/views/green_lanes/category_assessments/_measures.html.erb
+++ b/app/views/green_lanes/category_assessments/_measures.html.erb
@@ -5,6 +5,7 @@
       <th>Goods Nomenclature Item Id</th>
       <th>Goods Nomenclature Description</th>
       <th>Product Line Suffix</th>
+      <th>Action</th>
     </tr>
     </thead>
     <tbody>
@@ -17,6 +18,13 @@
           <%= me.goods_nomenclature.description if me.goods_nomenclature.present?%>
         </td>
         <td><%= me.productline_suffix %></td>
+        <td>
+          <%= link_to 'Remove',
+                      green_lanes_measure_path(me),
+                      method: :delete,
+                      class: 'govuk-button govuk-button--warning',
+                      data: { confirm: "Are you sure?", disable: 'Working ...' } %>
+        </td>
       </tr>
     <% end %>
     </tbody>

--- a/app/views/green_lanes/category_assessments/_measures.html.erb
+++ b/app/views/green_lanes/category_assessments/_measures.html.erb
@@ -10,22 +10,24 @@
     </thead>
     <tbody>
     <% @category_assessment.green_lanes_measures.each do |me| %>
-      <tr id="<%= dom_id(me) %>">
-        <td>
-          <%= me.goods_nomenclature.goods_nomenclature_item_id if me.goods_nomenclature.present?%>
-        </td>
-        <td>
-          <%= me.goods_nomenclature.description if me.goods_nomenclature.present?%>
-        </td>
-        <td><%= me.productline_suffix %></td>
-        <td>
-          <%= link_to 'Remove',
-                      green_lanes_measure_path(me),
-                      method: :delete,
-                      class: 'govuk-button govuk-button--warning',
-                      data: { confirm: "Are you sure?", disable: 'Working ...' } %>
-        </td>
-      </tr>
+      <% if me.has_goods_nomenclature %>
+        <tr id="<%= dom_id(me) %>">
+          <td>
+            <%= me.goods_nomenclature.goods_nomenclature_item_id %>
+          </td>
+          <td>
+            <%= me.goods_nomenclature.description %>
+          </td>
+          <td><%= me.productline_suffix %></td>
+          <td>
+            <%= link_to 'Remove',
+                        green_lanes_measure_path(me, category_assessment_id: @category_assessment.id),
+                        method: :delete,
+                        class: 'govuk-button govuk-button--warning',
+                        data: { confirm: "Are you sure?", disable: 'Working ...' } %>
+          </td>
+        </tr>
+      <% end %>
     <% end %>
     </tbody>
   </table>

--- a/app/views/green_lanes/category_assessments/index.html.erb
+++ b/app/views/green_lanes/category_assessments/index.html.erb
@@ -12,7 +12,7 @@
       <th>Measure type id</th>
       <th>Regulation id</th>
       <th>Regulation role</th>
-      <th>Theme id</th>
+      <th>Theme</th>
       <th>Action</th>
     </tr>
     </thead>
@@ -23,7 +23,7 @@
         <td><%= category.measure_type_id %></td>
         <td><%= category.regulation_id %></td>
         <td><%= category.regulation_role %></td>
-        <td><%= category.theme_id %></td>
+        <td><%= category.theme.code %></td>
         <td>
           <%= link_to 'Edit',
                       edit_green_lanes_category_assessment_path(category) %>

--- a/app/views/green_lanes/measures/index.html.erb
+++ b/app/views/green_lanes/measures/index.html.erb
@@ -13,18 +13,23 @@
       <th>Theme</th>
       <th>Measure Type</th>
       <th>Regulation Id</th>
+      <th>Action</th>
     </tr>
     </thead>
     <tbody>
     <% @measures.each do |me| %>
       <tr id="<%= dom_id(me) %>">
         <td><%= me.id%></td>
-        <td>
-          <%= me.goods_nomenclature.goods_nomenclature_item_id if me.goods_nomenclature.present?%>
-        </td>
-        <td>
-          <%= me.goods_nomenclature.description if me.goods_nomenclature.present?%>
-        </td>
+        <% if me.has_goods_nomenclature %>
+          <td>
+            <%= me.goods_nomenclature.goods_nomenclature_item_id %>
+          </td>
+          <td>
+            <%= me.goods_nomenclature.description %>
+          </td>
+        <% else%>
+          <td colspan="2"> Inactive Goods Nomenclature </td>
+        <% end %>
         <td><%= me.productline_suffix %></td>
         <td>
           <%= me.category_assessment&.theme&.code if me.category_assessment.present? && me.category_assessment.theme.present?%>
@@ -34,6 +39,13 @@
         </td>
         <td>
           <%= me.category_assessment.regulation_id if me.category_assessment.present?%>
+        </td>
+        <td>
+          <%= link_to 'Remove',
+                      green_lanes_measure_path(me),
+                      method: :delete,
+                      class: 'govuk-button govuk-button--warning',
+                      data: { confirm: "Are you sure?", disable: 'Working ...' } %>
         </td>
       </tr>
     <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,11 +66,13 @@ Rails.application.routes.draw do
     resources :category_assessments, only: %i[index new create edit update destroy] do
       member do
         post 'add_exemption'
+        delete 'remove_exemption'
+        post 'add_measure'
       end
     end
     resources :exempting_certificate_overrides, only: %i[index new create destroy]
     resources :exemptions, only: %i[index new create edit update destroy]
-    resources :measures, only: %i[index create destroy]
+    resources :measures, only: %i[index destroy]
   end
 
   resources :tariff_updates, only: %i[index show] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -70,7 +70,7 @@ Rails.application.routes.draw do
     end
     resources :exempting_certificate_overrides, only: %i[index new create destroy]
     resources :exemptions, only: %i[index new create edit update destroy]
-    resources :measures, only: %i[index create]
+    resources :measures, only: %i[index create destroy]
   end
 
   resources :tariff_updates, only: %i[index show] do

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -21,9 +21,7 @@ FactoryBot.define do
     end
 
     trait :with_theme do
-      association :green_lanes_theme, strategy: :build
-
-      theme_id { green_lanes_theme.id }
+      theme { { attributes: attributes_for(:green_lanes_theme) } }
     end
   end
 end

--- a/spec/factories/green_lanes/measure_factory.rb
+++ b/spec/factories/green_lanes/measure_factory.rb
@@ -8,8 +8,7 @@ FactoryBot.define do
     goods_nomenclature {}
 
     trait :with_category_assessment do
-      category_assessment { { attributes: attributes_for(:category_assessment) } }
-      # category_assessment_id { category_assessment.id }
+      category_assessment { { attributes: attributes_for(:category_assessment, id: '10') } }
     end
 
     trait :with_goods_nomenclature do

--- a/spec/factories/green_lanes/measure_factory.rb
+++ b/spec/factories/green_lanes/measure_factory.rb
@@ -8,11 +8,12 @@ FactoryBot.define do
     goods_nomenclature {}
 
     trait :with_category_assessment do
-      category_assessment { attributes_for(:category_assessment) }
+      category_assessment { { attributes: attributes_for(:category_assessment) } }
+      # category_assessment_id { category_assessment.id }
     end
 
     trait :with_goods_nomenclature do
-      goods_nomenclature { attributes_for(:green_lanes_goods_nomenclature) }
+      goods_nomenclature { { attributes: attributes_for(:green_lanes_goods_nomenclature) } }
     end
   end
 end

--- a/spec/factories/green_lanes/measure_factory.rb
+++ b/spec/factories/green_lanes/measure_factory.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     goods_nomenclature {}
 
     trait :with_category_assessment do
-      category_assessment { { attributes: attributes_for(:category_assessment, id: '10') } }
+      category_assessment { { attributes: attributes_for(:category_assessment, :with_theme, id: '10') } }
     end
 
     trait :with_goods_nomenclature do

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GreenLanes::CategoryAssessmentsController do
   subject(:rendered_page) { create_user && make_request && response }
 
-  let(:category_assessment) { build :category_assessment }
+  let(:category_assessment) { build :category_assessment, :with_theme }
   let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
 
   before do
@@ -15,7 +15,7 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
   describe 'GET #index' do
     before do
       stub_api_request('/admin/green_lanes/category_assessments?page=1', backend: 'xi').and_return \
-        jsonapi_response :category_assessments, attributes_for_list(:category_assessment, 3)
+        jsonapi_response :category_assessments, attributes_for_list(:category_assessment, 3, :with_theme)
     end
 
     let(:make_request) { get green_lanes_category_assessments_path }
@@ -123,6 +123,77 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
 
     context 'with empty exemption id' do
       let(:params) { { cae: { exemption_id: nil } } }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to have_attributes body: /can.+t be blank/ }
+      it { is_expected.not_to include 'div.current-service' }
+    end
+  end
+
+  describe 'POST #remove_exemption' do
+    before do
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}")
+        .and_return jsonapi_response(:category_assessment, category_assessment.attributes)
+
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}/exemptions", :delete).to_return \
+        webmock_response(:success)
+    end
+
+    let :make_request do
+      delete remove_exemption_green_lanes_category_assessment_path(category_assessment),
+             params:
+    end
+
+    context 'with valid exemption id' do
+      let(:params) { { exemption_id: 2 } }
+
+      it { is_expected.to redirect_to edit_green_lanes_category_assessment_path(id: category_assessment.id) }
+    end
+
+    context 'with empty exemption id' do
+      let(:params) { { cae: { exemption_id: nil } } }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to have_attributes body: /can.+t be blank/ }
+      it { is_expected.not_to include 'div.current-service' }
+    end
+  end
+
+  describe 'POST #add_measure' do
+    before do
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}")
+        .and_return jsonapi_response(:category_assessment, category_assessment.attributes)
+
+      stub_api_request('/admin/green_lanes/measures', :post).to_return \
+        webmock_response(:success)
+
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}/measures", :post).to_return \
+        webmock_response(:success)
+    end
+
+    let(:measure) { build :green_lanes_measure, :with_category_assessment }
+
+    let :make_request do
+      post add_measure_green_lanes_category_assessment_path(category_assessment),
+           params:
+    end
+
+    context 'with valid item' do
+      let(:params) do
+        { measure: { category_assessment_id: category_assessment.id,
+                     goods_nomenclature_item_id: measure.goods_nomenclature_item_id,
+                     productline_suffix: measure.productline_suffix } }
+      end
+
+      it { is_expected.to redirect_to edit_green_lanes_category_assessment_path(id: category_assessment.id) }
+    end
+
+    context 'with invalid item' do
+      let(:params) do
+        { measure: { category_assessment_id: category_assessment.id,
+                     goods_nomenclature_item_id: nil,
+                     productline_suffix: measure.productline_suffix } }
+      end
 
       it { is_expected.to have_http_status :ok }
       it { is_expected.to have_attributes body: /can.+t be blank/ }

--- a/spec/requests/green_lanes/measures_controller_spec.rb
+++ b/spec/requests/green_lanes/measures_controller_spec.rb
@@ -11,46 +11,13 @@ RSpec.describe GreenLanes::MeasuresController do
   describe 'GET #index' do
     before do
       stub_api_request('/admin/green_lanes/measures?page=1', backend: 'xi').and_return \
-        jsonapi_response :measures, build_list(:green_lanes_measure, 3, :with_category_assessment, :with_goods_nomenclature)
+        jsonapi_response :measures, attributes_for_list(:green_lanes_measure, 3, :with_category_assessment, :with_goods_nomenclature)
     end
 
     let(:make_request) { get green_lanes_measures_path }
 
     it { is_expected.to have_http_status :success }
     it { is_expected.not_to include 'div.current-service' }
-  end
-
-  describe 'POST #create' do
-    before do
-      stub_api_request('/admin/green_lanes/measures', :post).to_return create_response
-    end
-
-    let :make_request do
-      post green_lanes_measures_path(id: measure.category_assessment_id),
-           params: { measure: measure_params }
-    end
-
-    context 'with valid item' do
-      let(:measure_params) { measure.attributes.without(:id) }
-      let(:create_response) { webmock_response(:created, measure.attributes) }
-
-      it { is_expected.to redirect_to edit_green_lanes_category_assessment_path(id: measure.category_assessment_id) }
-    end
-
-    context 'with invalid item' do
-      let(:measure_params) { measure.attributes.without(:id, :goods_nomenclature_item_id) }
-      let(:create_response) { webmock_response(:error, measure: "can't be blank'") }
-
-      it { is_expected.to have_http_status :redirect }
-
-      it 'sets the session' do
-        rendered_page
-
-        expect(
-          session['measures_errors'],
-        ).to include("Goods nomenclature item can't be blank")
-      end
-    end
   end
 
   describe 'DELETE #destroy' do
@@ -62,8 +29,16 @@ RSpec.describe GreenLanes::MeasuresController do
         .and_return webmock_response :no_content
     end
 
-    let(:make_request) { delete green_lanes_measure_path(measure) }
+    context 'with category assessment edit' do
+      let(:make_request) { delete green_lanes_measure_path(measure, category_assessment_id: '10') }
 
-    it { is_expected.to redirect_to edit_green_lanes_category_assessment_path(id: '10') }
+      it { is_expected.to redirect_to edit_green_lanes_category_assessment_path(id: '10') }
+    end
+
+    context 'with measure list' do
+      let(:make_request) { delete green_lanes_measure_path(measure) }
+
+      it { is_expected.to redirect_to green_lanes_measures_path }
+    end
   end
 end

--- a/spec/requests/green_lanes/measures_controller_spec.rb
+++ b/spec/requests/green_lanes/measures_controller_spec.rb
@@ -63,8 +63,7 @@ RSpec.describe GreenLanes::MeasuresController do
     end
 
     let(:make_request) { delete green_lanes_measure_path(measure) }
-    let(:ca_id) { measure.category_assessment_id }
 
-    it { is_expected.to redirect_to edit_green_lanes_category_assessment_path(id: ca_id) }
+    it { is_expected.to redirect_to edit_green_lanes_category_assessment_path(id: '10') }
   end
 end

--- a/spec/requests/green_lanes/measures_controller_spec.rb
+++ b/spec/requests/green_lanes/measures_controller_spec.rb
@@ -52,4 +52,19 @@ RSpec.describe GreenLanes::MeasuresController do
       end
     end
   end
+
+  describe 'DELETE #destroy' do
+    before do
+      stub_api_request("/admin/green_lanes/measures/#{measure.id}")
+        .and_return jsonapi_response(:green_lanes_measure, measure.attributes)
+
+      stub_api_request("/admin/green_lanes/measures/#{measure.id}", :delete)
+        .and_return webmock_response :no_content
+    end
+
+    let(:make_request) { delete green_lanes_measure_path(measure) }
+    let(:ca_id) { measure.category_assessment_id }
+
+    it { is_expected.to redirect_to edit_green_lanes_category_assessment_path(id: ca_id) }
+  end
 end


### PR DESCRIPTION
### Jira link

[GL-384](https://transformuk.atlassian.net/browse/GL-384)

### What?

I have added/removed/altered:

- [ ] Added admin UI to delete GL measures

### Why?

I am doing this because:

- Admin user should be able to manage GL measures
