### PR TITLE
BAU: Fix descriptions table boundary overflow

### DIFF
--- a/app/views/goods_nomenclature_self_texts/index.html.erb
+++ b/app/views/goods_nomenclature_self_texts/index.html.erb
@@ -163,7 +163,7 @@
 
       <div class="govuk-grid-column-three-quarters">
         <p class="govuk-body" data-self-text-table-target="loading">Loading...</p>
-        <div data-self-text-table-target="table"></div>
+        <div class="self-text-table-container" data-self-text-table-target="table"></div>
         <div data-self-text-table-target="pagination"></div>
       </div>
     </div>

--- a/app/views/goods_nomenclature_self_texts/index.html.erb
+++ b/app/views/goods_nomenclature_self_texts/index.html.erb
@@ -304,7 +304,7 @@
 
       <div class="govuk-grid-column-three-quarters">
         <p class="govuk-body" data-label-table-target="loading">Loading...</p>
-        <div data-label-table-target="table"></div>
+        <div class="label-table-container" data-label-table-target="table"></div>
         <div data-label-table-target="pagination"></div>
       </div>
     </div>

--- a/app/webpacker/controllers/label_table_controller.js
+++ b/app/webpacker/controllers/label_table_controller.js
@@ -132,12 +132,12 @@ export default class extends Controller {
         col + '">' + label + arrow(col) + '</a>';
     };
 
-    var html = '<table class="govuk-table">' +
+    var html = '<table class="govuk-table label-table">' +
       '<thead class="govuk-table__head"><tr class="govuk-table__row">' +
-      '<th class="govuk-table__header" scope="col">' + sortHeader('goods_nomenclature_item_id', 'Commodity code') + '</th>' +
-      '<th class="govuk-table__header" scope="col">' + sortHeader('score', 'Score') + '</th>' +
-      '<th class="govuk-table__header" scope="col">Status</th>' +
-      '<th class="govuk-table__header" scope="col">Description</th>' +
+      '<th class="govuk-table__header label-table__code" scope="col">' + sortHeader('goods_nomenclature_item_id', 'Commodity code') + '</th>' +
+      '<th class="govuk-table__header label-table__score" scope="col">' + sortHeader('score', 'Score') + '</th>' +
+      '<th class="govuk-table__header label-table__status" scope="col">Status</th>' +
+      '<th class="govuk-table__header label-table__description" scope="col">Description</th>' +
       '</tr></thead><tbody class="govuk-table__body">';
 
     data.forEach(function(label) {
@@ -145,10 +145,10 @@ export default class extends Controller {
       var sc = self.scoreMeta(label.score);
 
       html += '<tr class="govuk-table__row">' +
-        '<td class="govuk-table__cell"><a href="' + showUrl + '" class="govuk-link">' + self.escapeHtml(label.goods_nomenclature_item_id) + '</a></td>' +
-        '<td class="govuk-table__cell">' + sc.tag + '</td>' +
-        '<td class="govuk-table__cell">' + self.statusTags(label) + '</td>' +
-        '<td class="govuk-table__cell">' + self.escapeHtml(label.description || '') + '</td>' +
+        '<td class="govuk-table__cell label-table__code"><a href="' + showUrl + '" class="govuk-link">' + self.escapeHtml(label.goods_nomenclature_item_id) + '</a></td>' +
+        '<td class="govuk-table__cell label-table__score">' + sc.tag + '</td>' +
+        '<td class="govuk-table__cell label-table__status">' + self.statusTags(label) + '</td>' +
+        '<td class="govuk-table__cell label-table__description">' + self.escapeHtml(label.description || '') + '</td>' +
         '</tr>';
     });
 

--- a/app/webpacker/controllers/self_text_table_controller.js
+++ b/app/webpacker/controllers/self_text_table_controller.js
@@ -124,12 +124,12 @@ export default class extends Controller {
         col + '">' + label + arrow(col) + '</a>';
     };
 
-    var html = '<table class="govuk-table">' +
+    var html = '<table class="govuk-table self-text-table">' +
       '<thead class="govuk-table__head"><tr class="govuk-table__row">' +
-      '<th class="govuk-table__header" scope="col">' + sortHeader('goods_nomenclature_item_id', 'Commodity code') + '</th>' +
-      '<th class="govuk-table__header" scope="col">' + sortHeader('score', 'Score') + '</th>' +
-      '<th class="govuk-table__header" scope="col">Status</th>' +
-      '<th class="govuk-table__header" scope="col">Self-text</th>' +
+      '<th class="govuk-table__header self-text-table__code" scope="col">' + sortHeader('goods_nomenclature_item_id', 'Commodity code') + '</th>' +
+      '<th class="govuk-table__header self-text-table__score" scope="col">' + sortHeader('score', 'Score') + '</th>' +
+      '<th class="govuk-table__header self-text-table__status" scope="col">Status</th>' +
+      '<th class="govuk-table__header self-text-table__description" scope="col">Self-text</th>' +
       '</tr></thead><tbody class="govuk-table__body">';
 
     data.forEach(function(st) {
@@ -137,10 +137,10 @@ export default class extends Controller {
       var sc = self.scoreMeta(st.score);
 
       html += '<tr class="govuk-table__row" data-score="' + (st.score !== null && st.score !== undefined ? st.score : '') + '" data-score-category="' + sc.category + '">' +
-        '<td class="govuk-table__cell"><a href="' + showUrl + '" class="govuk-link">' + self.escapeHtml(st.goods_nomenclature_item_id) + '</a></td>' +
-        '<td class="govuk-table__cell">' + sc.tag + '</td>' +
-        '<td class="govuk-table__cell">' + self.statusTags(st) + '</td>' +
-        '<td class="govuk-table__cell">' + self.escapeHtml(st.self_text || '') + '</td>' +
+        '<td class="govuk-table__cell self-text-table__code"><a href="' + showUrl + '" class="govuk-link">' + self.escapeHtml(st.goods_nomenclature_item_id) + '</a></td>' +
+        '<td class="govuk-table__cell self-text-table__score">' + sc.tag + '</td>' +
+        '<td class="govuk-table__cell self-text-table__status">' + self.statusTags(st) + '</td>' +
+        '<td class="govuk-table__cell self-text-table__description">' + self.escapeHtml(st.self_text || '') + '</td>' +
         '</tr>';
     });
 

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -200,6 +200,32 @@ $govuk-image-url-function: frontend-image-url;
   }
 }
 
