### PR TITLE
HMRC-941: Adds simple authentication scheme

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,6 +1,7 @@
 ADMIN_HOST='http://localhost:3000'
 API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000","xi":"http://localhost:3000" }
 AUTHENTICATE_WITH_SSO=false
+BASIC_PASSWORD=dev123
 BEARER_TOKEN=tariff-api-test-token
 PORT=3003
 SERVICE_DEFAULT=uk

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -8,6 +8,19 @@ class AuthenticatedController < ApplicationController
       # Layout and view comes from GDS::SSO::ControllerMethods
       render 'authorisations/unauthorised', layout: 'unauthorised', status: :forbidden, locals: { message: e.message }
     end
+
+  else
+    before_action :require_authentication, if: :require_auth?
+
+    def require_auth?
+      TradeTariffAdmin.basic_authentication?
+    end
+
+    def require_authentication
+      unless session[:authenticated]
+        redirect_to new_basic_session_path(return_url: request.fullpath)
+      end
+    end
   end
 
   protect_from_forgery with: :exception

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -11,9 +11,8 @@ class AuthenticatedController < ApplicationController
 
   else
     before_action :require_authentication, if: :require_auth?
-
     def require_auth?
-      TradeTariffAdmin.basic_authentication?
+      TradeTariffAdmin.basic_session_authentication?
     end
 
     def require_authentication

--- a/app/controllers/basic_sessions_controller.rb
+++ b/app/controllers/basic_sessions_controller.rb
@@ -1,5 +1,5 @@
 class BasicSessionsController < AuthenticatedController
-  skip_before_action :require_authentication, only: %i[new create] if TradeTariffAdmin.basic_authentication?
+  skip_before_action :require_authentication, only: %i[new create] if TradeTariffAdmin.basic_session_authentication?
 
   def new
     @basic_session = BasicSession.new

--- a/app/controllers/basic_sessions_controller.rb
+++ b/app/controllers/basic_sessions_controller.rb
@@ -1,0 +1,23 @@
+class BasicSessionsController < AuthenticatedController
+  skip_before_action :require_authentication, only: %i[new create] if TradeTariffAdmin.basic_authentication?
+
+  def new
+    @basic_session = BasicSession.new
+    @basic_session.return_url = params[:return_url] || root_path
+  end
+
+  def create
+    @basic_session = BasicSession.new(basic_session_params)
+
+    if @basic_session.valid?
+      session[:authenticated] = true
+      redirect_to @basic_session.return_url
+    else
+      render :new
+    end
+  end
+
+  def basic_session_params
+    params.require(:basic_session).permit(:return_url, :password)
+  end
+end

--- a/app/models/basic_session.rb
+++ b/app/models/basic_session.rb
@@ -1,0 +1,8 @@
+class BasicSession
+  include ActiveModel::Model
+
+  attr_accessor :return_url, :password
+
+  validates :return_url, presence: true
+  validates :password, inclusion: { in: [TradeTariffAdmin.basic_password] }
+end

--- a/app/models/basic_session.rb
+++ b/app/models/basic_session.rb
@@ -4,5 +4,5 @@ class BasicSession
   attr_accessor :return_url, :password
 
   validates :return_url, presence: true
-  validates :password, inclusion: { in: [TradeTariffAdmin.basic_password] }
+  validates :password, inclusion: { in: [TradeTariffAdmin.basic_session_password] }
 end

--- a/app/views/basic_sessions/new.html.erb
+++ b/app/views/basic_sessions/new.html.erb
@@ -1,0 +1,37 @@
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper" id="main-content" role="main">
+    <% if flash[:error] %>
+      <div class="govuk-error-summary">
+        <h2 class="govuk-error-summary__title">There was a problem</h2>
+        <div class="govuk-error-summary__body">
+          <p><%= flash[:error] %></p>
+        </div>
+      </div>
+    <% end %>
+
+    <%= govuk_form_for @basic_session, method: :post do |form| %>
+      <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds-from-desktop">
+          <h1 class="govuk-heading-xl">
+            This is a non-production admin application used for validation, only.
+          </h1>
+
+          <p>
+            If you need access to either this or the production application, please
+            <a href="mailto:hmrc-trade-tariff-support-g@digital.hmrc.gov.uk">contact</a>
+            the team.
+          </p>
+
+          <%= form.govuk_password_field :password,
+                                        label: { text: 'Password' },
+                                        class: 'govuk-input--width-10' %>
+
+
+	  <%= form.hidden_field :return_url, value: @basic_session.return_url %>
+
+          <%= form.govuk_submit 'Continue' %>
+        </div>
+      </div>
+    <% end %>
+  </main>
+</div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -76,3 +76,7 @@ en:
             order_number:
               not_a_number: Enter a valid quota order number
               wrong_length: Enter a valid quota order number
+        basic_session:
+          attributes:
+            password:
+              inclusion: "Incorrect password"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -98,7 +98,7 @@ Rails.application.routes.draw do
   match '/500', to: 'errors#internal_server_error', via: :all
   match '/501', to: 'errors#not_implemented', via: :all
 
-  if TradeTariffAdmin.basic_authentication?
+  if TradeTariffAdmin.basic_session_authentication?
     resources :basic_sessions, only: %i[new create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,4 +97,8 @@ Rails.application.routes.draw do
   match '/422', to: 'errors#unprocessable_entity', via: :all
   match '/500', to: 'errors#internal_server_error', via: :all
   match '/501', to: 'errors#not_implemented', via: :all
+
+  if TradeTariffAdmin.basic_authentication?
+    resources :basic_sessions, only: %i[new create]
+  end
 end

--- a/lib/trade_tariff_admin.rb
+++ b/lib/trade_tariff_admin.rb
@@ -18,7 +18,15 @@ module TradeTariffAdmin
     end
 
     def authenticate_with_sso?
-      ENV.fetch('AUTHENTICATE_WITH_SSO', 'true') == 'true'
+      @authenticate_with_sso ||= ENV.fetch('AUTHENTICATE_WITH_SSO', 'true') == 'true'
+    end
+
+    def basic_authentication?
+      @basic_authentication ||= !authenticate_with_sso? && basic_password.present?
+    end
+
+    def basic_password
+      @basic_password ||= ENV['BASIC_PASSWORD']
     end
   end
 end

--- a/lib/trade_tariff_admin.rb
+++ b/lib/trade_tariff_admin.rb
@@ -21,12 +21,12 @@ module TradeTariffAdmin
       @authenticate_with_sso ||= ENV.fetch('AUTHENTICATE_WITH_SSO', 'true') == 'true'
     end
 
-    def basic_authentication?
-      @basic_authentication ||= !authenticate_with_sso? && basic_password.present?
+    def basic_session_authentication?
+      @basic_session_authentication ||= !authenticate_with_sso? && basic_session_password.present?
     end
 
-    def basic_password
-      @basic_password ||= ENV['BASIC_PASSWORD']
+    def basic_session_password
+      @basic_session_password ||= ENV['BASIC_PASSWORD']
     end
   end
 end


### PR DESCRIPTION
### Jira link

![image](https://github.com/user-attachments/assets/8a432c9c-86c2-4a7e-bf12-b446ea61b609)

[HMRC-941](https://transformuk.atlassian.net/browse/HMRC-941)

### What?

I have added/removed/altered:

- [x] Added basic authentication scheme for the development and staging aws environments
- [x] Enabled this in local development using a dev123 password

### Why?

The plan is that:

1. local development, the development and staging aws-hosted apps will use this
2. production will use SSO using the signonotron2 app that GDS host (for now)
