### PR TITLE
HMRC-1379: Adds support for as of to quota search

### DIFF
--- a/app/controllers/quotas_controller.rb
+++ b/app/controllers/quotas_controller.rb
@@ -6,7 +6,12 @@ class QuotasController < AuthenticatedController
   def new
     return render 'errors/not_found' if TradeTariffAdmin::ServiceChooser.xi?
 
-    @quota_search = QuotaSearch.new
+    today = Time.zone.today
+    @quota_search = QuotaSearch.new(
+      'import_date(3i)': today.day.to_s,
+      'import_date(2i)': today.month.to_s,
+      'import_date(1i)': today.year.to_s,
+    )
   end
 
   def search
@@ -37,10 +42,18 @@ class QuotasController < AuthenticatedController
   end
 
   def quota_definitions
-    @quota_definitions ||= QuotaOrderNumbers::QuotaDefinition.all(quota_order_number_id: @quota_search.order_number)
+    @quota_definitions ||= QuotaOrderNumbers::QuotaDefinition.all(
+      quota_order_number_id: @quota_search.order_number,
+      as_of: @quota_search.import_date.iso8601,
+    )
   end
 
   def quota_params
-    params.require(:quota_search).permit(:order_number)
+    params.require(:quota_search).permit(
+      :order_number,
+      :'import_date(3i)',
+      :'import_date(2i)',
+      :'import_date(1i)',
+    )
   end
 end

--- a/app/models/quota_search.rb
+++ b/app/models/quota_search.rb
@@ -18,6 +18,6 @@ class QuotaSearch
   private
 
   def import_date_valid
-    errors.add(:quota_search, :invalid_date) unless attributes.empty? || import_date.is_a?(Date)
+    errors.add(:import_date, :invalid_date) unless attributes.empty? || import_date.is_a?(Date)
   end
 end

--- a/app/models/quota_search.rb
+++ b/app/models/quota_search.rb
@@ -1,10 +1,23 @@
 class QuotaSearch
   include ActiveModel::Model
+  include ActiveModel::Attributes
+  include ActiveRecord::AttributeAssignment
 
   QUOTA_ORDER_NUMBER_LENGTH = 6
+
+  validate :import_date_valid
 
   validates :order_number, numericality: true,
                            length: { is: QUOTA_ORDER_NUMBER_LENGTH }
 
-  attr_accessor :order_number
+  attribute :order_number
+  attribute :import_date, :tariff_date
+
+  delegate :day, :month, :year, to: :import_date, allow_nil: true
+
+  private
+
+  def import_date_valid
+    errors.add(:quota_search, :invalid_date) unless attributes.empty? || import_date.is_a?(Date)
+  end
 end

