### PR TITLE
HMRC-1479: Handle measure type and role presentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'rails', '~> 7.1.2'
 gem 'routing-filter', github: 'trade-tariff/routing-filter'
 
 # DB
-gem 'pg'
-gem 'sqlite3'
+gem 'pg', require: false
+gem 'sqlite3', require: false
 
 # Assets
 gem 'webpacker'

--- a/app/models/green_lanes/update_notification.rb
+++ b/app/models/green_lanes/update_notification.rb
@@ -18,5 +18,21 @@ module GreenLanes
         ''
       end
     end
+
+    def presented_measure_type_id
+      if try(:measure_type_description).present?
+        "<abbr title='#{measure_type_description}'>#{measure_type_id}</abbr>"
+      else
+        measure_type_id
+      end
+    end
+
+    def presented_regulation_id
+      if try(:regulation_description)
+        "<abbr title='#{regulation_description}'>#{regulation_id}</abbr>"
+      else
+        regulation_id
+      end
+    end
   end
 end

--- a/app/views/green_lanes/update_notifications/index.html.erb
+++ b/app/views/green_lanes/update_notifications/index.html.erb
@@ -16,13 +16,12 @@
     <tbody>
     <% @updates.each do |update| %>
       <tr id="<%= dom_id(update) %>">
-        <td><%= update.measure_type_id %></td>
-        <td><%= update.regulation_id %></td>
+        <td><%= sanitize update.presented_measure_type_id %></td>
+        <td><%= sanitize update.presented_regulation_id %></td>
         <td><%= update.regulation_role %></td>
         <td><%= update.status_label %></td>
         <td>
-          <%= link_to 'Edit',
-                      edit_green_lanes_update_notification_path(update) %>
+          <%= link_to 'Edit', edit_green_lanes_update_notification_path(update) %>
         </td>
       </tr>
     <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -6,6 +6,7 @@ require 'rails/all'
 # you've limited to :test, :development, or :production.
 Bundler.require(*Rails.groups)
 
+
 APP_SLUG = 'trade-tariff-admin'.freeze
 
 module TradeTariffAdmin
@@ -37,4 +38,12 @@ module TradeTariffAdmin
     # config.eager_load_paths << Rails.root.join("extras")
     config.x.http.retry_options = {}
   end
+end
+
+ADAPTER = Rails.application.config.database_configuration[Rails.env].try(:[], "adapter")
+
+if ADAPTER == 'sqlite3'
+  require 'sqlite3'
+else
+  require 'pg'
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,6 +1,25 @@
 {
   "ignored_warnings": [
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.1.5.1 ends on 2025-10-01",
+      "file": "Gemfile.lock",
+      "line": 587,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": "We'll be updating this soon and there are no currently open CVEs not patched"
+    },
+    {
       "warning_type": "Cross-Site Scripting",
       "warning_code": 4,
       "fingerprint": "45fc1c8ab944f192e74bbb98c00175ab45a50c992148fa2831b8003ffc198316",


### PR DESCRIPTION
### Jira link

[HMRC-1479](https://transformuk.atlassian.net/browse/HMRC-1479)

### What?

I have added/removed/altered:

- [x] Added presentational abbreviations for ease of use to measure type id
- [x] Added presentational abbreviations for ease of use to regulation role
- [x] Move to only requiring database adapter gem when required

### Why?

I am doing this because:

- This is required to make sure that HMRC has as much context as possible and reflects that some updated measure types actually aren't present in the database despite being referenced by the generated notification
