### PR TITLE
HMRC-1141: Create Admin UI element to allow MTypes to be added for automation

### DIFF
--- a/app/controllers/green_lanes/measure_type_mappings_controller.rb
+++ b/app/controllers/green_lanes/measure_type_mappings_controller.rb
@@ -1,0 +1,42 @@
+module GreenLanes
+  class MeasureTypeMappingsController < AuthenticatedController
+    include XiOnly
+
+    def index
+      @measure_type_mappings = GreenLanes::MeasureTypeMapping.all(page: current_page)
+    end
+
+    def new
+      @measure_type_mapping = GreenLanes::MeasureTypeMapping.new
+      @themes = GreenLanes::Theme.all
+    end
+
+    def create
+      @measure_type_mapping = GreenLanes::MeasureTypeMapping.new(mtm_params)
+      @measure_type_mapping.save
+
+      if @measure_type_mapping.errors.none?
+        redirect_to green_lanes_measure_type_mappings_path, notice: 'MeasureTypeMapping created'
+      else
+        @themes = GreenLanes::Theme.all
+        render :new
+      end
+    end
+
+    def destroy
+      @measure_type_mapping = GreenLanes::MeasureTypeMapping.find(params[:id])
+      @measure_type_mapping.destroy
+
+      redirect_to green_lanes_measure_type_mappings_path, notice: 'MeasureTypeMapping removed'
+    end
+
+    private
+
+    def mtm_params
+      params.require(:measure_type_mapping).permit(
+        :measure_type_id,
+        :theme_id,
+      )
+    end
+  end
+end

--- a/app/controllers/green_lanes/update_notifications_controller.rb
+++ b/app/controllers/green_lanes/update_notifications_controller.rb
@@ -10,7 +10,7 @@ module GreenLanes
       @update = GreenLanes::UpdateNotification.find(params[:id])
     end
 
-    # TODO: This actually does nothing as far as I can make out since no changes are taking place
+    # Backend will update the notification status to inactive
     def update
       @update = GreenLanes::UpdateNotification.find(params[:id])
 

--- a/app/models/green_lanes/measure_type_mapping.rb
+++ b/app/models/green_lanes/measure_type_mapping.rb
@@ -1,0 +1,14 @@
+module GreenLanes
+  class MeasureTypeMapping
+    include ApiEntity
+
+    attr_accessor :measure_type_id,
+                  :theme_id
+
+    has_one :theme
+
+    def label
+      theme_id
+    end
+  end
+end

--- a/app/models/green_lanes/update_notification.rb
+++ b/app/models/green_lanes/update_notification.rb
@@ -12,6 +12,8 @@ module GreenLanes
         'Updated'
       when 2
         'Expired'
+      when 3
+        'Category Assessment Created'
       else
         ''
       end

--- a/app/views/green_lanes/measure_type_mappings/_form.html.erb
+++ b/app/views/green_lanes/measure_type_mappings/_form.html.erb
@@ -1,0 +1,15 @@
+<%= govuk_form_for measure_type_mapping, as: :measure_type_mapping do |f| %>
+
+  <%= f.govuk_text_field :measure_type_id,
+                         label: { text: 'Measure Type' },
+                         width: 'one-half' %>
+
+  <%= f.govuk_collection_select :theme_id,
+                                @themes,
+                                :id,
+                                :label,
+                                options: { include_blank: 'Select Theme' },
+                                label: { text: 'Select Theme' } %>
+
+  <%= submit_and_back_buttons f, green_lanes_measure_type_mappings_path %>
+<% end %>

--- a/app/views/green_lanes/measure_type_mappings/index.html.erb
+++ b/app/views/green_lanes/measure_type_mappings/index.html.erb
@@ -1,0 +1,37 @@
+<h2>
+  Manage Green Lanes Measure Type Mappings
+</h2>
+
+<%= link_to 'Add a Measure Type Mapping', new_green_lanes_measure_type_mapping_path, class: 'govuk-button' %>
+
+<% if @measure_type_mappings.any? %>
+  <table>
+    <thead>
+    <tr>
+      <th>Measure Type Id</th>
+      <th>Theme Id</th>
+      <th>Action</th>
+    </tr>
+    </thead>
+    <tbody>
+    <% @measure_type_mappings.each do |mtp| %>
+      <tr id="<%= dom_id(mtp) %>">
+        <td><%= mtp.measure_type_id %></td>
+        <td><%= mtp.theme_id %></td>
+        <td>
+          <%= link_to 'Remove',
+                      green_lanes_measure_type_mapping_path(mtp),
+                      method: :delete,
+                      class: 'govuk-button govuk-button--warning',
+                      data: { confirm: "Are you sure?", disable: 'Working ...' } %>
+        </td>
+      </tr>
+    <% end %>
+    </tbody>
+  </table>
+  <%= paginate @measure_type_mappings %>
+<% else %>
+  <div class="govuk-inset-text">
+    <p>No any Green Lanes Measure Type Mapping</p>
+  </div>
+<% end %>

--- a/app/views/green_lanes/measure_type_mappings/new.html.erb
+++ b/app/views/green_lanes/measure_type_mappings/new.html.erb
@@ -1,0 +1,5 @@
+<%= govuk_breadcrumbs 'Measure Type Mapping': green_lanes_measure_type_mappings_path %>
+
+<h2>New Measure Type Mapping</h2>
+
+<%= render 'form', measure_type_mapping: @measure_type_mapping %>

