### PR TITLE
AI-553: Add multi-select admin configuration UI

### DIFF
--- a/app/controllers/classification_configurations_controller.rb
+++ b/app/controllers/classification_configurations_controller.rb
@@ -67,7 +67,7 @@ private
   def configuration_params
     permitted = params.require(:classification_configuration).permit(:value).to_h
 
-    if permitted[:value].is_a?(String) && permitted[:value].start_with?("{")
+    if permitted[:value].is_a?(String) && permitted[:value].match?(/\A\s*[\[{]/)
       begin
         permitted[:value] = JSON.parse(permitted[:value])
       rescue JSON::ParserError

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -37,6 +37,18 @@ class AdminConfiguration
     option&.dig("label") || selected
   end
 
+  def multi_selected_labels
+    return [] unless config_type == "multi_options" && value.is_a?(Hash)
+
+    selected_values = Array(value["selected"])
+    options = value["options"] || []
+
+    selected_values.filter_map do |selected|
+      option = options.find { |o| o["key"] == selected }
+      option&.dig("label") || selected
+    end
+  end
+
   def nested_selected_label
     return unless config_type == "nested_options" && value.is_a?(Hash)
 
@@ -63,6 +75,8 @@ class AdminConfiguration
       value.to_s
     when "options"
       selected_option_label
+    when "multi_options"
+      multi_selected_labels.join(", ")
     when "nested_options"
       label = nested_selected_label
       sub_values = value.is_a?(Hash) ? value["sub_values"] : nil

--- a/app/views/classification_configurations/_form.html.erb
+++ b/app/views/classification_configurations/_form.html.erb
@@ -42,6 +42,51 @@
         <% end %>
       </select>
     </div>
+  <% when "multi_options" %>
+    <% options = configuration.value.is_a?(Hash) ? (configuration.value["options"] || []) : [] %>
+    <% selected_values = configuration.value.is_a?(Hash) ? Array(configuration.value["selected"]) : [] %>
+
+    <input type="hidden"
+           id="multi-options-hidden-field"
+           name="classification_configuration[value]"
+           value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>">
+
+    <div class="govuk-form-group">
+      <fieldset class="govuk-fieldset">
+        <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Selected values</legend>
+        <div class="govuk-hint">Choose which options are active for this configuration</div>
+        <div class="govuk-checkboxes">
+          <% options.each do |opt| %>
+            <% option_key = opt["key"] %>
+            <% option_label = opt["label"] || option_key %>
+            <div class="govuk-checkboxes__item">
+              <input class="govuk-checkboxes__input"
+                     id="multi-option-<%= option_key %>"
+                     type="checkbox"
+                     value="<%= option_key %>"
+                     <%= "checked" if selected_values.include?(option_key) %>
+                     onchange="(function(box){
+                       var hidden = document.getElementById('multi-options-hidden-field');
+                       var data = JSON.parse(hidden.value);
+                       var selected = Array.isArray(data.selected) ? data.selected : [];
+
+                       if (box.checked) {
+                         if (!selected.includes(box.value)) selected.push(box.value);
+                       } else {
+                         selected = selected.filter(function(value) { return value !== box.value; });
+                       }
+
+                       data.selected = selected;
+                       hidden.value = JSON.stringify(data);
+                     })(this)">
+              <label class="govuk-label govuk-checkboxes__label" for="multi-option-<%= option_key %>">
+                <%= option_label %>
+              </label>
+            </div>
+          <% end %>
+        </div>
+      </fieldset>
+    </div>
   <% when "nested_options" %>
     <% options = configuration.value.is_a?(Hash) ? (configuration.value["options"] || []) : [] %>
     <% selected_value = configuration.value.is_a?(Hash) ? configuration.value["selected"] : "" %>

--- a/app/views/classification_configurations/index.html.erb
+++ b/app/views/classification_configurations/index.html.erb
@@ -37,6 +37,11 @@
                 <label class="govuk-label govuk-radios__label" for="ct-type-markdown">Markdown</label>
               </div>
               <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="ct-type-multi-options" name="ct_type" type="radio" value="multi_options"
