### PR TITLE
HMRC-962: Notify in production-alerts

### DIFF
--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -73,3 +73,4 @@ jobs:
           with:
             result: ${{ needs.deploy.result }}
             slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+            slack_channel: production-alerts


### PR DESCRIPTION
### Jira link

[HOTT-962](https://transformuk.atlassian.net/browse/HMRC-962)

### What?

I have added/removed/altered:

- [ ] Added production-alerts channel to notify prod deployment

### Why?

I am doing this because:

- When deploying to production, we’re notifying in production alerts 