### PR TITLE
Restore header border

### DIFF
--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -104,14 +104,6 @@ $govuk-image-url-function: frontend-image-url;
   }
 }
 
-.govuk-service-navigation {
-  border-bottom: none;
-
-  .govuk-width-container {
-    border-bottom: 1px solid govuk-functional-colour(border);
-  }
-}
-
 .app-sub-navigation {
   background-color: govuk-colour("white");
 


### PR DESCRIPTION
### What?

Custom CSS was removing the bottom border extending across the whole screen. Removing this CSS restores the correct look with out any side effects.

### Screenshots
Before
<img width="1409" height="266" alt="Screenshot 2026-04-16 at 16 30 35" src="https://github.com/user-attachments/assets/52449590-978a-406d-bbe9-e34fa7b912cd" />

After
<img width="1389" height="268" alt="Screenshot 2026-04-16 at 16 30 28" src="https://github.com/user-attachments/assets/8fd55c4a-1190-4a45-996c-9838534d4109" />

