### PR TITLE
HMRC-142: Implement Filtering Options on Category Assessments Page

### DIFF
--- a/app/controllers/green_lanes/category_assessments_controller.rb
+++ b/app/controllers/green_lanes/category_assessments_controller.rb
@@ -8,6 +8,7 @@ module GreenLanes
     def index
       merge_filters
       @category_assessments = GreenLanes::CategoryAssessment.all(search_params).fetch
+      @themes = GreenLanes::Theme.all.fetch
     end
 
     def new
@@ -133,14 +134,44 @@ module GreenLanes
       }
     end
 
-    def merge_filters
+    def merge_filter
       filters = params.fetch(:filters, {}).permit(:exemption_code).to_h
+
       if params[:exemption_code].present?
         filters.merge!(exemption_code: params[:exemption_code])
       else
         params[:exemption_code] = params.dig(:filters, :exemption_code)
       end
+
       params[:filters] = ActionController::Parameters.new(filters).permit(:exemption_code)
+    end
+
+    def merge_filters
+      filters = params.fetch(:filters, {}).permit(
+        :exemption_code,
+        :measure_type_id,
+        :regulation_id,
+        :regulation_role,
+        :theme_id).to_h
+
+      filter_keys = %i[exemption_code measure_type_id regulation_id regulation_role theme_id]
+      filter_keys.each { |filter_key| add_filter(filters, params, filter_key)}
+
+      params[:filters] = ActionController::Parameters.new(filters).permit(
+        :exemption_code,
+        :measure_type_id,
+        :regulation_id,
+        :regulation_role,
+        :theme_id
+      )
+    end
+
+    def add_filter(filters, params, filter_key)
+      if params[filter_key].present?
+        filters.merge!(filter_key => params[filter_key])
+      else
+        params[filter_key] = params.dig(:filters, filter_key)
+      end
     end
 
     def ca_params

--- a/app/views/green_lanes/category_assessments/index.html.erb
+++ b/app/views/green_lanes/category_assessments/index.html.erb
@@ -12,6 +12,14 @@
     <div class="govuk-form-group">
       <%= form.label :exemption_code, "Green Lanes Exemption Code", class: "govuk-label" %>
       <%= form.text_field :exemption_code, value: params[:exemption_code], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
+      <%= form.label :measure_type_id, "Measure Type ID", class: "govuk-label" %>
+      <%= form.text_field :measure_type_id, value: params[:measure_type_id], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
+      <%= form.label :regulation_id, "Regulation ID", class: "govuk-label" %>
+      <%= form.text_field :regulation_id, value: params[:regulation_id], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
+      <%= form.label :regulation_role, "Regulation Role", class: "govuk-label" %>
+      <%= form.text_field :regulation_role, value: params[:regulation_role], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
+      <%= form.label :theme_id, "Theme", class: "govuk-label" %>
+      <%= form.collection_select :theme_id, @themes, :id, :label, {prompt: "Select a Theme", selected: params[:theme_id]}, {class: "govuk-select govuk-!-width-one-third"}%>
     </div>
 
     <div class="govuk-form-group">

--- a/app/views/green_lanes/category_assessments/index.html.erb
+++ b/app/views/green_lanes/category_assessments/index.html.erb
@@ -21,7 +21,7 @@
           <%= form.label :regulation_role, "Regulation Role", class: "govuk-label" %>
           <%= form.text_field :regulation_role, value: params[:regulation_role], class: "govuk-input", id: "search-term"%>
           <%= form.label :theme_id, "Theme", class: "govuk-label" %>
-          <%= form.collection_select :theme_id, @themes, :id, :label, {prompt: "Select a Theme", selected: params[:theme_id]}, {class: "govuk-select govuk-!-width-one-third"}%>
+          <%= form.collection_select :theme_id, [OpenStruct.new(id: nil, label: "Select a Theme")] + @themes, :id, :label, {selected: params[:theme_id]}, {class: "govuk-select govuk-!-width-one-third"}%>
         </div>
 
         <div class="govuk-form-group">

--- a/app/views/green_lanes/category_assessments/index.html.erb
+++ b/app/views/green_lanes/category_assessments/index.html.erb
@@ -4,62 +4,68 @@
 
 <%= link_to 'Add a Category Assessment', new_green_lanes_category_assessment_path, class: 'govuk-button' %>
 
