### PR TITLE
Add subscribable attribute

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 ### Jira link
 
-HOTT-<TODO>
+HMRC-<TODO>
 
 ### What?
 

--- a/app/controllers/news_collections_controller.rb
+++ b/app/controllers/news_collections_controller.rb
@@ -41,6 +41,7 @@ class NewsCollectionsController < AuthenticatedController
 
   def news_collection_params
     params.require(:news_collection).permit(%i[
+      subscribable
       published
       priority
       description

--- a/app/models/news/collection.rb
+++ b/app/models/news/collection.rb
@@ -10,7 +10,8 @@ module News
                :description,
                :priority,
                :published,
-               :slug
+               :slug,
+               :subscribable
 
     def generate_or_normalise_slug!
       current_slug = slug.presence || name.presence

--- a/app/views/news_collections/_form.html.erb
+++ b/app/views/news_collections/_form.html.erb
@@ -16,6 +16,8 @@
 
   <%= f.govuk_collection_radio_buttons :published, {'true' => 'Yes', 'false' => 'No' }, :first, :last, legend: { text: "Is this collection published?" } %>
 
+  <%= f.govuk_collection_radio_buttons :subscribable, {'true' => 'Yes', 'false' => 'No' }, :first, :last, legend: { text: "Should items in this collection be emailed to subscribers?" } %>
+
   <%= submit_and_back_buttons f, news_collections_path %>
 <% end %>
 

--- a/app/views/news_collections/index.html.erb
+++ b/app/views/news_collections/index.html.erb
@@ -10,6 +10,7 @@
         <th>Collection title</th>
         <th>Priority</th>
         <th>Published</th>
+        <th>Send Emails</th>
         <th>Actions</th>
       </tr>
     </thead>
@@ -20,6 +21,7 @@
           <td><%= news_collection.name %></td>
           <td><%= news_collection.priority %></td>
           <td><%= news_collection_bool news_collection.published %></td>
+          <td><%= news_collection_bool news_collection.subscribable %></td>
           <td>
             <%= link_to 'Edit',
                         edit_news_collection_path(news_collection) %>

--- a/spec/factories/news/collection_factory.rb
+++ b/spec/factories/news/collection_factory.rb
@@ -4,6 +4,7 @@ FactoryBot.define do
     sequence(:name) { |n| "Collection #{n}" }
     priority { 1 }
     published { true }
+    subscribable { false }
     description { 'some description' }
     slug { nil }
   end

--- a/spec/models/news/collection_spec.rb
+++ b/spec/models/news/collection_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe News::Collection do
   it { is_expected.to respond_to :description }
   it { is_expected.to respond_to :priority }
   it { is_expected.to respond_to :published }
+  it { is_expected.to respond_to :subscribable }
 
   describe '#generate_or_normalise_slug!' do
     subject { news_collection.generate_or_normalise_slug! }

--- a/spec/views/news_collections/_form.html.erb_spec.rb
+++ b/spec/views/news_collections/_form.html.erb_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'news_collections/form' do
     it { is_expected.to have_css 'input[name="news_collection[priority]"]' }
     it { is_expected.to have_css 'textarea[name="news_collection[description]"]' }
     it { is_expected.to have_css 'input[name="news_collection[published]"]' }
+    it { is_expected.to have_css 'input[name="news_collection[subscribable]"]' }
     it { is_expected.to have_css 'button', text: 'Create Collection' }
   end
 


### PR DESCRIPTION
### Jira link

HOTT-1074

### What?

I have added/removed/altered:

- Added a new attribute for news collections

### Why?

I am doing this because:

- Which news items are sent to subscribers needs to be limited to certain types of news item.
