### PR TITLE
AI-553: Extract configuration form javascript to Stimulus

### DIFF
--- a/app/views/classification_configurations/_form.html.erb
+++ b/app/views/classification_configurations/_form.html.erb
@@ -1,4 +1,9 @@
-<%= govuk_form_for configuration, as: :classification_configuration, url: classification_configuration_path(configuration) do |f| %>
+<% form_data = %w[options multi_options nested_options].include?(configuration.config_type) ? { controller: 'config-form' } : {} %>
+
+<%= govuk_form_for configuration,
+                   as: :classification_configuration,
+                   url: classification_configuration_path(configuration),
+                   html: { data: form_data } do |f| %>
 
   <% case configuration.config_type %>
   <% when "markdown" %>
@@ -13,29 +18,24 @@
     <%= f.govuk_number_field :value, label: { text: "Value" } %>
   <% when "date" %>
     <%= f.govuk_text_field :value,
-                            label: { text: "Value" },
-                            hint: { text: "YYYY-MM-DD" },
-                            width: "one-third" %>
+                           label: { text: "Value" },
+                           hint: { text: "YYYY-MM-DD" },
+                           width: "one-third" %>
   <% when "options" %>
     <% options = configuration.value.is_a?(Hash) ? (configuration.value["options"] || []) : [] %>
     <% selected = configuration.value.is_a?(Hash) ? configuration.value["selected"] : "" %>
 
     <input type="hidden"
-           id="options-hidden-field"
            name="classification_configuration[value]"
-           value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>">
+           value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>"
+           data-config-form-target="hiddenField">
 
     <div class="govuk-form-group">
       <label class="govuk-label" for="options-selected-value">Selected value</label>
       <div class="govuk-hint">Choose which option is the active value</div>
       <select class="govuk-select"
               id="options-selected-value"
-              onchange="(function(sel){
-                var hidden = document.getElementById('options-hidden-field');
-                var data = JSON.parse(hidden.value);
-                data.selected = sel.value;
-                hidden.value = JSON.stringify(data);
-              })(this)">
+              data-action="change->config-form#updateOption">
         <option value="">-- Select a value --</option>
         <% options.each do |opt| %>
           <option value="<%= opt["key"] %>" <%= "selected" if opt["key"] == selected %>><%= opt["label"] || opt["key"] %></option>
@@ -47,9 +47,9 @@
     <% selected_values = configuration.value.is_a?(Hash) ? Array(configuration.value["selected"]) : [] %>
 
     <input type="hidden"
-           id="multi-options-hidden-field"
            name="classification_configuration[value]"
-           value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>">
+           value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>"
+           data-config-form-target="hiddenField">
 
     <div class="govuk-form-group">
       <fieldset class="govuk-fieldset">
@@ -65,20 +65,7 @@
                      type="checkbox"
                      value="<%= option_key %>"
                      <%= "checked" if selected_values.include?(option_key) %>
-                     onchange="(function(box){
-                       var hidden = document.getElementById('multi-options-hidden-field');
-                       var data = JSON.parse(hidden.value);
-                       var selected = Array.isArray(data.selected) ? data.selected : [];
-
-                       if (box.checked) {
-                         if (!selected.includes(box.value)) selected.push(box.value);
-                       } else {
-                         selected = selected.filter(function(value) { return value !== box.value; });
-                       }
-
-                       data.selected = selected;
-                       hidden.value = JSON.stringify(data);
-                     })(this)">
+                     data-action="change->config-form#updateMultiOption">
               <label class="govuk-label govuk-checkboxes__label" for="multi-option-<%= option_key %>">
                 <%= option_label %>
               </label>
@@ -93,16 +80,17 @@
     <% sub_values = configuration.value.is_a?(Hash) ? (configuration.value["sub_values"] || {}) : {} %>
 
     <input type="hidden"
-           id="nested-options-hidden-field"
            name="classification_configuration[value]"
