### PR TITLE
GL-735: Admin UI: Paginate pseudo measures in CA edit page

### DIFF
--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -25,7 +25,7 @@ module GreenLanes
     end
 
     def edit
-      @category_assessment = GreenLanes::CategoryAssessment.find(params[:id])
+      @category_assessment = GreenLanes::CategoryAssessment.find(params[:id], page: current_page)
       prepare_edit
     end
 

--- a/app/models/green_lanes/category_assessment.rb
+++ b/app/models/green_lanes/category_assessment.rb
@@ -12,6 +12,7 @@ module GreenLanes
                :updated_at
 
     has_one :theme
+    has_one :measure_pagination, class_name: 'GreenLanes::MeasurePagination'
     has_many :green_lanes_measures, class_name: 'GreenLanes::Measure'
     has_many :exemptions
 

--- a/app/models/green_lanes/measure_pagination.rb
+++ b/app/models/green_lanes/measure_pagination.rb
@@ -1,0 +1,7 @@
+module GreenLanes
+  class MeasurePagination
+    include Her::JsonApi::Model
+
+    attributes :total_pages, :current_page, :limit_value
+  end
+end

--- a/app/views/green_lanes/category_assessments/_measures.html.erb
+++ b/app/views/green_lanes/category_assessments/_measures.html.erb
@@ -31,6 +31,7 @@
     <% end %>
     </tbody>
   </table>
+  <%= paginate @category_assessment.measure_pagination %>
 <% end %>
 
 <h3>

--- a/app/views/green_lanes/exempting_additional_code_overrides/new.html.erb
+++ b/app/views/green_lanes/exempting_additional_code_overrides/new.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_breadcrumbs 'Exempting Additional Code Override': green_lanes_exempting_additional_code_overrides_path %>
+<%= govuk_breadcrumbs 'Exempting Additional Code Override': green_lanes_exempting_overrides_path %>
 
 <h2>New Exempting Additional Code Override</h2>
 
@@ -12,6 +12,6 @@
                          label: { text: 'Additional Code' },
                          width: 'one-half' %>
 
-  <%= submit_and_back_buttons f, green_lanes_exempting_additional_code_overrides_path %>
+  <%= submit_and_back_buttons f, green_lanes_exempting_overrides_path %>
 <% end %>
 

--- a/app/views/green_lanes/exempting_certificate_overrides/new.html.erb
+++ b/app/views/green_lanes/exempting_certificate_overrides/new.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_breadcrumbs 'Exempting Certificate Override': green_lanes_exempting_certificate_overrides_path %>
+<%= govuk_breadcrumbs 'Exempting Certificate Override': green_lanes_exempting_overrides_path %>
 
 <h2>New Exempting Certificate Override</h2>
 
@@ -12,5 +12,5 @@
                          label: { text: 'Certificate Code' },
                          width: 'one-half' %>
 
-  <%= submit_and_back_buttons f, green_lanes_exempting_certificate_overrides_path %>
+  <%= submit_and_back_buttons f, green_lanes_exempting_overrides_path %>
 <% end %>

--- a/spec/factories/green_lanes/category_assessment_factory.rb
+++ b/spec/factories/green_lanes/category_assessment_factory.rb
@@ -23,5 +23,9 @@ FactoryBot.define do
     trait :with_theme do
       theme { { attributes: attributes_for(:green_lanes_theme) } }
     end
+
+    trait :with_measure_pagination do
+      measure_pagination { { attributes: attributes_for(:measure_pagination) } }
+    end
   end
 end

--- a/spec/factories/green_lanes/measure_pagination_factory.rb
+++ b/spec/factories/green_lanes/measure_pagination_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :measure_pagination, class: 'GreenLanes::MeasurePagination' do
+    total_pages               { 10 }
+    sequence(:current_page) { |n| n }
+    limit_value { 20 }
+  end
+end

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -1,7 +1,7 @@
 RSpec.describe GreenLanes::CategoryAssessmentsController do
   subject(:rendered_page) { create_user && make_request && response }
 
-  let(:category_assessment) { build :category_assessment, :with_theme }
+  let(:category_assessment) { build :category_assessment, :with_theme, :with_measure_pagination }
   let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
 
   before do
@@ -60,7 +60,7 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
 
   describe 'GET #edit' do
     before do
-      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}")
+      stub_api_request("/admin/green_lanes/category_assessments/#{category_assessment.id}?page=1")
         .and_return jsonapi_response(:category_assessment, category_assessment.attributes)
     end
 


### PR DESCRIPTION
### Jira link

[GL-735](https://transformuk.atlassian.net/browse/GL-735)

### What?

I have added/removed/altered:

- [ ] Added pagination to list of pseudo measures in category assessment edit page


### Why?

I am doing this because:

- Number of measure records cannot be handle without pagination
