### PR TITLE
OTTIMP-463: Add superadmin role for high-risk admin paths

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,14 @@
 class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
 
+  SUPERADMIN = "SUPERADMIN".freeze
   TECHNICAL_OPERATOR = "TECHNICAL_OPERATOR".freeze
   HMRC_ADMIN = "HMRC_ADMIN".freeze
   AUDITOR = "AUDITOR".freeze
   GUEST = "GUEST".freeze
 
-  VALID_ROLES = [TECHNICAL_OPERATOR, HMRC_ADMIN, AUDITOR, GUEST].freeze
+  PRIVILEGED_OPERATOR_ROLES = [SUPERADMIN, TECHNICAL_OPERATOR].freeze
+  VALID_ROLES = [SUPERADMIN, TECHNICAL_OPERATOR, HMRC_ADMIN, AUDITOR, GUEST].freeze
 
   validates :role, inclusion: { in: VALID_ROLES }
   validates :email, presence: true, on: :create
@@ -53,7 +55,11 @@ class User < ApplicationRecord
 
   # Role helper methods - assume single role exclusivity
   def technical_operator?
-    current_role == TECHNICAL_OPERATOR
+    PRIVILEGED_OPERATOR_ROLES.include?(current_role)
+  end
+
+  def superadmin?
+    current_role == SUPERADMIN
   end
 
   def hmrc_admin?

--- a/app/policies/admin_configuration_policy.rb
+++ b/app/policies/admin_configuration_policy.rb
@@ -1,14 +1,14 @@
 class AdminConfigurationPolicy < ApplicationPolicy
   def index?
-    technical_operator?
+    superadmin?
   end
 
   def show?
-    technical_operator?
+    superadmin?
   end
 
   def update?
-    technical_operator?
+    superadmin?
   end
 
   def create?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -34,6 +34,10 @@ class ApplicationPolicy
     user&.technical_operator? || false
   end
 
+  def superadmin?
+    user&.superadmin? || false
+  end
+
   def hmrc_admin?
     user&.hmrc_admin? || false
   end

--- a/app/policies/rollback_policy.rb
+++ b/app/policies/rollback_policy.rb
@@ -1,14 +1,14 @@
-# Rollback: TECHNICAL_OPERATOR execute/download/recover, HMRC_ADMIN hidden, AUDITOR index (history only), GUEST hidden
+# Rollback: SUPERADMIN execute/download/recover, AUDITOR index (history only), HMRC_ADMIN hidden, GUEST hidden
 class RollbackPolicy < ApplicationPolicy
   def index?
-    technical_operator? || auditor?
+    superadmin? || auditor?
   end
 
   def show?
-    technical_operator? || auditor?
+    superadmin? || auditor?
   end
 
   def create?
-    technical_operator?
+    superadmin?
   end
 end

--- a/app/policies/update_policy.rb
+++ b/app/policies/update_policy.rb
@@ -1,23 +1,23 @@
-# Updates (Daily Tariff Files): TECHNICAL_OPERATOR monitor/diagnose/clear cache, HMRC_ADMIN hidden, AUDITOR read-only, GUEST hidden
+# Updates (Daily Tariff Files): SUPERADMIN full control, AUDITOR read-only, HMRC_ADMIN hidden, GUEST hidden
 class UpdatePolicy < ApplicationPolicy
   def index?
-    technical_operator? || auditor?
+    superadmin? || auditor?
   end
 
   def show?
-    technical_operator? || auditor?
+    superadmin? || auditor?
   end
 
   # Actions like download, apply_and_clear_cache, resend_cds_update_notification
   def download?
-    technical_operator?
+    superadmin?
   end
 
   def apply_and_clear_cache?
-    technical_operator?
+    superadmin?
   end
 
   def resend_cds_update_notification?
