### PR TITLE
HMRC-1362: Start identity service when running e2e tests

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 ADMIN_HOST='http://localhost:3000'
-API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000","xi":"http://localhost:3000" }
+API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000/uk","xi":"http://localhost:3000/xi" }
 AUTHENTICATE_WITH_SSO=false
 BASIC_PASSWORD=dev123
 BEARER_TOKEN=tariff-api-test-token

--- a/.github/workflows/deploy-to-development-full.yml
+++ b/.github/workflows/deploy-to-development-full.yml
@@ -38,6 +38,11 @@ jobs:
             "repo": "trade-tariff/trade-tariff-frontend",
             "service-names": ["frontend"]
           },
+          {
+            "name": "identity",
+            "repo": "trade-tariff/identity",
+            "service-names": ["identity"]
+          }
         ]
       test-flavour: tariff
     secrets:


### PR DESCRIPTION
### Jira link

[HMRC-1362](https://transformuk.atlassian.net/browse/HMRC-1362)

### What?

I have a...

- Enabled identity service when running the e2e tests

### Why?

I am doing this because...

- This is required to make sure the e2e tests pass