+                       data-action="change->config-table#changeType" data-config-type="multi_options">
+                <label class="govuk-label govuk-radios__label" for="ct-type-multi-options">Multi options</label>
+              </div>
+              <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="ct-type-nested-options" name="ct_type" type="radio" value="nested_options"
                        data-action="change->config-table#changeType" data-config-type="nested_options">
                 <label class="govuk-label govuk-radios__label" for="ct-type-nested-options">Nested options</label>
@@ -85,6 +90,8 @@
                     <%= config.value %>
                   <% when "options" %>
                     <%= config.selected_option_label %>
+                  <% when "multi_options" %>
+                    <%= config.multi_selected_labels.join(", ") %>
                   <% when "nested_options" %>
                     <%= config.nested_selected_label %>
                     <% sub_values = config.value.is_a?(Hash) ? (config.value["sub_values"] || {}) : {} %>

--- a/app/views/classification_configurations/show.html.erb
+++ b/app/views/classification_configurations/show.html.erb
@@ -59,6 +59,46 @@
             </tbody>
           </table>
         <% end %>
+      <% when "multi_options" %>
+        <% if @configuration.value.is_a?(Hash) %>
+          <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-4">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Selected</dt>
+              <dd class="govuk-summary-list__value"><%= @configuration.multi_selected_labels.join(", ") %></dd>
+            </div>
+          </dl>
+
+          <details class="govuk-details govuk-!-margin-bottom-0">
+            <summary class="govuk-details__summary">
+              <span class="govuk-details__summary-text">Available options</span>
+            </summary>
+            <div class="govuk-details__text">
+              <table class="govuk-table govuk-!-margin-bottom-0">
+                <thead class="govuk-table__head">
+                  <tr class="govuk-table__row">
+                    <th class="govuk-table__header" scope="col">Key</th>
+                    <th class="govuk-table__header" scope="col">Label</th>
+                    <th class="govuk-table__header" scope="col">Selected</th>
+                  </tr>
+                </thead>
+                <tbody class="govuk-table__body">
+                  <% selected_values = Array(@configuration.value["selected"]) %>
+                  <% (@configuration.value["options"] || []).each do |opt| %>
+                    <tr class="govuk-table__row">
+                      <td class="govuk-table__cell"><%= opt["key"] %></td>
+                      <td class="govuk-table__cell"><%= opt["label"] %></td>
+                      <td class="govuk-table__cell">
+                        <% if selected_values.include?(opt["key"]) %>
+                          <strong class="govuk-tag">Selected</strong>
+                        <% end %>
+                      </td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+            </div>
+          </details>
+        <% end %>
       <% when "nested_options" %>
         <% if @configuration.value.is_a?(Hash) %>
           <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-4">

--- a/spec/requests/classification_configurations_controller_spec.rb
+++ b/spec/requests/classification_configurations_controller_spec.rb
@@ -91,6 +91,24 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
               "deleted" => false,
             },
           },
+          {
+            type: "admin_configuration",
+            id: "interactive_search_excluded_chapters",
+            attributes: {
+              "name" => "interactive_search_excluded_chapters",
+              "value" => {
+                "selected" => %w[98 99],
+                "options" => [
+                  { "key" => "98", "label" => "Chapter 98" },
+                  { "key" => "99", "label" => "Chapter 99" },
+                ],
+              },
+              "config_type" => "multi_options",
+              "area" => "classification",
+              "description" => "Chapters excluded from guided search results",
+              "deleted" => false,
+            },
+          },
         ],
       }.to_json,
     }
@@ -149,6 +167,10 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
     it "displays options values as selected label" do
       expect(rendered_page.body).to include("GPT-4o (multimodal)")
+    end
+
+    it "displays multi_options values as selected labels" do
+      expect(rendered_page.body).to include("Chapter 98, Chapter 99")
     end
 
     it "displays markdown/string values truncated" do
@@ -266,6 +288,33 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
       it "displays the integer value in a pre block" do
         expect(rendered_page.body).to include("<pre>250</pre>")
