### PR TITLE
GL-735: Admin UI: Paginate pseudo measures in CA edit page

### DIFF
--- a/app/controllers/green_lanes/update_notifications_controller.rb
+++ b/app/controllers/green_lanes/update_notifications_controller.rb
@@ -1,0 +1,25 @@
+module GreenLanes
+  class UpdateNotificationsController < AuthenticatedController
+    include XiOnly
+
+    before_action :disable_service_switching!
+    before_action :check_service
+    def index
+      @updates = GreenLanes::UpdateNotification.all(page: current_page).fetch
+    end
+
+    def edit
+      @update = GreenLanes::UpdateNotification.find(params[:id])
+    end
+
+    def update
+      @update = GreenLanes::UpdateNotification.find(params[:id])
+
+      if @update.valid? && @update.save
+        redirect_to green_lanes_update_notifications_path, notice: 'Notification updated'
+      else
+        render :edit
+      end
+    end
+  end
+end

--- a/app/models/green_lanes/update_notification.rb
+++ b/app/models/green_lanes/update_notification.rb
@@ -1,0 +1,17 @@
+module GreenLanes
+  class UpdateNotification
+    include Her::JsonApi::Model
+    use_api Her::XI_API
+    extend HerPaginatable
+
+    attributes :measure_type_id,
+               :regulation_id,
+               :regulation_role,
+               :status,
+               :measure_type_description,
+               :regulation_description,
+               :regulation_url
+
+    collection_path '/admin/green_lanes/update_notifications'
+  end
+end

--- a/app/views/green_lanes/update_notifications/edit.html.erb
+++ b/app/views/green_lanes/update_notifications/edit.html.erb
@@ -27,7 +27,7 @@
       <p><%= @update.regulation_description %></p>
       <% if @update.regulation_url.present? %>
         <p>
-          # braakeman:disable CheckLinkToHref
+          # brakeman:disable CheckLinkToHref
           <%= link_to 'Further information', @update.regulation_url, target: '_blank' %>
           # brakeman:enable CheckLinkToHref
         </p>

--- a/app/views/green_lanes/update_notifications/edit.html.erb
+++ b/app/views/green_lanes/update_notifications/edit.html.erb
@@ -1,0 +1,46 @@
+<%= govuk_breadcrumbs 'Update Notifications': green_lanes_update_notifications_path %>
+
+<h2>Update Notifications</h2>
+
+<div class="govuk-div--with-border">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h3 class="govuk-heading-s">Measure Type</h3>
+      <p><%= @update.measure_type_id %></p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h3 class="govuk-heading-s">Measure Type Description</h3>
+      <p><%= @update.measure_type_description %></p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h3 class="govuk-heading-s">Regulation</h3>
+      <p><%= @update.regulation_id %></p>
+    </div>
+  </div>
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
+      <h3 class="govuk-heading-s">Regulation Description</h3>
+      <p><%= @update.regulation_description %></p>
+      <% if @update.regulation_url.present? %>
+        <p>
+          <%= link_to 'Further information', @update.regulation_url, target: '_blank' %>
+        </p>
+      <% end %>
+    </div>
+  </div>
+</div>
+
+<hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+<h3>
+  Action taken for this data update
+</h3>
+<%= link_to 'Update',
+            green_lanes_update_notification_path(@update),
+            method: :patch,
+            class: 'govuk-button govuk-button--warning',
+            data: { confirm: "Are you sure?", disable: 'Working ...' } %>

--- a/app/views/green_lanes/update_notifications/edit.html.erb
+++ b/app/views/green_lanes/update_notifications/edit.html.erb
@@ -27,7 +27,9 @@
       <p><%= @update.regulation_description %></p>
       <% if @update.regulation_url.present? %>
         <p>
+          # braakeman:disable CheckLinkToHref
           <%= link_to 'Further information', @update.regulation_url, target: '_blank' %>
+          # brakeman:enable CheckLinkToHref
         </p>
       <% end %>
     </div>

--- a/app/views/green_lanes/update_notifications/edit.html.erb
+++ b/app/views/green_lanes/update_notifications/edit.html.erb
@@ -27,9 +27,7 @@
       <p><%= @update.regulation_description %></p>
       <% if @update.regulation_url.present? %>
         <p>
-          # brakeman:disable CheckLinkToHref
           <%= link_to 'Further information', @update.regulation_url, target: '_blank' %>
-          # brakeman:enable CheckLinkToHref
         </p>
       <% end %>
     </div>

--- a/app/views/green_lanes/update_notifications/index.html.erb
+++ b/app/views/green_lanes/update_notifications/index.html.erb
@@ -1,0 +1,34 @@
+<h2>
+  Green Lanes Update Notifications
+</h2>
+
+
+<% if @updates.any? %>
+  <table>
+    <thead>
+    <tr>
+      <th>Measure Type Id</th>
+      <th>Regulation Id</th>
+      <th>Regulation Role</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @updates.each do |update| %>
+      <tr id="<%= dom_id(update) %>">
+        <td><%= update.measure_type_id %></td>
+        <td><%= update.regulation_id %></td>
+        <td><%= update.regulation_role %></td>
+        <td>
+          <%= link_to 'Edit',
+                      edit_green_lanes_update_notification_path(update) %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+  <%= paginate @updates %>
+<% else %>
+  <div class="govuk-inset-text">
+    <p>No any Green Lanes Update Notifications</p>
+  </div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -60,6 +60,9 @@
       <%= header.with_navigation_item text: 'Exempting Overrides',
                                       href: green_lanes_exempting_overrides_path,
                                       active: active_nav_link?(/\/exempting_overrides/) %>
