### PR TITLE
GL-785: Enable notifications component to surface what data expired

### DIFF
--- a/app/models/green_lanes/update_notification.rb
+++ b/app/models/green_lanes/update_notification.rb
@@ -13,5 +13,19 @@ module GreenLanes
                :regulation_url
 
     collection_path '/admin/green_lanes/update_notifications'
+
+    def status_label
+      case status
+      when 0
+        'Created'
+      when 1
+        'Updated'
+      when 2
+        'Expired'
+      else
+        ''
+      end
+    end
+
   end
 end

--- a/app/views/green_lanes/update_notifications/index.html.erb
+++ b/app/views/green_lanes/update_notifications/index.html.erb
@@ -10,6 +10,7 @@
       <th>Measure Type Id</th>
       <th>Regulation Id</th>
       <th>Regulation Role</th>
+      <th>Status</th>
     </tr>
     </thead>
     <tbody>
@@ -18,6 +19,7 @@
         <td><%= update.measure_type_id %></td>
         <td><%= update.regulation_id %></td>
         <td><%= update.regulation_role %></td>
+        <td><%= update.status_label %></td>
         <td>
           <%= link_to 'Edit',
                       edit_green_lanes_update_notification_path(update) %>


### PR DESCRIPTION
### Jira link

[GL-785](https://transformuk.atlassian.net/browse/GL-785)

### What?

I have added/removed/altered:

- [ ] Added updated and expired measures to green lanes update notifications

### Why?

I am doing this because:

- We need to let HMRC know about updates to take relevant actions