-           value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>">
+           value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>"
+           data-config-form-target="hiddenField">
 
     <div class="govuk-form-group">
       <label class="govuk-label" for="nested-options-selected">Selected value</label>
       <div class="govuk-hint">Choose the primary value for this configuration</div>
       <select class="govuk-select"
               id="nested-options-selected"
-              onchange="updateNestedOptions()">
+              data-config-form-target="nestedSelect"
+              data-action="change->config-form#updateNestedOption">
         <option value="">-- Select a value --</option>
         <% options.each do |opt| %>
           <option value="<%= opt["key"] %>"
@@ -112,85 +100,7 @@
       </select>
     </div>
 
-    <div id="nested-sub-options-container"></div>
-
-    <script>
-      (function() {
-        var mainSelect = document.getElementById('nested-options-selected');
-        var container = document.getElementById('nested-sub-options-container');
-        var hiddenField = document.getElementById('nested-options-hidden-field');
-        var currentSubValues = <%= sub_values.to_json.html_safe %>;
-
-        function rebuildSubOptions() {
-          container.innerHTML = '';
-          var selectedOption = mainSelect.options[mainSelect.selectedIndex];
-          if (!selectedOption || !selectedOption.value) return;
-
-          var subOptions = {};
-          try { subOptions = JSON.parse(selectedOption.getAttribute('data-sub-options') || '{}'); } catch(e) {}
-
-          Object.keys(subOptions).forEach(function(key) {
-            var levels = subOptions[key];
-            if (!Array.isArray(levels) || levels.length === 0) return;
-
-            var group = document.createElement('div');
-            group.className = 'govuk-form-group';
-
-            var label = document.createElement('label');
-            label.className = 'govuk-label';
-            label.setAttribute('for', 'nested-sub-' + key);
-            label.textContent = key.replace(/_/g, ' ').replace(/\b\w/g, function(c) { return c.toUpperCase(); });
-            group.appendChild(label);
-
-            var select = document.createElement('select');
-            select.className = 'govuk-select';
-            select.id = 'nested-sub-' + key;
-            select.setAttribute('data-sub-key', key);
-            select.onchange = syncHiddenField;
-
-            var noneOpt = document.createElement('option');
-            noneOpt.value = '';
-            noneOpt.textContent = 'None';
-            select.appendChild(noneOpt);
-
-            levels.forEach(function(level) {
-              if (level === 'none') return;
-              var opt = document.createElement('option');
-              opt.value = level;
-              opt.textContent = level.charAt(0).toUpperCase() + level.slice(1);
-              select.appendChild(opt);
-            });
-
-            select.value = currentSubValues[key] || '';
-
-            group.appendChild(select);
-            container.appendChild(group);
-          });
-
-          syncHiddenField();
-        }
-
-        function syncHiddenField() {
-          var data = JSON.parse(hiddenField.value);
-          data.selected = mainSelect.value;
-
-          var sv = {};
-          container.querySelectorAll('select[data-sub-key]').forEach(function(sel) {
-            sv[sel.getAttribute('data-sub-key')] = sel.value || null;
-          });
-          data.sub_values = sv;
-          currentSubValues = sv;
-
-          hiddenField.value = JSON.stringify(data);
-        }
-
-        mainSelect.onchange = function() {
-          rebuildSubOptions();
-        };
-
-        rebuildSubOptions();
-      })();
-    </script>
+    <div data-config-form-target="nestedSubOptionsContainer" data-sub-values="<%= sub_values.to_json %>"></div>
   <% else %>
     <%= f.govuk_text_area :value,
                           label: { text: "Value" },