-<%= form_with url: green_lanes_category_assessments_path, method: :get, class: "govuk-form-group" do |form| %>
-  <fieldset class="govuk-fieldset">
-    <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
-      Search Category Assessments
-    </legend>
-    <div class="govuk-form-group">
-      <%= form.label :exemption_code, "Green Lanes Exemption Code", class: "govuk-label" %>
-      <%= form.text_field :exemption_code, value: params[:exemption_code], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
-      <%= form.label :measure_type_id, "Measure Type ID", class: "govuk-label" %>
-      <%= form.text_field :measure_type_id, value: params[:measure_type_id], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
-      <%= form.label :regulation_id, "Regulation ID", class: "govuk-label" %>
-      <%= form.text_field :regulation_id, value: params[:regulation_id], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
-      <%= form.label :regulation_role, "Regulation Role", class: "govuk-label" %>
-      <%= form.text_field :regulation_role, value: params[:regulation_role], class: "govuk-input govuk-!-width-one-third", id: "search-term", width: 'one-third'%>
-      <%= form.label :theme_id, "Theme", class: "govuk-label" %>
-      <%= form.collection_select :theme_id, @themes, :id, :label, {prompt: "Select a Theme", selected: params[:theme_id]}, {class: "govuk-select govuk-!-width-one-third"}%>
-    </div>
+<div id="ca-search-container">
+  <div id="search-section">
+    <%= form_with url: green_lanes_category_assessments_path, method: :get, class: "govuk-form-group" do |form| %>
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--m">
+          Search Category Assessments
+        </legend>
+        <div class="govuk-form-group">
+          <%= form.label :exemption_code, "Green Lanes Exemption Code", class: "govuk-label" %>
+          <%= form.text_field :exemption_code, value: params[:exemption_code], class: "govuk-input", id: "search-term"%>
+          <%= form.label :measure_type_id, "Measure Type ID", class: "govuk-label" %>
+          <%= form.text_field :measure_type_id, value: params[:measure_type_id], class: "govuk-input", id: "search-term"%>
+          <%= form.label :regulation_id, "Regulation ID", class: "govuk-label" %>
+          <%= form.text_field :regulation_id, value: params[:regulation_id], class: "govuk-input", id: "search-term"%>
+          <%= form.label :regulation_role, "Regulation Role", class: "govuk-label" %>
+          <%= form.text_field :regulation_role, value: params[:regulation_role], class: "govuk-input", id: "search-term"%>
+          <%= form.label :theme_id, "Theme", class: "govuk-label" %>
+          <%= form.collection_select :theme_id, @themes, :id, :label, {prompt: "Select a Theme", selected: params[:theme_id]}, {class: "govuk-select govuk-!-width-one-third"}%>
+        </div>
 
-    <div class="govuk-form-group">
-      <%= form.submit "Search", class: "govuk-button" %>
-    </div>
-  </fieldset>
-<% end %>
-
-<% if @category_assessments.any? %>
-  <table>
-    <thead>
-    <tr>
-      <th>ID</th>
-      <th><%= sortable "measure_type_id", "Measure type id" %></th>
-      <th><%= sortable "regulation_id", "Regulation id" %></th>
-      <th><%= sortable "regulation_role", "Regulation role" %></th>
-      <th><%= sortable "theme_id", "Theme" %></th>
-      <th>Action</th>
-    </tr>
-    </thead>
-    <tbody>
-    <% @category_assessments.each do |category| %>
-      <tr id="<%= dom_id(category) %>">
-        <td><%= category.id %></td>
-        <td><%= category.measure_type_id %></td>
-        <td><%= category.regulation_id %></td>
-        <td><%= category.regulation_role %></td>
-        <td><%= category.theme.code %></td>
-        <td>
-          <%= link_to 'Edit',
-                      edit_green_lanes_category_assessment_path(category) %>
-        </td>
-      </tr>
+        <div class="govuk-form-group">
+          <%= form.submit "Search", class: "govuk-button" %>
+        </div>
+      </fieldset>
     <% end %>
-    </tbody>
-  </table>
-
-  <%= paginate @category_assessments %>
-<% else %>
-  <div class="govuk-inset-text">
-    <p>No Category Assessments</p>
   </div>
-<% end %>
+
+  <div id="result-section">
+    <% if @category_assessments.any? %>
+      <table>
+        <thead>
+        <tr>
+          <th>ID</th>
+          <th><%= sortable "measure_type_id", "Measure type id" %></th>
+          <th><%= sortable "regulation_id", "Regulation id" %></th>
+          <th><%= sortable "regulation_role", "Regulation role" %></th>
+          <th><%= sortable "theme_id", "Theme" %></th>
+          <th>Action</th>
+        </tr>
+        </thead>
+        <tbody>
+        <% @category_assessments.each do |category| %>
+          <tr id="<%= dom_id(category) %>">
+            <td><%= category.id %></td>
+            <td><%= category.measure_type_id %></td>
+            <td><%= category.regulation_id %></td>
+            <td><%= category.regulation_role %></td>
+            <td><%= category.theme.code %></td>
+            <td>
+              <%= link_to 'Edit',
+                          edit_green_lanes_category_assessment_path(category) %>
+            </td>
+          </tr>
+        <% end %>
+        </tbody>
+      </table>
+
+      <%= paginate @category_assessments %>
+    <% else %>
+      <div class="govuk-inset-text">
+        <p>No Category Assessments</p>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -81,3 +81,16 @@ $govuk-image-url-function: frontend-image-url;
     font-family:courier, monospace;
   }
 }
+
+#ca-search-container {
+  display: flex;
+}
+
+#search-section {
+  flex: 1;
+}
+
+#result-section {
+  flex: 4;
+  padding: 20px;
+}


### PR DESCRIPTION
### Jira link

[HMRC-142](https://transformuk.atlassian.net/browse/HMRC-142)

### What?

I have added/removed/altered:

- [ ] Added 'Regulation ID', 'Measure Type', 'Theme', and 'Regulation Role' filters to CA search


### Why?

I am doing this because:

- Admin users need to filter the CA list by these fields