### PR TITLE
HMRC-956: Fixes bug in preview since we enabled protect_from_forgery with: :exception

### DIFF
--- a/app/webpacker/javascripts/markdown-preview.js
+++ b/app/webpacker/javascripts/markdown-preview.js
@@ -1,36 +1,41 @@
 import autosize from "autosize/dist/autosize";
-document.addEventListener("DOMContentLoaded", function () {
+document.addEventListener("DOMContentLoaded", function() {
   var Previewer = {
-    preview: function (content, output) {
+    preview: function(content, output) {
       fetch("/govspeak", {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
+          "X-CSRF-Token": this.fetchCSRFToken(),
         },
-        body: JSON.stringify({govspeak: content.value}),
+        body: JSON.stringify({ govspeak: content.value }),
       })
-        .then(function (response) {
+        .then(function(response) {
           return response.json();
         })
-        .then(function (data) {
+        .then(function(data) {
           output.innerHTML = data.govspeak;
         })
-        .catch(function (error) {
+        .catch(function(error) {
           console.error("Error:", error);
         });
     },
+    fetchCSRFToken: function() {
+      var csrfToken = document.querySelector('meta[name="csrf-token"]');
+      return csrfToken ? csrfToken.getAttribute("content") : null;
+    }
   };
 
-  document.querySelectorAll("[data-preview]").forEach(function (element) {
+  document.querySelectorAll("[data-preview]").forEach(function(element) {
     var source_field = document.querySelector(element.dataset.previewFor);
     var render_area = element;
 
-    source_field.addEventListener("input", function () {
+    source_field.addEventListener("input", function() {
       Previewer.preview(source_field, render_area);
     });
   });
 
-  document.querySelectorAll("textarea.govuk-textarea").forEach(function (element) {
+  document.querySelectorAll("textarea.govuk-textarea").forEach(function(element) {
     autosize(element);
   });
 


### PR DESCRIPTION
### Jira link

[HMRC-956](https://transformuk.atlassian.net/browse/HMRC-956)

### What?

I have added/removed/altered:

- [x] Added CSRF token to requests to POST a markdown preview

### Why?

I am doing this because:

- This is needed to make sure we can safely preview content