--- a/app/webpacker/controllers/config_form_controller.js
+++ b/app/webpacker/controllers/config_form_controller.js
@@ -1,0 +1,137 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  static get targets() {
+    return ['hiddenField', 'nestedSelect', 'nestedSubOptionsContainer'];
+  }
+
+  connect() {
+    if (this.hasNestedSelectTarget && this.hasNestedSubOptionsContainerTarget) {
+      this.rebuildNestedSubOptions();
+    }
+  }
+
+  updateOption(event) {
+    var data = this.parseHiddenValue();
+    data.selected = event.currentTarget.value;
+    this.writeHiddenValue(data);
+  }
+
+  updateMultiOption(event) {
+    var data = this.parseHiddenValue();
+    var selected = Array.isArray(data.selected) ? data.selected.slice() : [];
+    var value = event.currentTarget.value;
+
+    if (event.currentTarget.checked) {
+      if (selected.indexOf(value) === -1) {
+        selected.push(value);
+      }
+    } else {
+      selected = selected.filter(function(item) { return item !== value; });
+    }
+
+    data.selected = selected;
+    this.writeHiddenValue(data);
+  }
+
+  updateNestedOption() {
+    this.rebuildNestedSubOptions();
+  }
+
+  syncNestedSubValues() {
+    this.writeHiddenValue(this.currentNestedValue());
+  }
+
+  rebuildNestedSubOptions() {
+    var container = this.nestedSubOptionsContainerTarget;
+    var selectedOption = this.nestedSelectTarget.options[this.nestedSelectTarget.selectedIndex];
+
+    container.innerHTML = '';
+
+    if (!selectedOption || !selectedOption.value) {
+      this.writeHiddenValue(this.currentNestedValue());
+      return;
+    }
+
+    var currentData = this.parseHiddenValue();
+    var currentSubValues = this.normalizeSubValues(currentData.sub_values);
+    var subOptions = this.parseJson(selectedOption.dataset.subOptions);
+
+    Object.keys(subOptions).forEach(function(key) {
+      var levels = subOptions[key];
+      if (!Array.isArray(levels) || levels.length === 0) return;
+
+      var group = document.createElement('div');
+      group.className = 'govuk-form-group';
+
+      var label = document.createElement('label');
+      label.className = 'govuk-label';
+      label.setAttribute('for', 'nested-sub-' + key);
+      label.textContent = key.replace(/_/g, ' ').replace(/\b\w/g, function(char) { return char.toUpperCase(); });
+      group.appendChild(label);
+
+      var select = document.createElement('select');
+      select.className = 'govuk-select';
+      select.id = 'nested-sub-' + key;
+      select.setAttribute('data-sub-key', key);
+      select.setAttribute('data-action', 'change->config-form#syncNestedSubValues');
+
+      var noneOption = document.createElement('option');
+      noneOption.value = '';
+      noneOption.textContent = 'None';
+      select.appendChild(noneOption);
+
+      levels.forEach(function(level) {
+        if (level === 'none') return;
+
+        var option = document.createElement('option');
+        option.value = level;
+        option.textContent = level.charAt(0).toUpperCase() + level.slice(1);
+        select.appendChild(option);
+      });
+
+      select.value = currentSubValues[key] || '';
+      group.appendChild(select);
+      container.appendChild(group);
+    });
+
+    this.writeHiddenValue(this.currentNestedValue());
+  }
+
+  currentNestedValue() {
+    var data = this.parseHiddenValue();
+    data.selected = this.nestedSelectTarget.value;
+    data.sub_values = this.collectNestedSubValues();
+    return data;
+  }
+
+  collectNestedSubValues() {
+    var subValues = {};
+
+    this.nestedSubOptionsContainerTarget.querySelectorAll('select[data-sub-key]').forEach(function(select) {
+      subValues[select.dataset.subKey] = select.value || null;
+    });
+
+    return subValues;
+  }
+
+  normalizeSubValues(subValues) {
+    return subValues && typeof subValues === 'object' ? subValues : {};
+  }
+
+  parseHiddenValue() {
+    return this.parseJson(this.hiddenFieldTarget.value);
+  }
+
+  writeHiddenValue(data) {
+    this.hiddenFieldTarget.value = JSON.stringify(data);
+  }
+
+  parseJson(value) {
+    try {
+      return JSON.parse(value || '{}');
+    } catch (_error) {
+      return {};
+    }
+  }
+}

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -22,6 +22,7 @@ import SelfTextTableController from '../controllers/self_text_table_controller';
 import LabelTableController from '../controllers/label_table_controller';
 import ScoredTagListController from '../controllers/scored_tag_list_controller';
 import ConfigTableController from '../controllers/config_table_controller';