--- a/app/views/quotas/new.html.erb
+++ b/app/views/quotas/new.html.erb
@@ -3,8 +3,13 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_form_for @quota_search, url: perform_search_quotas_path, method: :get do |f| %>
+      <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :order_number, label: { text: "Enter the 6-digit quota order number ID to return the details of the quota's definitions,
       balance updates and other events." }, width: 'one-third' %>
+
+      <%= f.govuk_date_field :import_date,
+        legend: { text: "When is the quota active?" },
+        hint: { text: "Enter a date within the start and end of the active quota. This will return the quota's definitions, balance updates and other events for that date." } %>
 
       <%= f.govuk_submit 'Search' %>
     <% end %>

--- a/app/views/quotas/new.html.erb
+++ b/app/views/quotas/new.html.erb
@@ -3,7 +3,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
     <%= govuk_form_for @quota_search, url: perform_search_quotas_path, method: :get do |f| %>
-      <%= f.govuk_error_summary %>
       <%= f.govuk_text_field :order_number, label: { text: "Enter the 6-digit quota order number ID to return the details of the quota's definitions,
       balance updates and other events." }, width: 'one-third' %>
 

--- a/config/initializers/attribute_types.rb
+++ b/config/initializers/attribute_types.rb
@@ -1,0 +1,3 @@
+require_relative '../../lib/active_model_types/tariff_date'
+
+ActiveModel::Type.register(:tariff_date, ActiveModelTypes::TariffDate)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -80,6 +80,8 @@ en:
             order_number:
               not_a_number: Enter a valid quota order number
               wrong_length: Enter a valid quota order number
+            import_date:
+              invalid_date: Enter a valid date
         basic_session:
           attributes:
             password:

--- a/lib/active_model_types/tariff_date.rb
+++ b/lib/active_model_types/tariff_date.rb
@@ -1,0 +1,24 @@
+module ActiveModelTypes
+  # There is currently no good way to handle the fact that
+  # the ActiveModel::Attributes module (through Time.utc)
+  # propagates an error on unparseable multi parameter date
+  # types currently. This is not something that happens within
+  # ActiveRecord where the broken date fails validation rather than
+  # when being casted.
+  #
+  # This is the most generic way we can think of to avoid propagating
+  # these errors and leave them to be appended to the messages hash as
+  # part of the validation callbacks.
+  class TariffDate < ActiveModel::Type::Date
+    def value_from_multiparameter_assignment(values_hash)
+      return unless values_hash[1] && values_hash[2] && values_hash[3]
+
+      values = values_hash.sort.map!(&:last)
+
+      ::Date.civil(*values)
+    rescue ArgumentError
+      # This needs to be nil to put an empty value in the form
+      nil
+    end
+  end
+end

--- a/spec/models/quota_search_spec.rb
+++ b/spec/models/quota_search_spec.rb
@@ -1,23 +1,32 @@
-require 'rails_helper'
-
 RSpec.describe QuotaSearch do
   subject(:quota_search) { described_class.new(attributes) }
 
   describe 'validations' do
+    let(:today) { Time.zone.today }
+
+    let(:base_attributes) do
+      {
+        order_number: '123456',
+        'import_date(3i)': today.day.to_s,
+        'import_date(2i)': today.month.to_s,
+        'import_date(1i)': today.year.to_s,
+      }
+    end
+
     context 'when the order number is 6 numerical chars' do
-      let(:attributes) { { order_number: '123456' } }
+      let(:attributes) { base_attributes.merge(order_number: '123456') }
 
       it { is_expected.to be_valid }
     end
 
     context 'when the order number is not 6 numerical chars' do
-      let(:attributes) { { order_number: '1456' } }
+      let(:attributes) { base_attributes.merge(order_number: '1456') }
 
       it { is_expected.not_to be_valid }
     end
 
     context 'when the order number is not numerical chars' do
-      let(:attributes) { { order_number: 'abcdef' } }
+      let(:attributes) { base_attributes.merge(order_number: 'abcdef') }
 
       it { is_expected.not_to be_valid }
     end

--- a/spec/requests/quotas_controller_spec.rb
+++ b/spec/requests/quotas_controller_spec.rb
@@ -25,7 +25,15 @@ RSpec.describe QuotasController do
     subject(:do_request) do
       create(:user, :hmrc_editor)
 
-      get perform_search_quotas_path(quota_search: { order_number: quota_definition.quota_order_number_id })
+      today = Time.zone.today
+      get perform_search_quotas_path(
+        quota_search: {
+          order_number: quota_definition.quota_order_number_id,
+          'import_date(3i)': today.day.to_s,
+          'import_date(2i)': today.month.to_s,
+          'import_date(1i)': today.year.to_s,
+        },
+      )
 
       response
     end
@@ -57,7 +65,7 @@ RSpec.describe QuotasController do
       it 'fetches the quota definition' do
         do_request
 
-        expect(QuotaOrderNumbers::QuotaDefinition).to have_received(:all).with(quota_order_number_id: quota_definition.quota_order_number_id)
+        expect(QuotaOrderNumbers::QuotaDefinition).to have_received(:all).with(quota_order_number_id: quota_definition.quota_order_number_id, as_of: Time.zone.today.iso8601)
       end
 
       it { is_expected.to render_template(:search) }


### PR DESCRIPTION
### Jira link

[HMRC-1379](https://transformuk.atlassian.net/browse/HMRC-1379)

### What?

I have added/removed/altered:

- [x] Added as of to quota search

### Why?

I am doing this because:

- This is needed to pick a version of an order number and avoid confusion
