### PR TITLE
BAU: Remove flaky notify-release job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -179,10 +179,6 @@ jobs:
       - image: cimg/ruby:3.3.4
     steps:
       - checkout
-      - tariff/notify-production-release:
-          app-name: Admin
-          slack-channel: trade_tariff
-          release-tag: $CIRCLE_TAG
 
 workflows:
   version: 2


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Removed notify-release job

### Why?

I am doing this because:

- This was always flaky and duplicates existing release notes and slack alerts