+      <%= header.with_navigation_item text: 'Update Notifications',
+                                      href: green_lanes_update_notifications_path,
+                                      active: active_nav_link?(/\/update_notifications/) %>
       <% end %>
     <% end %>
 

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -30,6 +30,39 @@
       "user_input": "TariffUpdate.find(params[:id]).file_presigned_url",
       "confidence": "Weak",
       "note": ""
+    },
+    {
+      "warning_type": "Cross-Site Scripting",
+      "warning_code": 4,
+      "fingerprint": "fa3268e55ada78bf2d83b6129e983c03d2210e416cd7191fe515daa83f3414dd",
+      "check_name": "LinkToHref",
+      "message": "Potentially unsafe model attribute in `link_to` href",
+      "file": "app/views/green_lanes/update_notifications/edit.html.erb",
+      "line": 30,
+      "link": "https://brakemanscanner.org/docs/warning_types/link_to_href",
+      "code": "link_to(\"Further information\", GreenLanes::UpdateNotification.find(params[:id]).regulation_url, :target => \"_blank\")",
+      "render_path": [
+        {
+          "type": "controller",
+          "class": "GreenLanes::UpdateNotificationsController",
+          "method": "edit",
+          "line": 13,
+          "file": "app/controllers/green_lanes/update_notifications_controller.rb",
+          "rendered": {
+            "name": "green_lanes/update_notifications/edit",
+            "file": "app/views/green_lanes/update_notifications/edit.html.erb"
+          }
+        }
+      ],
+      "location": {
+        "type": "template",
+        "template": "green_lanes/update_notifications/edit"
+      },
+      "user_input": "GreenLanes::UpdateNotification.find(params[:id]).regulation_url",
+      "confidence": "Weak",
+      "cwe_id": [
+        79
+      ]
     }
   ],
   "updated": "2022-05-30 15:54:11 +0100",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -75,6 +75,7 @@ Rails.application.routes.draw do
     resources :exempting_additional_code_overrides, only: %i[new create destroy]
     resources :exemptions, only: %i[index new create edit update destroy]
     resources :measures, only: %i[index destroy]
+    resources :update_notifications, only: %i[index edit update]
   end
 
   resources :tariff_updates, only: %i[index show] do

--- a/spec/factories/green_lanes/update_notification_factory.rb
+++ b/spec/factories/green_lanes/update_notification_factory.rb
@@ -1,0 +1,10 @@
+FactoryBot.define do
+  factory :update_notification, class: 'GreenLanes::UpdateNotification' do
+    sequence(:id) { |n| n }
+    measure_type_id { '464' }
+    regulation_id { 'R9700880' }
+    regulation_role { '3' }
+    measure_type_description { 'Measure Description' }
+    regulation_description { 'Regulation Description' }
+  end
+end

--- a/spec/requests/green_lanes/update_notifications_controller_spec.rb
+++ b/spec/requests/green_lanes/update_notifications_controller_spec.rb
@@ -1,0 +1,49 @@
+RSpec.describe GreenLanes::ExemptionsController do
+  subject(:rendered_page) { create_user && make_request && response }
+
+  let(:update) { build :update_notification }
+  let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
+
+  before do
+    allow(TradeTariffAdmin::ServiceChooser).to receive(:service_choice).and_return 'xi'
+  end
+
+  describe 'GET #index' do
+    before do
+      stub_api_request('/admin/green_lanes/update_notifications?page=1', backend: 'xi').and_return \
+        jsonapi_response :update, attributes_for_list(:update_notification, 3)
+    end
+
+    let(:make_request) { get green_lanes_update_notifications_path }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.not_to include 'div.current-service' }
+  end
+
+  describe 'GET #edit' do
+    before do
+      stub_api_request("/admin/green_lanes/update_notifications/#{update.id}")
+        .and_return jsonapi_response(:update, update.attributes)
+    end
+
+    let(:make_request) { get edit_green_lanes_update_notification_path(update) }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.not_to include 'div.current-service' }
+  end
+
+  describe 'PATCH #update' do
+    before do
+      stub_api_request("/admin/green_lanes/update_notifications/#{update.id}")
+        .and_return jsonapi_response(:update, update.attributes)
+
+      stub_api_request("/admin/green_lanes/update_notifications/#{update.id}", :patch)
+        .and_return patch_response
+    end
+
+    let :make_request do
+      patch green_lanes_exemption_path(exemption),
+            params: { exemption: exemption.attributes.merge(description: new_desc) }
+    end
+  end
+end

--- a/spec/requests/green_lanes/update_notifications_controller_spec.rb
+++ b/spec/requests/green_lanes/update_notifications_controller_spec.rb
@@ -31,19 +31,4 @@ RSpec.describe GreenLanes::ExemptionsController do
     it { is_expected.to have_http_status :success }
     it { is_expected.not_to include 'div.current-service' }
   end
-
-  describe 'PATCH #update' do
-    before do
-      stub_api_request("/admin/green_lanes/update_notifications/#{update.id}")
-        .and_return jsonapi_response(:update, update.attributes)
-
-      stub_api_request("/admin/green_lanes/update_notifications/#{update.id}", :patch)
-        .and_return patch_response
-    end
-
-    let :make_request do
-      patch green_lanes_exemption_path(exemption),
-            params: { exemption: exemption.attributes.merge(description: new_desc) }
-    end
-  end
 end


### PR DESCRIPTION
### Jira link

[GL-786](https://transformuk.atlassian.net/browse/GL-786)

### What?

I have added/removed/altered:

- [ ] Added admin api to manage green lanes update notifications

### Why?

I am doing this because:

- Admin user should be able to see green lanes data updates and take a action for them