### PR TITLE
Replace deprecated unprocessable_entity symbol

### DIFF
--- a/app/controllers/goods_nomenclature_labels_controller.rb
+++ b/app/controllers/goods_nomenclature_labels_controller.rb
@@ -47,7 +47,7 @@ class GoodsNomenclatureLabelsController < AuthenticatedController
                   notice: "Label updated successfully."
     else
       @versions = fetch_versions
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   rescue Faraday::ResourceNotFound
     redirect_to goods_nomenclature_labels_path, alert: "Label not found for commodity code #{goods_nomenclature_id}."

--- a/app/controllers/goods_nomenclature_self_texts_controller.rb
+++ b/app/controllers/goods_nomenclature_self_texts_controller.rb
@@ -96,7 +96,7 @@ class GoodsNomenclatureSelfTextsController < AuthenticatedController
                   notice: "Self-text updated successfully."
     else
       @versions = fetch_versions
-      render :show, status: :unprocessable_entity
+      render :show, status: :unprocessable_content
     end
   end
 

--- a/app/controllers/references/search_references_controller.rb
+++ b/app/controllers/references/search_references_controller.rb
@@ -29,7 +29,7 @@ module References
         @search_reference = build_search_reference
         assign_release_services_to_form(@search_reference)
         @search_reference.errors.add(:release_services, "Select at least one service to release this reference")
-        return render :new, status: :unprocessable_entity
+        return render :new, status: :unprocessable_content
       end
 
       failed_reference, = run_for_selected_services(selected_services) do
@@ -41,7 +41,7 @@ module References
 
       if failed_reference
         @search_reference = failed_reference
-        render :new, status: :unprocessable_entity
+        render :new, status: :unprocessable_content
       else
         redirect_to [:references, search_reference_parent, :search_references], notice: "Search reference was successfully created."
       end
@@ -74,7 +74,7 @@ module References
         @search_reference = search_reference_for_action || SearchReference.new(title: original_title_param)
         assign_release_services_to_form(@search_reference)
         @search_reference.errors.add(:release_services, "Select at least one service to release this reference")
-        return render :edit, status: :unprocessable_entity
+        return render :edit, status: :unprocessable_content
       end
 
       failed_reference, missing_services, successful_services = run_for_selected_services(selected_services) do
@@ -89,7 +89,7 @@ module References
 
       if failed_reference
         @search_reference = failed_reference
-        render :edit, status: :unprocessable_entity
+        render :edit, status: :unprocessable_content
       elsif successful_services.any? && missing_services.any?
         notice = "Search reference was successfully updated only for #{format_release_services(successful_services)}. Not available in #{format_release_services(missing_services)}."
         redirect_to [:references, search_reference_parent, :search_references], notice:
@@ -109,7 +109,7 @@ module References
         @search_reference = search_reference_for_action || SearchReference.new(title: original_title_param)
         assign_release_services_to_form(@search_reference)
         @search_reference.errors.add(:release_services, "Select at least one service to release this reference")
-        return render :remove, status: :unprocessable_entity
+        return render :remove, status: :unprocessable_content
       end
 
       failed_reference, missing_services, successful_services = run_for_selected_services(selected_services) do

--- a/spec/requests/goods_nomenclature_labels_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_labels_controller_spec.rb
@@ -273,7 +273,7 @@ RSpec.describe GoodsNomenclatureLabelsController, type: :request do
           .and_return(webmock_response(:error, description: "can't be blank"))
       end
 
-      it { is_expected.to have_http_status :unprocessable_entity }
+      it { is_expected.to have_http_status :unprocessable_content }
       it { is_expected.to render_template(:show) }
     end
   end

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -476,7 +476,7 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
           .and_return(webmock_response(:error, self_text: "can't be blank"))
       end
 
-      it { is_expected.to have_http_status :unprocessable_entity }
+      it { is_expected.to have_http_status :unprocessable_content }
       it { is_expected.to render_template(:show) }
     end
   end


### PR DESCRIPTION
### Jira link

[OTTIMP-501](https://transformuk.atlassian.net/browse/OTTIMP-501)

### What?

unprocessable_entity has been deprecated as the symbol for HTTP status 422,. The correct symbol is now unprocessable_content