-    technical_operator?
+    superadmin?
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,4 @@
-# User Management: ONLY TECHNICAL_OPERATOR may manage users
+# User Management: SUPERADMIN can create/delete users, TECHNICAL_OPERATOR can view/update users
 # Exception: Basic auth allows user management regardless of role (testing mode)
 # Basic auth override only works when basic auth is enabled and for non-guest users
 class UserPolicy < ApplicationPolicy
@@ -7,7 +7,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def create?
-    basic_auth_override? || technical_operator?
+    basic_auth_override? || superadmin?
   end
 
   def show?
@@ -19,7 +19,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def destroy?
-    basic_auth_override? || technical_operator?
+    basic_auth_override? || superadmin?
   end
 
 private

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,8 +1,17 @@
 <h2>Manage Users</h2>
 
 <p>
-  Use this page to manage users and roles.
+  Use this page to manage user roles.
+  <% unless policy(User.new).update? %>
+    Only technical operators and superadmins can change user roles.
+  <% end %>
 </p>
+
+<% if policy(User.new).update? && !policy(User.new).create? %>
+  <p>
+    Only superadmins can add or remove users.
+  </p>
+<% end %>
 
 <% if policy(User.new).create? %>
   <p>

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     # Default user has GUEST role (assigned by User model before_create callback)
     # No need to remove it - GUEST is the valid default
 
+    trait :superadmin do
+      role { User::SUPERADMIN }
+    end
+
     trait :technical_operator do
       role { User::TECHNICAL_OPERATOR }
     end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -77,11 +77,9 @@ RSpec.describe NavigationHelper, type: :helper do
                          "News",
                          "Live Issues",
                          "Quotas",
-                         "Updates",
                          "Reports",
-                         "Rollbacks",
                        ],
-                       classification: ["Search References", "Descriptions", "Configuration", "Recent changes"],
+                       classification: ["Search References", "Descriptions", "Recent changes"],
                        manage_users: nil
     end
 
@@ -128,7 +126,7 @@ RSpec.describe NavigationHelper, type: :helper do
       let(:user) { build(:user, :technical_operator) }
 
       include_examples "visible sections and items",
