### PR TITLE
GL-1065: Implement Sorting Functionality on Category Assessments Page

### DIFF
--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -12,6 +12,6 @@ module Sortable
   end
 
   def sort_direction
-    %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+    %w[asc desc].include?(params[:direction]) ? params[:direction] : 'asc'
   end
 end

--- a/app/controllers/concerns/sortable.rb
+++ b/app/controllers/concerns/sortable.rb
@@ -1,0 +1,17 @@
+module Sortable
+  extend ActiveSupport::Concern
+
+  included do
+    helper_method :sort_column, :sort_direction
+  end
+
+  private
+
+  def sort_column
+    params[:sort]
+  end
+
+  def sort_direction
+    %w[asc desc].include?(params[:direction]) ? params[:direction] : "asc"
+  end
+end

--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -128,8 +128,8 @@ module GreenLanes
             filters: params[:filters].to_h,
             page: current_page,
             sort: params[:sort],
-            direction: params[:direction]
-          }
+            direction: params[:direction],
+          },
       }
     end
 
@@ -138,7 +138,7 @@ module GreenLanes
       if params[:exemption_code].present?
         filters.merge!(exemption_code: params[:exemption_code])
       else
-        params[:exemption_code] = params[:filters][:exemption_code]
+        params[:exemption_code] = params.dig(:filters, :exemption_code)
       end
       params[:filters] = ActionController::Parameters.new(filters).permit(:exemption_code)
     end

--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -1,11 +1,13 @@
 module GreenLanes
   class CategoryAssessmentsController < AuthenticatedController
+    include Sortable
     include XiOnly
 
     before_action :disable_service_switching!
     before_action :check_service
     def index
-      @category_assessments = GreenLanes::CategoryAssessment.all(query: { exemption_code: params[:exemption_code], page: current_page }).fetch
+      merge_filters
+      @category_assessments = GreenLanes::CategoryAssessment.all(search_params).fetch
     end
 
     def new
@@ -117,6 +119,28 @@ module GreenLanes
       @category_assessment_exemption = GreenLanes::CategoryAssessmentExemption.new(category_assessment_id: @category_assessment.id)
 
       @measure = GreenLanes::Measure.new(category_assessment_id: @category_assessment.id)
+    end
+
+    def search_params
+      {
+        query:
+          {
+            filters: params[:filters].to_h,
+            page: current_page,
+            sort: params[:sort],
+            direction: params[:direction]
+          }
+      }
+    end
+
+    def merge_filters
+      filters = params.fetch(:filters, {}).permit(:exemption_code).to_h
+      if params[:exemption_code].present?
+        filters.merge!(exemption_code: params[:exemption_code])
+      else
+        params[:exemption_code] = params[:filters][:exemption_code]
+      end
+      params[:filters] = ActionController::Parameters.new(filters).permit(:exemption_code)
     end
 
     def ca_params

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,4 +3,10 @@ module ApplicationHelper
     (activator.is_a?(String) && request.path.start_with?(activator)) ||
       (activator.is_a?(Regexp) && request.path =~ activator)
   end
+
+  def sortable(column, title = nil)
+    title ||= column.titleize
+    direction = (column == sort_column && sort_direction == "asc") ? "desc" : "asc"
+    link_to title, { sort: column, direction: direction, page: params[:page], filters: params[:filters] }
+  end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -6,7 +6,7 @@ module ApplicationHelper
 
   def sortable(column, title = nil)
     title ||= column.titleize
-    direction = (column == sort_column && sort_direction == "asc") ? "desc" : "asc"
-    link_to title, { sort: column, direction: direction, page: params[:page], filters: params[:filters] }
+    direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
+    link_to title, { sort: column, direction:, page: params[:page], filters: params[:filters] }
   end
 end

--- a/app/views/green_lanes/category_assessments/index.html.erb
+++ b/app/views/green_lanes/category_assessments/index.html.erb
@@ -11,7 +11,7 @@
     </legend>
     <div class="govuk-form-group">
       <%= form.label :exemption_code, "Green Lanes Exemption Code", class: "govuk-label" %>
-      <%= form.text_field :exemption_code, class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
+      <%= form.text_field :exemption_code, value: params[:exemption_code], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
     </div>
 
     <div class="govuk-form-group">
@@ -25,10 +25,10 @@
     <thead>
     <tr>
       <th>ID</th>
-      <th>Measure type id</th>
-      <th>Regulation id</th>
-      <th>Regulation role</th>
-      <th>Theme</th>
+      <th><%= sortable "measure_type_id", "Measure type id" %></th>
+      <th><%= sortable "regulation_id", "Regulation id" %></th>
+      <th><%= sortable "regulation_role", "Regulation role" %></th>
+      <th><%= sortable "theme_id", "Theme" %></th>
       <th>Action</th>
     </tr>
     </thead>

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
 
   describe 'GET #index' do
     before do
-      stub_api_request('/admin/green_lanes/category_assessments?query[filters]&query[page]=1&query[sort]&query[direction]', backend: 'xi').and_return \
+      stub_api_request('/admin/green_lanes/category_assessments?query[page]=1&query[sort]&query[direction]', backend: 'xi').and_return \
         jsonapi_response :category_assessments, attributes_for_list(:category_assessment, 3, :with_theme)
     end
 
-    let(:make_request) { get green_lanes_category_assessments_path, params: {filters: {}} }
+    let(:make_request) { get green_lanes_category_assessments_path, params: { filters: {} } }
 
     it { is_expected.to have_http_status :success }
     it { is_expected.not_to include 'div.current-service' }

--- a/spec/requests/green_lanes/category_assessments_controller_spec.rb
+++ b/spec/requests/green_lanes/category_assessments_controller_spec.rb
@@ -14,11 +14,11 @@ RSpec.describe GreenLanes::CategoryAssessmentsController do
 
   describe 'GET #index' do
     before do
-      stub_api_request('/admin/green_lanes/category_assessments?query[exemption_code]&query[page]=1', backend: 'xi').and_return \
+      stub_api_request('/admin/green_lanes/category_assessments?query[filters]&query[page]=1&query[sort]&query[direction]', backend: 'xi').and_return \
         jsonapi_response :category_assessments, attributes_for_list(:category_assessment, 3, :with_theme)
     end
 
-    let(:make_request) { get green_lanes_category_assessments_path }
+    let(:make_request) { get green_lanes_category_assessments_path, params: {filters: {}} }
 
     it { is_expected.to have_http_status :success }
     it { is_expected.not_to include 'div.current-service' }


### PR DESCRIPTION
### Jira link

[GL-1065](https://transformuk.atlassian.net/browse/GL-1065)

### What?

I have added/removed/altered:

- [ ] Sorting functionality to Category Assessment tables

### Why?

I am doing this because:

- User needs to sort the result table by different attributes
