### PR TITLE
HMRC-950: Enables continuous deployments of the admin application

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -1,9 +1,11 @@
 name: Deploy to production
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - 'Deploy to staging'
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       ref:
@@ -35,6 +37,7 @@ jobs:
 
   deploy:
     environment: production
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     needs: build
     steps:


### PR DESCRIPTION
### Jira link

[HMRC-950](https://transformuk.atlassian.net/browse/HMRC-950)

### What?

I have added/removed/altered:

- [x] Added workflow_run to the production deployments

### Why?

I am doing this because:

- This enables automatic deploys to production behind the new admin specs