+import ConfigFormController from '../controllers/config_form_controller';
 
 import '../javascripts/markdown-preview';
 
@@ -33,3 +34,4 @@ application.register('self-text-table', SelfTextTableController);
 application.register('label-table', LabelTableController);
 application.register('scored-tag-list', ScoredTagListController);
 application.register('config-table', ConfigTableController);
+application.register('config-form', ConfigFormController);

--- a/spec/requests/classification_configurations_controller_spec.rb
+++ b/spec/requests/classification_configurations_controller_spec.rb
@@ -407,6 +407,14 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         expect(rendered_page.body).not_to include("Add option")
         expect(rendered_page.body).not_to include("Remove")
       end
+
+      it "uses stimulus instead of inline javascript", :aggregate_failures do
+        body = rendered_page.body
+        expect(body).to include('data-controller="config-form"')
+        expect(body).to include('data-action="change->config-form#updateOption"')
+        expect(body).not_to include("onchange=")
+        expect(body).not_to include("<script>")
+      end
     end
 
     context "with a boolean config" do
@@ -490,6 +498,58 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         expect(rendered_page.body).to include("Chapter 97")
         expect(rendered_page.body).to include("Chapter 98")
         expect(rendered_page.body).to include("Chapter 99")
+      end
+
+      it "uses stimulus instead of inline javascript", :aggregate_failures do
+        body = rendered_page.body
+        expect(body).to include('data-controller="config-form"')
+        expect(body).to include('data-action="change->config-form#updateMultiOption"')
+        expect(body).not_to include("onchange=")
+        expect(body).not_to include("<script>")
+      end
+    end
+
+    context "with a nested_options config" do
+      let(:config_name) { "search_term_confidence_thresholds" }
+      let(:config_attributes) do
+        {
+          "name" => "search_term_confidence_thresholds",
+          "value" => {
+            "selected" => "strict",
+            "options" => [
+              {
+                "key" => "strict",
+                "label" => "Strict",
+                "sub_options" => {
+                  "minimum_confidence" => %w[high medium low],
+                },
+              },
+              {
+                "key" => "relaxed",
+                "label" => "Relaxed",
+                "sub_options" => {
+                  "minimum_confidence" => %w[medium low],
+                },
+              },
+            ],
+            "sub_values" => {
+              "minimum_confidence" => "medium",
+            },
+          },
+          "config_type" => "nested_options",
+          "area" => "classification",
+          "description" => "Thresholds for search term confidence",
+          "deleted" => false,
+        }
+      end
+
+      it "uses stimulus instead of inline javascript", :aggregate_failures do
+        body = rendered_page.body
+        expect(body).to include('data-controller="config-form"')
+        expect(body).to include('data-action="change->config-form#updateNestedOption"')
+        expect(body).to include('data-config-form-target="nestedSubOptionsContainer"')
+        expect(body).not_to include("onchange=")
+        expect(body).not_to include("<script>")
       end
     end
 


### PR DESCRIPTION
### Jira link

[AI-553](https://transformuk.atlassian.net/browse/AI-553)

### What?

- [x] Add a Stimulus controller for JSON-backed classification configuration form inputs
- [x] Remove inline JavaScript from `options`, `multi_options`, and `nested_options` edit flows
- [x] Extend request specs to assert Stimulus wiring and absence of inline handlers

### Why?

The excluded chapters work introduced more inline JavaScript in the configuration form partial. This follow-up keeps the behaviour the same while moving that logic into Stimulus so the form is easier to maintain, test, and extend.
