### PR TITLE
BAU: Refactor auth types into concern and add `current_user`

### DIFF
--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,6 +1,6 @@
 class AuthenticatedController < ApplicationController
   if TradeTariffAdmin.authenticate_with_sso?
-    include SSOAuth
+    include SsoAuth
   else
     include BasicSessionAuth
   end

--- a/app/controllers/authenticated_controller.rb
+++ b/app/controllers/authenticated_controller.rb
@@ -1,25 +1,8 @@
 class AuthenticatedController < ApplicationController
   if TradeTariffAdmin.authenticate_with_sso?
-    include Pundit::Authorization
-    include GDS::SSO::ControllerMethods
-    prepend_before_action :authenticate_user!
-
-    rescue_from Pundit::NotAuthorizedError do |e|
-      # Layout and view comes from GDS::SSO::ControllerMethods
-      render 'authorisations/unauthorised', layout: 'unauthorised', status: :forbidden, locals: { message: e.message }
-    end
-
+    include SSOAuth
   else
-    before_action :require_authentication, if: :require_auth?
-    def require_auth?
-      TradeTariffAdmin.basic_session_authentication?
-    end
-
-    def require_authentication
-      unless session[:authenticated]
-        redirect_to new_basic_session_path(return_url: request.fullpath)
-      end
-    end
+    include BasicSessionAuth
   end
 
   protect_from_forgery with: :exception

--- a/app/controllers/concerns/basic_session_auth.rb
+++ b/app/controllers/concerns/basic_session_auth.rb
@@ -1,0 +1,25 @@
+module BasicSessionAuth
+  extend ActiveSupport::Concern
+
+  included do
+    before_action :require_authentication, if: :require_auth?
+    def require_auth?
+      TradeTariffAdmin.basic_session_authentication?
+    end
+
+    def require_authentication
+      unless session[:authenticated]
+        redirect_to new_basic_session_path(return_url: request.fullpath)
+      end
+    end
+
+    def current_user
+      @current_user ||= begin
+        user = User.new
+        user.name = 'tariff'
+        user.id = 'tariff'
+        user
+      end
+    end
+  end
+end

--- a/app/controllers/concerns/sso_auth.rb
+++ b/app/controllers/concerns/sso_auth.rb
@@ -1,4 +1,4 @@
-module SSOAuth
+module SsoAuth
   extend ActiveSupport::Concern
 
   included do

--- a/app/controllers/concerns/sso_auth.rb
+++ b/app/controllers/concerns/sso_auth.rb
@@ -1,0 +1,14 @@
+module SSOAuth
+  extend ActiveSupport::Concern
+
+  included do
+    include Pundit::Authorization
+    include GDS::SSO::ControllerMethods
+    prepend_before_action :authenticate_user!
+
+    rescue_from Pundit::NotAuthorizedError do |e|
+      # Layout and view comes from GDS::SSO::ControllerMethods
+      render 'authorisations/unauthorised', layout: 'unauthorised', status: :forbidden, locals: { message: e.message }
+    end
+  end
+end

--- a/app/policies/rollback_policy.rb
+++ b/app/policies/rollback_policy.rb
@@ -1,5 +1,5 @@
 RollbackPolicy = Struct.new(:user, :rollback) do
   def access?
-    user.hmrc_admin? || !TradeTariffAdmin.authenticate_with_sso?
+    user.hmrc_admin?
   end
 end

--- a/config/initializers/secret_token.rb
+++ b/config/initializers/secret_token.rb
@@ -1,8 +1,0 @@
-# Be sure to restart your server when you modify this file.
-
-# Your secret key for verifying the integrity of signed cookies.
-# If you change this key, all old signed cookies will become invalid!
-# Make sure the secret is at least 30 characters and all random,
-# no regular words or you'll be exposed to dictionary attacks.
-TradeTariffAdmin::Application.config.secret_token = Rails.application.secrets.secret_token
-TradeTariffAdmin::Application.config.secret_key_base = Rails.application.secrets.secret_key_base

--- a/spec/features/rollbacks_spec.rb
+++ b/spec/features/rollbacks_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe 'Rollbacks management', skip: 'TODO: Fix intermittent failures' do
+RSpec.describe 'Rollbacks management' do
   let!(:user) { create :user, :hmrc_admin }
 
   describe 'Rollback creation' do
@@ -48,7 +48,6 @@ RSpec.describe 'Rollbacks management', skip: 'TODO: Fix intermittent failures' d
 
     fill_in 'Reason', with: 'a reason'
     fill_in 'Rollback to', with: rollback.date
-    fill_in 'Confirm the service to rollback', with: 'uk'
 
     click_button 'Create Rollback'
   end

--- a/spec/requests/news_collections_controller_spec.rb
+++ b/spec/requests/news_collections_controller_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe NewsCollectionsController, skip: 'TODO: Fix intermittent failures' do
+RSpec.describe NewsCollectionsController do
   subject(:rendered_page) { create_user && make_request && response }
 
   let(:news_collection) { build :news_collection }

--- a/spec/requests/news_items_controller_spec.rb
+++ b/spec/requests/news_items_controller_spec.rb
@@ -1,4 +1,4 @@
-RSpec.describe NewsItemsController, skip: 'TODO: Need to debug this flaky test' do
+RSpec.describe NewsItemsController do
   subject(:rendered_page) { create_user && make_request && response }
 
   before do

--- a/spec/trade_tariff_admin/service_chooser_spec.rb
+++ b/spec/trade_tariff_admin/service_chooser_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe TradeTariffAdmin::ServiceChooser do
     end
   end
 
-  describe '.service_choice=', skip: 'TODO: fix intermittent failures' do
+  describe '.service_choice=' do
     it 'assigns the service choice to the current Thread' do
       expect { described_class.service_choice = 'xi' }
         .to change { Thread.current[:service_choice] }


### PR DESCRIPTION
### Jira link

BAU

### What?

I have added/removed/altered:

- [x] Added concern for the two auth types
- [x] Added current user method to the BasicSessionAuth concern
- [x] Removes skipping tests now that we have `rspec/rebound` in place

### Why?

I am doing this because:

- This is required to fix certain operations that expect a hydrated user model
