### PR TITLE
Change description and suggested action to markdown fields

### DIFF
--- a/app/views/live_issues/_form.html.erb
+++ b/app/views/live_issues/_form.html.erb
@@ -1,19 +1,15 @@
 <%= govuk_form_for live_issue do |f| %>
   <%= f.govuk_text_field :title, width: 'one-half' %>
 
-  <%= f.govuk_text_area :description,
-          hint: { text: 'Provide a description of the issue in 256 characters or less' },
-          max_chars: 256,
-          threshold: 50,
-          rows: 6
+  <%= govuk_markdown_area f, :description,
+          hint: { text: 'Provide a description of the issue. Aim for 256 characters or less' },
+          rows: 8
   %>
 
-  <%= f.govuk_text_area :suggested_action,
+  <%= govuk_markdown_area f, :suggested_action,
           label: { text: 'Suggested action' },
-          hint: { text: 'Provide next steps for the users in 256 characters or less' },
-          max_chars: 256,
-          threshold: 50,
-          rows: 6
+          hint: { text: 'Provide next steps for the users. Aim for 256 characters or less' },
+          rows: 8
   %>
 
   <%= f.govuk_text_field :commodities,


### PR DESCRIPTION
### Jira link

[PRDEX-67](https://transformuk.atlassian.net/browse/PRDEX-67)

### What?

I have added/removed/altered:

- [x] Add markdown support for description and suggested action

### Why?

I am doing this because:

- We want to support hyperlinks in the frontend for live issues

<img width="1017" height="799" alt="Screenshot 2025-07-17 at 15 54 03" src="https://github.com/user-attachments/assets/1c747c7e-1c33-407e-b25e-73fa86c5f153" />

