### PR TITLE
HMRC-1068: HMRC-1068: Kill the totally non-json-api compliant x-meta in pagination - some changes left uncommited

### DIFF
--- a/app/views/references/chapters/search_references/index.html.erb
+++ b/app/views/references/chapters/search_references/index.html.erb
@@ -30,5 +30,3 @@
     </tbody>
   </table>
 <% end %>
-
-<%= paginate @search_references %>

--- a/app/views/references/commodities/search_references/index.html.erb
+++ b/app/views/references/commodities/search_references/index.html.erb
@@ -30,5 +30,3 @@
     </tbody>
   </table>
 <% end %>
-
-<%= paginate @search_references %>

--- a/app/views/references/headings/search_references/index.html.erb
+++ b/app/views/references/headings/search_references/index.html.erb
@@ -30,5 +30,3 @@
     </tbody>
   </table>
 <% end %>
-
-<%= paginate @search_references %>


### PR DESCRIPTION

### Jira link

[HMRC-1068](https://transformuk.atlassian.net/browse/HMRC-1068)

### What?

I have added/removed/altered:

- [ ] Removed pagination from admin search reference controller

### Why?

I am doing this because:

- It's not been used and built using non-json-api compliant x-meta header