### PR TITLE
HMRC-1067 Add Notify Subscribers To News Item 

### DIFF
--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -7,7 +7,7 @@ class NewsItemsController < AuthenticatedController
   end
 
   def new
-    @news_item = News::Item.new
+    @news_item = News::Item.new(notify_subscribers: true)
     @collections = collection_options
   end
 

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -30,8 +30,6 @@ class NewsItemsController < AuthenticatedController
   end
 
   def update
-    # require 'pry'
-    # binding.pry
     @news_item = News::Item.build(news_item_params.merge(resource_id: params[:id]))
     @news_item.generate_or_normalise_slug!
     @news_item.save

--- a/app/controllers/news_items_controller.rb
+++ b/app/controllers/news_items_controller.rb
@@ -30,6 +30,8 @@ class NewsItemsController < AuthenticatedController
   end
 
   def update
+    # require 'pry'
+    # binding.pry
     @news_item = News::Item.build(news_item_params.merge(resource_id: params[:id]))
     @news_item.generate_or_normalise_slug!
     @news_item.save
@@ -73,6 +75,7 @@ class NewsItemsController < AuthenticatedController
       start_date
       end_date
       chapters
+      notify_subscribers
     ], collection_ids: []).reverse_merge(default_params)
   end
 

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -20,6 +20,7 @@ module News
                :start_date,
                :end_date,
                :chapters,
+               :notify_subscribers,
                :created_at,
                :updated_at
 

--- a/app/views/news_items/_form.html.erb
+++ b/app/views/news_items/_form.html.erb
@@ -56,6 +56,11 @@
 
   <%= f.govuk_text_field :chapters, width: 'one-half' %>
 
+  <%= f.govuk_check_box :notify_subscribers, 1, 0,
+                          label: { text: 'Notify subscribers' },
+                          multiple: false,
+                          link_errors: true %>
+
   <%= f.govuk_check_boxes_fieldset :display do %>
 
     <%= f.govuk_check_box :show_on_uk, 1, 0,

--- a/app/views/news_items/_form.html.erb
+++ b/app/views/news_items/_form.html.erb
@@ -57,7 +57,7 @@
   <%= f.govuk_text_field :chapters, width: 'one-half' %>
 
   <%= f.govuk_check_box :notify_subscribers, 1, 0,
-                          label: { text: 'Notify subscribers' },
+                          label: { text: 'e-mail subscribers?' },
                           multiple: false,
                           link_errors: true %>
 

--- a/spec/factories/news/item_factory.rb
+++ b/spec/factories/news/item_factory.rb
@@ -15,6 +15,8 @@ FactoryBot.define do
     end_date { nil }
     created_at { 2.days.ago.to_date }
     updated_at { nil }
+    chapters { [] }
+    notify_subscribers { false }
 
     trait :updates_page do
       show_on_updates_page { true }

--- a/spec/models/news/item_spec.rb
+++ b/spec/models/news/item_spec.rb
@@ -18,6 +18,8 @@ RSpec.describe News::Item do
   it { is_expected.to respond_to :end_date }
   it { is_expected.to respond_to :created_at }
   it { is_expected.to respond_to :updated_at }
+  it { is_expected.to respond_to :chapters }
+  it { is_expected.to respond_to :notify_subscribers }
 
   it { is_expected.to have_attributes id: news_item.id }
   it { is_expected.to have_attributes title: news_item.title }
@@ -32,6 +34,8 @@ RSpec.describe News::Item do
   it { is_expected.to have_attributes end_date: news_item.end_date }
   it { is_expected.to have_attributes created_at: news_item.created_at }
   it { is_expected.to have_attributes updated_at: news_item.updated_at }
+  it { is_expected.to have_attributes chapters: news_item.chapters }
+  it { is_expected.to have_attributes notify_subscribers: news_item.notify_subscribers }
 
   describe '#preview' do
     subject { news_item.preview }


### PR DESCRIPTION
### Jira link

[HOTT-1067](https://transformuk.atlassian.net/browse/HMRC-1067)

### What?

I have added notify subscribers to news item

### Why?

I am doing this because:

- Admin news items can be checked or unchecked to notify subscribers of stop press updates
 
![image](https://github.com/user-attachments/assets/ca753c38-3b53-423a-9e67-55dc9edbdce2)