+.self-text-table-container {
+  overflow-x: hidden;
+}
+
+.self-text-table {
+  table-layout: fixed;
+  width: 100%;
+
+  &__code {
+    width: 18%;
+  }
+
+  &__score {
+    width: 11%;
+  }
+
+  &__status {
+    width: 12%;
+  }
+
+  &__description {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}
+
 #ca-search-container {
   display: flex;
 }

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -226,6 +226,32 @@ $govuk-image-url-function: frontend-image-url;
   }
 }
 
+.label-table-container {
+  overflow-x: hidden;
+}
+
+.label-table {
+  table-layout: fixed;
+  width: 100%;
+
+  &__code {
+    width: 18%;
+  }
+
+  &__score {
+    width: 11%;
+  }
+
+  &__status {
+    width: 12%;
+  }
+
+  &__description {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}
+
 #ca-search-container {
   display: flex;
 }

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -81,6 +81,10 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
         expect(rendered_page.body).to include('class="self-text-table-container" data-self-text-table-target="table"')
       end
 
+      it "renders the labels table inside a bounded container" do
+        expect(rendered_page.body).to include('class="label-table-container" data-label-table-target="table"')
+      end
+
       it "defines a fixed layout for the self-text table styles" do
         stylesheet = Rails.root.join("app/webpacker/packs/application.scss").read
 
@@ -91,6 +95,18 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
         stylesheet = Rails.root.join("app/webpacker/packs/application.scss").read
 
         expect(stylesheet).to match(/\.self-text-table\s*\{[\s\S]*&__description\s*\{[\s\S]*overflow-wrap:\s*anywhere;[\s\S]*word-break:\s*break-word;/)
+      end
+
+      it "defines a fixed layout for the labels table styles" do
+        stylesheet = Rails.root.join("app/webpacker/packs/application.scss").read
+
+        expect(stylesheet).to match(/\.label-table\s*\{[\s\S]*table-layout:\s*fixed;/)
+      end
+
+      it "defines wrapping styles for long label descriptions" do
+        stylesheet = Rails.root.join("app/webpacker/packs/application.scss").read
+
+        expect(stylesheet).to match(/\.label-table\s*\{[\s\S]*&__description\s*\{[\s\S]*overflow-wrap:\s*anywhere;[\s\S]*word-break:\s*break-word;/)
       end
       # rubocop:enable RSpec/MultipleExpectations
     end

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -76,6 +76,22 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
         expect(rendered_page.body).to include('for="st-type-all"')
         expect(rendered_page.body).not_to include('for="st-type-heading"')
       end
+
+      it "renders the self-text table inside a bounded container" do
+        expect(rendered_page.body).to include('class="self-text-table-container" data-self-text-table-target="table"')
+      end
+
+      it "defines a fixed layout for the self-text table styles" do
+        stylesheet = Rails.root.join("app/webpacker/packs/application.scss").read
+
+        expect(stylesheet).to match(/\.self-text-table\s*\{[\s\S]*table-layout:\s*fixed;/)
+      end
+
+      it "defines wrapping styles for long self-text content" do
+        stylesheet = Rails.root.join("app/webpacker/packs/application.scss").read
+
+        expect(stylesheet).to match(/\.self-text-table\s*\{[\s\S]*&__description\s*\{[\s\S]*overflow-wrap:\s*anywhere;[\s\S]*word-break:\s*break-word;/)
+      end
       # rubocop:enable RSpec/MultipleExpectations
     end
 


### PR DESCRIPTION
### Jira link

BAU


Before

<img width="753" height="700" alt="image" src="https://github.com/user-attachments/assets/72c96617-5406-4e9c-8bca-0553467b176e" />


After

<img width="975" height="707" alt="image" src="https://github.com/user-attachments/assets/ff60eaae-94a6-407d-8311-b18011a28022" />


### What?

- [x] add bounded containers and fixed table layouts for the descriptions tables rendered in the tabs UI
- [x] give the labels table explicit widths for the code, score and status columns
- [x] wrap long label descriptions inside the description cell so they stay within the tab panel

### Why?

- We were running outside of the boundary of the self-texts table in the self-texts tab. This fixes the issue in both places