+      end
+    end
+
+    context "with a multi_options config" do
+      let(:config_name) { "interactive_search_excluded_chapters" }
+      let(:config_attributes) do
+        {
+          "name" => "interactive_search_excluded_chapters",
+          "value" => {
+            "selected" => %w[98 99],
+            "options" => [
+              { "key" => "97", "label" => "Chapter 97" },
+              { "key" => "98", "label" => "Chapter 98" },
+              { "key" => "99", "label" => "Chapter 99" },
+            ],
+          },
+          "config_type" => "multi_options",
+          "area" => "classification",
+          "description" => "Chapters excluded from guided search results",
+          "deleted" => false,
+        }
+      end
+
+      it "displays selected values and available options", :aggregate_failures do
+        expect(rendered_page.body).to include("Chapter 98")
+        expect(rendered_page.body).to include("Chapter 99")
+        expect(rendered_page.body).to include("Chapter 97")
       end
     end
 
@@ -413,6 +462,34 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
       it "renders a number field" do
         expect(rendered_page.body).to include('type="number"')
+      end
+    end
+
+    context "with a multi_options config" do
+      let(:config_name) { "interactive_search_excluded_chapters" }
+      let(:config_attributes) do
+        {
+          "name" => "interactive_search_excluded_chapters",
+          "value" => {
+            "selected" => %w[98 99],
+            "options" => [
+              { "key" => "97", "label" => "Chapter 97" },
+              { "key" => "98", "label" => "Chapter 98" },
+              { "key" => "99", "label" => "Chapter 99" },
+            ],
+          },
+          "config_type" => "multi_options",
+          "area" => "classification",
+          "description" => "Chapters excluded from guided search results",
+          "deleted" => false,
+        }
+      end
+
+      it "renders checkboxes for available chapter options", :aggregate_failures do
+        expect(rendered_page.body).to include('type="checkbox"')
+        expect(rendered_page.body).to include("Chapter 97")
+        expect(rendered_page.body).to include("Chapter 98")
+        expect(rendered_page.body).to include("Chapter 99")
       end
     end
 
@@ -602,6 +679,52 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
       before do
         stub_api_request("/admin_configurations/#{config_name}", :patch)
+          .and_return(config_response)
+      end
+
+      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+    end
+
+    context "with a multi_options config JSON value" do
+      let(:config_name) { "interactive_search_excluded_chapters" }
+      let(:multi_options_json) do
+        '{"selected":["97","99"],"options":[{"key":"97","label":"Chapter 97"},{"key":"98","label":"Chapter 98"},{"key":"99","label":"Chapter 99"}]}'
+      end
+      let(:config_attributes) do
+        {
+          "name" => "interactive_search_excluded_chapters",
+          "value" => JSON.parse(multi_options_json),
+          "config_type" => "multi_options",
+          "area" => "classification",
+          "description" => "Chapters excluded from guided search results",
+          "deleted" => false,
+        }
+      end
+      let(:make_request) do
+        patch classification_configuration_path(config_name),
+              params: {
+                classification_configuration: {
+                  value: multi_options_json,
+                },
+              }
+      end
+
+      before do
+        stub_api_request("/admin_configurations/#{config_name}", :patch)
+          .with(body: hash_including(
+            "data" => hash_including(
+              "attributes" => hash_including(
+                "value" => {
+                  "selected" => %w[97 99],
+                  "options" => [
+                    { "key" => "97", "label" => "Chapter 97" },
+                    { "key" => "98", "label" => "Chapter 98" },
+                    { "key" => "99", "label" => "Chapter 99" },
+                  ],
+                },
+              ),
+            ),
+          ))
           .and_return(config_response)
       end
 


### PR DESCRIPTION
### Jira link

[AI-553](https://transformuk.atlassian.net/browse/AI-553)

<img width="1381" height="956" alt="image" src="https://github.com/user-attachments/assets/0d207e4a-575b-4153-bc59-9874de3dbf8a" />
<img width="1393" height="1198" alt="image" src="https://github.com/user-attachments/assets/640deb6c-5294-4313-8476-cef13533e612" />
<img width="1393" height="1198" alt="image" src="https://github.com/user-attachments/assets/5854aed5-427b-4fca-a717-a488ad742cc6" />


### What?

- [x] Add `multi_options` rendering support to admin configuration views
- [x] Add checkbox editing for multi-select configuration values
- [x] Add request spec coverage for listing, showing and updating excluded chapters

### Why?

- This is needed to configure which chapters are searchable as part of tactical release generally but also as part of specific chapters that should never be searched through
