### PR TITLE
HMRC-941: Support admin validations in e2e tests

### DIFF
--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -124,11 +124,13 @@ jobs:
           ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
 
   post-deploy:
-    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     needs: deploy
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     with:
       test-url: "https://dev.trade-tariff.service.gov.uk"
-      ref: main
+      admin-test-url: "https://admin.dev.trade-tariff.service.gov.uk"
+    secrets:
+      basic_password: ${{ secrets.BASIC_PASSWORD }}
 
   notifications:
       runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -64,7 +64,6 @@ jobs:
     needs: deploy
     with:
       test-url: "https://www.trade-tariff.service.gov.uk"
-      ref: main
 
   notifications:
       runs-on: ubuntu-latest

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -47,11 +47,14 @@ jobs:
           ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
 
   post-deploy:
-    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     needs: deploy
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/e2e-tests.yml@main
     with:
       test-url: "https://staging.trade-tariff.service.gov.uk"
-      ref: main
+      admin-test-url: "https://admin.staging.trade-tariff.service.gov.uk"
+    secrets:
+      basic_password: ${{ secrets.BASIC_PASSWORD }}
+
 
   notifications:
       runs-on: ubuntu-latest

--- a/Gemfile
+++ b/Gemfile
@@ -67,6 +67,7 @@ group :test do
   gem 'rails-controller-testing'
   gem 'rspec_junit_formatter'
   gem 'rspec-rails'
+  gem 'rspec-rebound'
   gem 'shoulda-matchers'
   gem 'simplecov'
   gem 'webmock'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -629,6 +629,8 @@ GEM
       rspec-expectations (~> 3.13)
       rspec-mocks (~> 3.13)
       rspec-support (~> 3.13)
+    rspec-rebound (0.2.1)
+      rspec-core (~> 3.3)
     rspec-support (3.13.2)
     rspec_junit_formatter (0.6.0)
       rspec-core (>= 2, < 4, != 2.12.0)
@@ -781,6 +783,7 @@ DEPENDENCIES
   responders
   routing-filter!
   rspec-rails
+  rspec-rebound
   rspec_junit_formatter
   rubocop-govuk
   ruby-lsp-rails

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,7 @@
 ENV['RAILS_ENV'] ||= 'test'
 
 require 'simplecov'
+require 'rspec/rebound'
 
 SimpleCov.start 'rails'
 SimpleCov.formatters = SimpleCov::Formatter::HTMLFormatter
@@ -43,4 +44,8 @@ RSpec.configure do |config|
       example.run
     end
   end
+
+  config.verbose_retry = true
+  config.display_try_failure_messages = true
+  config.around { |ex| ex.run_with_retry retry: 3 }
 end


### PR DESCRIPTION
### Jira link

[HMRC-941](https://transformuk.atlassian.net/browse/HMRC-941)

### What?

I have added/removed/altered:

- [x] Support admin validations in e2e tests

### Why?

I am doing this because:

- This is needed since we're now testing the admin apps in e2e tests
