### PR TITLE
Remove unnecessary gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-ruby File.read(".ruby-version").chomp
+ruby file: ".ruby-version"
 
 # Server
 gem "puma"
@@ -15,22 +15,19 @@ gem "pg", require: false
 gem "webpacker"
 
 # GovUK
+gem "govuk-components", "6.1.0"
 gem "govuk_design_system_formbuilder"
 
 # Markdown
-gem "addressable"
 gem "govspeak"
-gem "govuk-components", "6.1.0"
 
 # API
 gem "faraday"
 gem "faraday-net_http_persistent"
 gem "faraday-retry"
 gem "jwt"
-gem "net-http-persistent"
 
 # Authorization
-gem "plek"
 gem "pundit"
 
 # Helpers
@@ -44,7 +41,6 @@ gem "logstash-event"
 # Misc
 gem "bootsnap", require: false
 gem "nokogiri"
-gem "sentry-rails"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -435,15 +435,8 @@ GEM
       nokogiri (>= 1.16.8)
     securerandom (0.4.1)
     semantic_range (3.1.0)
-    sentry-rails (6.5.0)
-      railties (>= 5.2.0)
-      sentry-ruby (~> 6.5.0)
     sentry-raven (3.1.2)
       faraday (>= 1.0)
-    sentry-ruby (6.5.0)
-      bigdecimal
-      concurrent-ruby (~> 1.0, >= 1.0.2)
-      logger
     shoulda-matchers (7.0.1)
       activesupport (>= 7.1)
     simplecov (0.22.0)
@@ -507,7 +500,6 @@ PLATFORMS
   x86_64-linux-musl
 
 DEPENDENCIES
-  addressable
   amazing_print
   bootsnap
   brakeman
@@ -525,10 +517,8 @@ DEPENDENCIES
   kaminari
   lograge
   logstash-event
-  net-http-persistent
   nokogiri
   pg
-  plek
   pry-rails
   puma
   pundit
@@ -540,7 +530,6 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-govuk
   ruby-lsp-rails
-  sentry-rails
   shoulda-matchers
   simplecov
   webmock


### PR DESCRIPTION
### What?

Removes some unused gems from Gemfile:
- `addressable` is not used directly and is already a transitive dependency
- `net-http-persistent` is a transitive dependency of faraday-net_http_persistent
- `plek` was needed for SSO, but is no longer required
- `sentry-rails` - no longer needed
