### PR TITLE
AI-557: Fix description intercept empty arrays

### DIFF
--- a/app/controllers/description_intercepts_controller.rb
+++ b/app/controllers/description_intercepts_controller.rb
@@ -102,8 +102,8 @@ private
     permitted[:message] = permitted[:message].presence if permitted.key?(:message)
     permitted[:guidance_level] = permitted[:guidance_level].presence if permitted.key?(:guidance_level)
     permitted[:guidance_location] = permitted[:guidance_location].presence if permitted.key?(:guidance_location)
-    permitted[:sources] = Array(permitted[:sources]).reject(&:blank?) if permitted.key?(:sources)
-    permitted[:filter_prefixes] = Array(permitted[:filter_prefixes]).reject(&:blank?) if permitted.key?(:filter_prefixes)
+    permitted[:sources] = Array(permitted[:sources]).reject(&:blank?)
+    permitted[:filter_prefixes] = Array(permitted[:filter_prefixes]).reject(&:blank?)
 
     if permitted[:message].blank?
       permitted.delete(:guidance_level)

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -30,7 +30,10 @@ class DescriptionIntercept
       attrs[:guidance_location] = nil
     end
 
-    attrs[:filter_prefixes] = [] if attrs[:excluded] || Array(attrs[:filter_prefixes]).reject(&:blank?).empty?
+    # Faraday URL-encodes API payloads, which drops empty arrays entirely.
+    # Send a blank array value so updates can explicitly clear existing values.
+    attrs[:filter_prefixes] = [""] if attrs[:excluded] || Array(attrs[:filter_prefixes]).reject(&:blank?).empty?
+    attrs[:sources] = [""] if Array(attrs[:sources]).reject(&:blank?).empty?
   end
 
   def self.listing(params)

--- a/app/views/description_intercepts/_form.html.erb
+++ b/app/views/description_intercepts/_form.html.erb
@@ -55,6 +55,7 @@
   </div>
 
   <% filter_prefixes_error = description_intercept.errors[:filter_prefixes].first %>
+  <input type="hidden" name="description_intercept[filter_prefixes][]" value="">
   <div class="govuk-form-group <%= 'govuk-form-group--error' if filter_prefixes_error.present? %>"
        data-description-intercept-form-target="filteringFields"
        <%= 'style="display:none"'.html_safe if description_intercept.excluded? || !description_intercept.filtering? %>>
@@ -94,6 +95,7 @@
     <fieldset class="govuk-fieldset" aria-describedby="description_intercept_sources_hint">
       <legend class="govuk-visually-hidden">Search sources</legend>
       <div id="description_intercept_sources_hint" class="govuk-hint">Choose where this intercept should apply.</div>
+      <input type="hidden" name="description_intercept[sources][]" value="">
       <div class="govuk-checkboxes govuk-checkboxes--small">
         <% DescriptionIntercept::SOURCES.each do |source| %>
           <div class="govuk-checkboxes__item">

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -510,6 +510,64 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       end
     end
 
+    context "when all selected short codes are removed" do
+      let(:make_request) do
+        patch description_intercept_path(intercept_id), params: {
+          description_intercept: {
+            term: "animal feed",
+            excluded: "0",
+            message: "Updated guidance",
+            guidance_level: "info",
+            guidance_location: "question",
+            escalate_to_webchat: "1",
+            sources: %w[guided_search],
+          },
+        }
+      end
+
+      before do
+        stub_api_request("/description_intercepts/#{intercept_id}", :patch)
+          .with { |request|
+            attrs = Rack::Utils.parse_nested_query(request.body).dig("data", "attributes")
+            attrs.key?("filter_prefixes") && Array(attrs["filter_prefixes"]).all?(&:blank?)
+          }
+          .and_return(intercept_response.merge(status: 200))
+      end
+
+      it "sends an empty filter prefix array" do
+        expect(rendered_page).to redirect_to(description_intercept_path(intercept_id))
+      end
+    end
+
+    context "when all sources are deselected" do
+      let(:make_request) do
+        patch description_intercept_path(intercept_id), params: {
+          description_intercept: {
+            term: "animal feed",
+            excluded: "0",
+            message: "Updated guidance",
+            guidance_level: "info",
+            guidance_location: "question",
+            escalate_to_webchat: "1",
+            filter_prefixes: %w[1201],
+          },
+        }
+      end
+
+      before do
+        stub_api_request("/description_intercepts/#{intercept_id}", :patch)
+          .with { |request|
+            attrs = Rack::Utils.parse_nested_query(request.body).dig("data", "attributes")
+            attrs.key?("sources") && Array(attrs["sources"]).all?(&:blank?)
+          }
+          .and_return(intercept_response.merge(status: 200))
+      end
+
+      it "sends an empty sources array" do
+        expect(rendered_page).to redirect_to(description_intercept_path(intercept_id))
+      end
+    end
+
     context "when guidance is completely removed" do
       let(:make_request) do
         patch description_intercept_path(intercept_id), params: {


### PR DESCRIPTION
### Jira link

[AI-557](https://transformuk.atlassian.net/browse/AI-557)

### What?

- [x] Treat missing description intercept array params as empty arrays on update
- [x] Add hidden form inputs so removed short codes and deselected sources are submitted
- [x] Preserve explicit empty arrays through Faraday URL encoding
- [x] Add request coverage for clearing filter prefixes and sources

### Why?

Browsers omit unchecked checkboxes and removed dynamic inputs. That meant the admin app left the existing `sources` and `filter_prefixes` values on the model, then PATCHed those old values back to the backend. Faraday also drops empty arrays when URL encoding, so the backend never received an explicit clear.

The form and model now send a blank array value for these fields, which the backend can normalise into an empty list.