--- a/app/views/green_lanes/update_notifications/edit.html.erb
+++ b/app/views/green_lanes/update_notifications/edit.html.erb
@@ -32,6 +32,15 @@
       <% end %>
     </div>
   </div>
+  <% if @update.theme.present? %>
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-full">
+        <h3 class="govuk-heading-s">Category Assessment creates for </h3>
+        <h3 class="govuk-heading-s">Theme: </h3>
+        <p><%= @update.theme %></p>
+      </div>
+    </div>
+  <% end %>
 </div>
 
 <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -64,6 +64,9 @@
         <%= header.with_navigation_item text: 'Update Notifications',
                                         href: green_lanes_update_notifications_path,
                                         active: active_nav_link?(/\/update_notifications/) %>
+        <%= header.with_navigation_item text: 'Measure Type Mappings',
+                                      href: green_lanes_measure_type_mappings_path,
+                                      active: active_nav_link?(/\/measure_type_mappings/) %>
       <% end %>
     <% end %>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -62,6 +62,7 @@ Rails.application.routes.draw do
     resources :exemptions, only: %i[index new create edit update destroy]
     resources :measures, only: %i[index destroy]
     resources :update_notifications, only: %i[index edit update]
+    resources :measure_type_mappings, only: %i[index new create destroy]
   end
 
   resources :tariff_updates, only: %i[index show] do

--- a/spec/factories/green_lanes/measure_type_mapping_factory.rb
+++ b/spec/factories/green_lanes/measure_type_mapping_factory.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :measure_type_mapping, class: 'GreenLanes::MeasureTypeMapping' do
+    sequence(:resource_id) { |n| n }
+    measure_type_id { resource_id }
+    theme_id { 1 }
+  end
+end

--- a/spec/requests/green_lanes/measure_type_mappings_controller_spec.rb
+++ b/spec/requests/green_lanes/measure_type_mappings_controller_spec.rb
@@ -1,0 +1,73 @@
+RSpec.describe GreenLanes::MeasureTypeMappingsController do
+  subject(:rendered_page) { create_user && make_request && response }
+
+  let(:measure_type_mapping) { build :measure_type_mapping }
+  let(:create_user) { create :user, permissions: ['signin', 'HMRC Editor'] }
+
+  before do
+    allow(TradeTariffAdmin::ServiceChooser).to receive(:service_choice).and_return 'xi'
+
+    stub_api_request('/admin/green_lanes/themes', backend: 'xi').and_return \
+      jsonapi_response :themes, attributes_for_list(:green_lanes_theme, 3)
+  end
+
+  describe 'GET #index' do
+    before do
+      stub_api_request('/admin/green_lanes/measure_type_mappings?page=1', backend: 'xi').and_return \
+        jsonapi_response :measure_type_mappings, attributes_for_list(:measure_type_mapping, 3)
+    end
+
+    let(:make_request) { get green_lanes_measure_type_mappings_path }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.not_to include 'div.current-service' }
+  end
+
+  describe 'GET #new' do
+    let(:make_request) { get new_green_lanes_measure_type_mapping_path }
+
+    it { is_expected.to have_http_status :ok }
+    it { is_expected.not_to include 'div.current-service' }
+  end
+
+  describe 'POST #create' do
+    before do
+      stub_api_request('/admin/green_lanes/measure_type_mappings', :post).to_return create_response
+    end
+
+    let :make_request do
+      post green_lanes_measure_type_mappings_path,
+           params: { measure_type_mapping: mtm_params }
+    end
+
+    context 'with valid item' do
+      let(:mtm_params) { measure_type_mapping.attributes.without(:id) }
+      let(:create_response) { webmock_response(:created, measure_type_mapping.attributes) }
+
+      it { is_expected.to redirect_to green_lanes_measure_type_mappings_path }
+    end
+
+    context 'with invalid item' do
+      let(:mtm_params) { measure_type_mapping.attributes.without(:id, :theme_id) }
+      let(:create_response) { webmock_response(:error, theme_id: "can't be blank'") }
+
+      it { is_expected.to have_http_status :ok }
+      it { is_expected.to have_attributes body: /can.+t be blank/ }
+      it { is_expected.not_to include 'div.current-service' }
+    end
+  end
+
+  describe 'DELETE #destroy' do
+    before do
+      stub_api_request("/admin/green_lanes/measure_type_mappings/#{measure_type_mapping.id}")
+        .and_return jsonapi_response(:measure_type_mapping, measure_type_mapping.attributes)
+
+      stub_api_request("/admin/green_lanes/measure_type_mappings/#{measure_type_mapping.id}", :delete)
+        .and_return webmock_response :no_content
+    end
+
+    let(:make_request) { delete green_lanes_measure_type_mapping_path(measure_type_mapping) }
+
+    it { is_expected.to redirect_to green_lanes_measure_type_mappings_path }
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-1143](https://transformuk.atlassian.net/browse/HMRC-1143)

### What?

I have added/removed/altered:

- [ ] Added UI component to manage measure type mapping theme


### Why?

I am doing this because:

- To support automatic generation of Category Assessments for specific Measure Types, a new database table is needed to map Measure Type IDs to SPIMM Themes
- If the MType is in the list, it should auto-create a Category Assessment for the new MType-RegID-Role combination with the correct theme assigned


