### PR TITLE
BAU: Add markdown preview for description intercepts

### DIFF
--- a/app/helpers/govuk_helper.rb
+++ b/app/helpers/govuk_helper.rb
@@ -35,10 +35,11 @@ module GovukHelper
     end
   end
 
-  def govuk_markdown_area(form, field_name, **options)
+  def govuk_markdown_area(form, field_name, **options, &block)
     render "application/markdown_field",
            form:,
            field_name:,
-           field_options: options
+           field_options: options,
+           help_content: block_given? ? capture(&block) : nil
   end
 end

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -67,6 +67,11 @@ class DescriptionIntercept
     message.present?
   end
 
+  def preview(field_name = :message)
+    content = public_send(field_name)
+    GovspeakPreview.new(content).render if content.present?
+  end
+
   def filtering?
     filter_prefixes.present?
   end

--- a/app/views/application/_markdown_field.html.erb
+++ b/app/views/application/_markdown_field.html.erb
@@ -2,11 +2,15 @@
   <div class="govuk-grid-column-one-half">
     <%= form.govuk_text_area field_name, **field_options %>
 
-    <p>
-      <a href="https://govspeak-preview.publishing.service.gov.uk/guide" rel="noopener" target="_blank">
-        Markdown guide
-      </a>
-    </p>
+    <% if help_content.present? %>
+      <%= help_content %>
+    <% else %>
+      <p>
+        <a href="https://govspeak-preview.publishing.service.gov.uk/guide" rel="noopener" target="_blank">
+          Markdown guide
+        </a>
+      </p>
+    <% end %>
   </div>
 
   <div class="govuk-grid-column-one-half">

--- a/app/views/description_intercepts/_form.html.erb
+++ b/app/views/description_intercepts/_form.html.erb
@@ -113,11 +113,30 @@
   </div>
 
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Guidance</h2>
-  <%= f.govuk_text_area :message,
-                        label: { text: "Guidance message" },
-                        hint: { text: "Shown to the trader-facing frontend when this intercept matches." },
-                        rows: 5,
-                        data: { action: "input->description-intercept-form#toggleGuidance", description_intercept_form_target: "messageInput" } %>
+  <%= govuk_markdown_area f,
+                          :message,
+                          label: { text: "Guidance message" },
+                          hint: { text: "Shown to the trader-facing frontend when this intercept matches." },
+                          rows: 5,
+                          data: { action: "input->description-intercept-form#toggleGuidance", description_intercept_form_target: "messageInput" } do %>
+    <%= govuk_details(summary_text: "Markdown and automatic short code links") do %>
+      <p class="govuk-body">
+        Short codes are automatically rendered as links in the frontend. You do not need to add markdown links for
+        chapters, headings, subheadings or commodities.
+      </p>
+      <p class="govuk-body">
+        For example, <code>01</code>, <code>0101</code>, <code>010121</code> and <code>0101210000</code> will be linked
+        automatically.
+      </p>
+      <p class="govuk-body">
+        Use the
+        <a class="govuk-link" href="https://govspeak-preview.publishing.service.gov.uk/guide" rel="noopener" target="_blank">
+          Markdown guide
+        </a>
+        for formatting such as headings, lists and emphasis.
+      </p>
+    <% end %>
+  <% end %>
 
   <div data-description-intercept-form-target="guidanceFields">
     <%= f.govuk_select :guidance_level,

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -193,6 +193,34 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       expect(rendered_page.body).to include("Selected short codes")
     end
 
+    it "renders the guidance message as a markdown editor with preview" do
+      page = Capybara.string(rendered_page.body)
+
+      expect(page).to have_css ".govuk-grid-row .govuk-grid-column-one-half", count: 2
+      expect(page).to have_css 'textarea.govuk-textarea[name="description_intercept[message]"]'
+      expect(page).to have_css '.hott-markdown-preview[data-preview="govspeak"][data-preview-for="#description-intercept-message-field"]'
+    end
+
+    it "explains markdown and automatic short code links in a details component" do
+      page = Capybara.string(rendered_page.body)
+
+      expect(page).to have_css ".govuk-details__summary-text", text: "Markdown and automatic short code links"
+      expect(page).to have_css ".govuk-details__text", text: "Short codes are automatically rendered as links", visible: :all
+      expect(page).to have_css ".govuk-details__text", text: "01", visible: :all
+      expect(page).to have_css ".govuk-details__text", text: "0101", visible: :all
+      expect(page).to have_css ".govuk-details__text", text: "010121", visible: :all
+      expect(page).to have_css ".govuk-details__text", text: "0101210000", visible: :all
+      expect(page).to have_link "Markdown guide", href: "https://govspeak-preview.publishing.service.gov.uk/guide", visible: :all
+    end
+
+    context "with a markdown guidance message" do
+      let(:intercept_attributes) { super().merge("message" => "Ask the **trader** to pick a more specific feed type.") }
+
+      it "renders the existing guidance message in the preview" do
+        expect(Capybara.string(rendered_page.body)).to have_css ".hott-markdown-preview strong", text: "trader"
+      end
+    end
+
     it "shows remove controls for selected short codes" do
       expect(rendered_page.body).to include('aria-label="Remove 1201900000"')
       expect(rendered_page.body).to include('aria-label="Remove 2309900000"')


### PR DESCRIPTION
### What?

- [x] Render description intercept guidance as a markdown editor with a live preview
- [x] Add preview rendering for existing description intercept guidance
- [x] Let markdown fields provide custom help content while keeping the default Markdown guide link elsewhere
- [x] Add guidance that short codes are automatically linked on the frontend

### Why?

Description intercept guidance is markdown, but the admin form was a plain textarea. That meant editors could not see the rendered output while writing, and the help text did not explain that tariff short codes are linked automatically by the frontend.