### PR TITLE
HMRC-683 Repoint to central backend

### DIFF
--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -1,8 +1,8 @@
 locals {
   service = "admin"
   api_service_backend_url_options = {
-    uk = "http://backend-admin-uk.tariff.internal:8080"
-    xi = "http://backend-admin-xi.tariff.internal:8080"
+    uk = "http://backend-uk.tariff.internal:8080"
+    xi = "http://backend-xi.tariff.internal:8080"
   }
 
   signon_url = var.environment == "production" ? "https://signon.publishing.service.gov.uk" : "https://signon.${var.base_domain}"


### PR DESCRIPTION
### Jira link

HMRC-683

### What?

Historically `backend-admin-uk/xi` had a read-write connection to the database, and `backend-uk/xi` was read-only.  For a while now `backend` has had read/write making the extra `backend-admin` deployments unnecessary.

This PR points the admin straight at the regular backend.

Requires https://github.com/trade-tariff/trade-tariff-backend/pull/2117