-                       ott_admin: ["Section & chapter notes", "Updates", "Reports", "Rollbacks"],
+                       ott_admin: ["Section & chapter notes", "Reports"],
                        classification: ["Search References", "Descriptions", "Recent changes"],
                        spimm: [
                          "Category Assessments",
@@ -251,7 +249,7 @@ RSpec.describe NavigationHelper, type: :helper do
     include_context "with UK service"
 
     let(:user) { build(:user, :technical_operator) }
-    let(:request_path) { "/tariff_updates" }
+    let(:request_path) { "/notes/1" }
 
     it "returns true for OTT Admin when path matches" do
       section = helper.visible_navigation_sections.find { |s| s.key == :ott_admin }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,12 @@ RSpec.describe User do
   describe "#technical_operator?" do
     subject(:user) { create(:user, *traits) }
 
+    context "when user has superadmin role" do
+      let(:traits) { [:superadmin] }
+
+      it { is_expected.to be_technical_operator }
+    end
+
     context "when user has technical operator role" do
       let(:traits) { [:technical_operator] }
 
@@ -12,6 +18,22 @@ RSpec.describe User do
       let(:traits) { [] }
 
       it { is_expected.not_to be_technical_operator }
+    end
+  end
+
+  describe "#superadmin?" do
+    subject(:user) { create(:user, *traits) }
+
+    context "when user has superadmin role" do
+      let(:traits) { [:superadmin] }
+
+      it { is_expected.to be_superadmin }
+    end
+
+    context "when user does not have superadmin role" do
+      let(:traits) { [:technical_operator] }
+
+      it { is_expected.not_to be_superadmin }
     end
   end
 
@@ -123,6 +145,7 @@ RSpec.describe User do
 
     describe "role constants" do
       it "defines all required role constants", :aggregate_failures do
+        expect(User::SUPERADMIN).to eq("SUPERADMIN")
         expect(User::TECHNICAL_OPERATOR).to eq("TECHNICAL_OPERATOR")
         expect(User::HMRC_ADMIN).to eq("HMRC_ADMIN")
         expect(User::AUDITOR).to eq("AUDITOR")
@@ -130,7 +153,7 @@ RSpec.describe User do
       end
 
       it "includes all roles in VALID_ROLES" do
-        expect(User::VALID_ROLES).to contain_exactly(User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR, User::GUEST)
+        expect(User::VALID_ROLES).to contain_exactly(User::SUPERADMIN, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR, User::GUEST)
       end
     end
 

--- a/spec/policies/admin_configuration_policy_spec.rb
+++ b/spec/policies/admin_configuration_policy_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe AdminConfigurationPolicy do
   let(:configuration) { AdminConfiguration.new(name: "test") }
 
   permissions :index?, :show?, :update? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(policy).to permit(user, configuration)
     end
 
@@ -19,6 +19,11 @@ RSpec.describe AdminConfigurationPolicy do
       expect(policy).not_to permit(user, configuration)
     end
 
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
+      expect(policy).not_to permit(user, configuration)
+    end
+
     it "denies access to guest user" do
       user = create(:user, :guest)
       expect(policy).not_to permit(user, configuration)
@@ -26,8 +31,8 @@ RSpec.describe AdminConfigurationPolicy do
   end
 
   permissions :create?, :destroy? do
-    it "denies access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "denies access to superadmin" do
+      user = create(:user, :superadmin)
       expect(policy).not_to permit(user, configuration)
     end
   end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -27,6 +27,21 @@ RSpec.describe ApplicationPolicy do
   end
 
   describe "role helper methods" do
+    context "with superadmin" do
+      let(:user) { create(:user, :superadmin) }
+
+      it "returns true for elevated role checks", :aggregate_failures do
+        expect(policy.superadmin?).to be(true)
+        expect(policy.technical_operator?).to be(true)
+      end
+
+      it "returns false for other roles", :aggregate_failures do
+        expect(policy.hmrc_admin?).to be(false)
+        expect(policy.auditor?).to be(false)
+        expect(policy.guest?).to be(false)
+      end
+    end
+
     context "with technical operator" do
       let(:user) { create(:user, :technical_operator) }
 
@@ -69,6 +84,7 @@ RSpec.describe ApplicationPolicy do
       let(:user) { nil }
 
       it "returns false for all role checks", :aggregate_failures do
+        expect(policy.superadmin?).to be(false)
         expect(policy.technical_operator?).to be(false)
         expect(policy.hmrc_admin?).to be(false)
         expect(policy.auditor?).to be(false)
@@ -78,6 +94,12 @@ RSpec.describe ApplicationPolicy do
   end
 
   describe "#can_access_xi?" do
+    it "returns true for superadmin" do
+      user = create(:user, :superadmin)
+      policy = described_class.new(user, record)
+      expect(policy.can_access_xi?).to be(true)
+    end
+
     it "returns true for technical operator" do
       user = create(:user, :technical_operator)
       policy = described_class.new(user, record)

--- a/spec/policies/rbac_comprehensive_spec.rb
+++ b/spec/policies/rbac_comprehensive_spec.rb
@@ -199,15 +199,13 @@ RSpec.describe "RBAC Comprehensive Rules" do
       expect(QuotaPolicy.new(technical_operator, Quota.new).destroy?).to be(true)
     end
 
-    it "allows full access to updates", :aggregate_failures do
-      expect(UpdatePolicy.new(technical_operator, Update.new).index?).to be(true)
-      expect(UpdatePolicy.new(technical_operator, Update.new).download?).to be(true)
-      expect(UpdatePolicy.new(technical_operator, Update.new).apply_and_clear_cache?).to be(true)
+    it "denies access to updates" do
+      expect(UpdatePolicy.new(technical_operator, Update.new).index?).to be(false)
     end
 
-    it "allows full access to rollbacks", :aggregate_failures do
-      expect(RollbackPolicy.new(technical_operator, Rollback.new).index?).to be(true)
-      expect(RollbackPolicy.new(technical_operator, Rollback.new).create?).to be(true)
+    it "denies access to rollbacks", :aggregate_failures do
+      expect(RollbackPolicy.new(technical_operator, Rollback.new).index?).to be(false)
+      expect(RollbackPolicy.new(technical_operator, Rollback.new).create?).to be(false)
     end
 
     it "allows full access to XI services", :aggregate_failures do
@@ -222,15 +220,36 @@ RSpec.describe "RBAC Comprehensive Rules" do
       expect(GoodsNomenclatureLabelPolicy.new(technical_operator, GoodsNomenclatureLabel.new).update?).to be(true)
     end
 
-    it "allows access to user management", :aggregate_failures do
+    it "allows view and update access to user management", :aggregate_failures do
       expect(UserPolicy.new(technical_operator, User.new).index?).to be(true)
       expect(UserPolicy.new(technical_operator, User.new).update?).to be(true)
+      expect(UserPolicy.new(technical_operator, User.new).create?).to be(false)
+      expect(UserPolicy.new(technical_operator, User.new).destroy?).to be(false)
+    end
+  end
+
+  describe "SUPERADMIN role - technical operator plus user lifecycle" do
+    let(:superadmin) { create(:user, :superadmin) }
+
+    it "inherits technical operator access for content management", :aggregate_failures do
+      expect(SectionNotePolicy.new(superadmin, SectionNote.new).index?).to be(true)
+      expect(SearchReferencePolicy.new(superadmin, SearchReference.new).create?).to be(true)
+      expect(AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test")).update?).to be(true)
+      expect(UpdatePolicy.new(superadmin, Update.new).apply_and_clear_cache?).to be(true)
+      expect(RollbackPolicy.new(superadmin, Rollback.new).create?).to be(true)
+    end
+
+    it "allows full access to user management", :aggregate_failures do
+      expect(UserPolicy.new(superadmin, User.new).index?).to be(true)
+      expect(UserPolicy.new(superadmin, User.new).update?).to be(true)
+      expect(UserPolicy.new(superadmin, User.new).create?).to be(true)
+      expect(UserPolicy.new(superadmin, User.new).destroy?).to be(true)
     end
   end
 
   describe "XI Service access restriction" do
-    it "only TECHNICAL_OPERATOR and AUDITOR can access XI services", :aggregate_failures do
-      allowed = [create(:user, :technical_operator), create(:user, :auditor)]
+    it "only privileged operators and AUDITOR can access XI services", :aggregate_failures do
+      allowed = [create(:user, :superadmin), create(:user, :technical_operator), create(:user, :auditor)]
       denied = [create(:user, :hmrc_admin), create(:user, :guest)]
       index = ->(user) { GreenLanes::CategoryAssessmentPolicy.new(user, double).index? }
       expect(allowed.map(&index)).to all(be(true))

--- a/spec/policies/rollback_policy_spec.rb
+++ b/spec/policies/rollback_policy_spec.rb
@@ -5,14 +5,19 @@ RSpec.describe RollbackPolicy do
   let(:rollback) { Rollback.new }
 
   permissions :index?, :show? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(rollback_policy).to permit(user, rollback)
     end
 
     it "grants access to auditor" do
       user = create(:user, :auditor)
       expect(rollback_policy).to permit(user, rollback)
+    end
+
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
+      expect(rollback_policy).not_to permit(user, rollback)
     end
 
     it "denies access to hmrc admin" do
@@ -27,13 +32,18 @@ RSpec.describe RollbackPolicy do
   end
 
   permissions :create? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(rollback_policy).to permit(user, rollback)
     end
 
     it "denies access to auditor" do
       user = create(:user, :auditor)
+      expect(rollback_policy).not_to permit(user, rollback)
+    end
+
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
       expect(rollback_policy).not_to permit(user, rollback)
     end
 

--- a/spec/policies/update_policy_spec.rb
+++ b/spec/policies/update_policy_spec.rb
@@ -5,14 +5,19 @@ RSpec.describe UpdatePolicy do
   let(:update) { Update.new }
 
   permissions :index?, :show? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(update_policy).to permit(user, update)
     end
 
     it "grants access to auditor" do
       user = create(:user, :auditor)
       expect(update_policy).to permit(user, update)
+    end
+
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
+      expect(update_policy).not_to permit(user, update)
     end
 
     it "denies access to hmrc admin" do
@@ -27,13 +32,18 @@ RSpec.describe UpdatePolicy do
   end
 
   permissions :download?, :apply_and_clear_cache?, :resend_cds_update_notification? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(update_policy).to permit(user, update)
     end
 
     it "denies access to auditor" do
       user = create(:user, :auditor)
+      expect(update_policy).not_to permit(user, update)
+    end
+
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
       expect(update_policy).not_to permit(user, update)
     end
 

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,6 +1,26 @@
 RSpec.describe UserPolicy do
   subject(:user_policy) { described_class }
 
+  permissions :create?, :destroy? do
+    context "when not using basic auth" do
+      before do
+        allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(false)
+      end
+
+      it "grants access to superadmin" do
+        user = create(:user, :superadmin)
+        target_user = create(:user)
+        expect(user_policy).to permit(user, target_user)
+      end
+
+      it "denies access to technical operator" do
+        user = create(:user, :technical_operator)
+        target_user = create(:user)
+        expect(user_policy).not_to permit(user, target_user)
+      end
+    end
+  end
+
   permissions :update? do
     context "when using basic auth" do
       before do
@@ -42,6 +62,12 @@ RSpec.describe UserPolicy do
     context "when not using basic auth" do
       before do
         allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(false)
+      end
+
+      it "grants access to superadmin" do
+        user = create(:user, :superadmin)
+        target_user = create(:user)
+        expect(user_policy).to permit(user, target_user)
       end
 
       it "grants access to technical operator" do

--- a/spec/requests/classification_configurations_controller_spec.rb
+++ b/spec/requests/classification_configurations_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
   include_context "with authenticated user"
 
-  let(:current_user) { create(:user, :technical_operator) }
+  let(:current_user) { create(:user, :superadmin) }
   let(:config_name) { "expansion_prompt" }
   let(:config_attributes) do
     {

--- a/spec/requests/rollbacks_controller_spec.rb
+++ b/spec/requests/rollbacks_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe RollbacksController do
   subject(:rendered_page) { make_request && response }
 
   include_context "with authenticated user"
+  let(:current_user) { create(:user, :superadmin) }
 
   describe "GET #index" do
     before do
@@ -30,5 +31,12 @@ RSpec.describe RollbacksController do
 
     it { is_expected.to have_http_status :forbidden }
     it { is_expected.to have_attributes body: /contact your Delivery Manager/ }
+  end
+
+  context "when technical operator" do
+    let(:current_user) { create(:user, :technical_operator) }
+    let(:make_request) { get rollbacks_path }
+
+    it { is_expected.to have_http_status :forbidden }
   end
 end

--- a/spec/requests/tariff_updates_controller_spec.rb
+++ b/spec/requests/tariff_updates_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe TariffUpdatesController do
   subject(:rendered_page) { make_request && response }
 
   include_context "with authenticated user"
+  let(:current_user) { create(:user, :superadmin) }
 
   describe "GET #index" do
     before do
@@ -30,6 +31,13 @@ RSpec.describe TariffUpdatesController do
 
     it { is_expected.to have_http_status :forbidden }
     it { is_expected.to have_attributes body: /contact your Delivery Manager/ }
+  end
+
+  context "when technical operator" do
+    let(:current_user) { create(:user, :technical_operator) }
+    let(:make_request) { get tariff_updates_path }
+
+    it { is_expected.to have_http_status :forbidden }
   end
 
   describe "POST #download" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -19,6 +19,7 @@ RSpec.describe UsersController do
   end
 
   describe "GET #new" do
+    let(:current_user) { create(:user, :superadmin) }
     let(:make_request) { get new_user_path }
 
     it { is_expected.to have_http_status :success }
@@ -26,7 +27,7 @@ RSpec.describe UsersController do
     it "displays fields for email and role selection", :aggregate_failures do
       rendered_page
 
-      expect(response.body).to include("Email address", "radio", User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
+      expect(response.body).to include("Email address", "radio", User::SUPERADMIN, User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
     end
   end
 
@@ -37,7 +38,7 @@ RSpec.describe UsersController do
 
     it "displays radio buttons for role selection", :aggregate_failures do
       rendered_page
-      expect(response.body).to include("radio", User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
+      expect(response.body).to include("radio", User::SUPERADMIN, User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
     end
 
     it "preselects the current role" do
@@ -47,6 +48,7 @@ RSpec.describe UsersController do
   end
 
   describe "POST #create" do
+    let(:current_user) { create(:user, :superadmin) }
     let(:make_request) do
       post users_path,
            params: { user: new_user_params }
@@ -164,6 +166,7 @@ RSpec.describe UsersController do
   end
 
   describe "DELETE #destroy" do
+    let(:current_user) { create(:user, :superadmin) }
     let(:make_request) { delete user_path(target_user) }
 
     it { is_expected.to redirect_to users_path }
@@ -205,8 +208,20 @@ RSpec.describe UsersController do
     it { is_expected.to have_http_status :forbidden }
   end
 
-  context "when non-technical operator tries to remove a user" do
+  context "when technical operator tries to add a user" do
+    let(:make_request) { get new_user_path }
+
+    it { is_expected.to have_http_status :forbidden }
+  end
+
+  context "when non-superadmin tries to remove a user" do
     let(:current_user) { create(:user, :hmrc_admin) }
+    let(:make_request) { delete user_path(target_user) }
+
+    it { is_expected.to have_http_status :forbidden }
+  end
+
+  context "when technical operator tries to remove a user" do
     let(:make_request) { delete user_path(target_user) }
 
     it { is_expected.to have_http_status :forbidden }


### PR DESCRIPTION
### Jira link

OTTIMP-463

### Depends on

- Stacked on #1172 (`OTTIMP-460/invite-admin-user-ui`)

### What?

- [x] Add a `SUPERADMIN` role in the admin portal
- [x] Make `SUPERADMIN` inherit `TECHNICAL_OPERATOR` access through the shared role helpers
- [x] Restrict high-risk paths to `SUPERADMIN`: classification configuration, updates, rollbacks, and admin user create/delete
- [x] Update navigation and request/policy/spec coverage for the new split

### Why?

- the admin portal contains high-risk paths that can materially change guided search behaviour and operational state
- those paths need stricter access control than the broader `TECHNICAL_OPERATOR` role
- stacking on #1172 keeps the user-management flow and the superadmin follow-up separate

### Have you? (optional)

- [ ] Reviewed view changes with stakeholders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- stacked PR: merge #1172 first, then this PR
- `TECHNICAL_OPERATOR` can still update an existing user's role, so promoting someone to `SUPERADMIN` is still possible via the edit flow unless that is tightened separately
- focused checks passed with `asdf exec bundle exec rspec spec/policies/admin_configuration_policy_spec.rb spec/policies/update_policy_spec.rb spec/policies/rollback_policy_spec.rb spec/policies/application_policy_spec.rb spec/policies/user_policy_spec.rb spec/policies/rbac_comprehensive_spec.rb spec/requests/classification_configurations_controller_spec.rb spec/requests/tariff_updates_controller_spec.rb spec/requests/rollbacks_controller_spec.rb spec/requests/users_controller_spec.rb spec/helpers/navigation_helper_spec.rb`, `asdf exec bundle exec rubocop`, and `asdf exec bundle exec brakeman -q`
- full `asdf exec bundle exec rspec` currently fails in `spec/features/rollbacks_spec.rb` because that feature still expects `TECHNICAL_OPERATOR` rollback creation access
