### PR TITLE
OTTIMP-463: Add superadmin role for high-risk admin paths

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -15,7 +15,7 @@ class UsersController < AuthenticatedController
     authorize User, :create?
 
     @user = User.new(create_user_params)
-    @user.role = role_param
+    assign_role!(@user)
 
     if @user.save
       redirect_to users_path, notice: "User added successfully"
@@ -32,7 +32,7 @@ class UsersController < AuthenticatedController
     authorize @user, :update?
 
     @user.assign_attributes(update_user_params)
-    @user.role = role_param
+    assign_role!(@user)
 
     if @user.save
       redirect_to users_path, notice: "User updated successfully"
@@ -65,5 +65,12 @@ private
 
   def role_param
     params.require(:user).require(:role)
+  end
+
+  def assign_role!(user)
+    requested_role = role_param
+    authorize user, :assign_superadmin? if requested_role == User::SUPERADMIN
+
+    user.role = requested_role
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -69,8 +69,11 @@ private
 
   def assign_role!(user)
     requested_role = role_param
-    authorize user, :assign_superadmin? if requested_role == User::SUPERADMIN
+    user_policy = policy(user)
 
-    user.role = requested_role
+    return user.role = requested_role unless User::VALID_ROLES.include?(requested_role)
+    return user.role = requested_role if user_policy.role_submittable?(requested_role)
+
+    raise Pundit::NotAuthorizedError.new(query: :update?, record: user, policy: user_policy)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -74,6 +74,6 @@ private
     return user.role = requested_role unless User::VALID_ROLES.include?(requested_role)
     return user.role = requested_role if user_policy.role_submittable?(requested_role)
 
-    raise Pundit::NotAuthorizedError.new(query: :update?, record: user, policy: user_policy)
+    raise Pundit::NotAuthorizedError.new(query: :"#{action_name}?", record: user, policy: user_policy)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,8 +7,9 @@ class User < ApplicationRecord
   AUDITOR = "AUDITOR".freeze
   GUEST = "GUEST".freeze
 
+  ROLE_ASSIGNMENT_ORDER = [SUPERADMIN, TECHNICAL_OPERATOR, HMRC_ADMIN, AUDITOR, GUEST].freeze
   PRIVILEGED_OPERATOR_ROLES = [SUPERADMIN, TECHNICAL_OPERATOR].freeze
-  VALID_ROLES = [SUPERADMIN, TECHNICAL_OPERATOR, HMRC_ADMIN, AUDITOR, GUEST].freeze
+  VALID_ROLES = ROLE_ASSIGNMENT_ORDER
 
   validates :role, inclusion: { in: VALID_ROLES }
   validates :name, presence: true
@@ -19,6 +20,10 @@ class User < ApplicationRecord
   before_validation :ensure_default_role
 
   class << self
+    def role_assignment_index(role)
+      ROLE_ASSIGNMENT_ORDER.index(role.to_s)
+    end
+
     def from_passwordless_payload!(token)
       return if token.blank?
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,12 +1,14 @@
 class User < ApplicationRecord
   has_many :sessions, dependent: :destroy
 
+  SUPERADMIN = "SUPERADMIN".freeze
   TECHNICAL_OPERATOR = "TECHNICAL_OPERATOR".freeze
   HMRC_ADMIN = "HMRC_ADMIN".freeze
   AUDITOR = "AUDITOR".freeze
   GUEST = "GUEST".freeze
 
-  VALID_ROLES = [TECHNICAL_OPERATOR, HMRC_ADMIN, AUDITOR, GUEST].freeze
+  PRIVILEGED_OPERATOR_ROLES = [SUPERADMIN, TECHNICAL_OPERATOR].freeze
+  VALID_ROLES = [SUPERADMIN, TECHNICAL_OPERATOR, HMRC_ADMIN, AUDITOR, GUEST].freeze
 
   validates :role, inclusion: { in: VALID_ROLES }
   validates :name, presence: true
@@ -55,7 +57,11 @@ class User < ApplicationRecord
 
   # Role helper methods - assume single role exclusivity
   def technical_operator?
-    current_role == TECHNICAL_OPERATOR
+    PRIVILEGED_OPERATOR_ROLES.include?(current_role)
+  end
+
+  def superadmin?
+    current_role == SUPERADMIN
   end
 
   def hmrc_admin?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -52,9 +52,9 @@ class User < ApplicationRecord
         user.name = "basic_auth_user"
         user.disabled = false
         user.remotely_signed_out = false
-        user.role = TECHNICAL_OPERATOR
       end
       user.name ||= "basic_auth_user"
+      user.role = SUPERADMIN
       user.save!
       user
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,10 @@ class User < ApplicationRecord
   AUDITOR = "AUDITOR".freeze
   GUEST = "GUEST".freeze
 
+  BASIC_AUTH_UID = "basic_auth_user".freeze
+  BASIC_AUTH_EMAIL = "basic_auth@trade-tariff-admin.local".freeze
+  BASIC_AUTH_NAME = "basic_auth_user".freeze
+
   ROLE_ASSIGNMENT_ORDER = [SUPERADMIN, TECHNICAL_OPERATOR, HMRC_ADMIN, AUDITOR, GUEST].freeze
   PRIVILEGED_OPERATOR_ROLES = [SUPERADMIN, TECHNICAL_OPERATOR].freeze
   VALID_ROLES = ROLE_ASSIGNMENT_ORDER
@@ -47,13 +51,13 @@ class User < ApplicationRecord
     end
 
     def basic_auth_user!
-      user = find_or_initialize_by(uid: "basic_auth_user", email: "basic_auth@trade-tariff-admin.local")
+      user = find_or_initialize_by(uid: BASIC_AUTH_UID, email: BASIC_AUTH_EMAIL)
       if user.new_record?
-        user.name = "basic_auth_user"
+        user.name = BASIC_AUTH_NAME
         user.disabled = false
         user.remotely_signed_out = false
       end
-      user.name ||= "basic_auth_user"
+      user.name ||= BASIC_AUTH_NAME
       user.role = SUPERADMIN
       user.save!
       user
@@ -79,6 +83,10 @@ class User < ApplicationRecord
 
   def guest?
     current_role == GUEST
+  end
+
+  def basic_auth_user?
+    uid == BASIC_AUTH_UID && email == BASIC_AUTH_EMAIL
   end
 
   def current_role

--- a/app/policies/admin_configuration_policy.rb
+++ b/app/policies/admin_configuration_policy.rb
@@ -1,14 +1,14 @@
 class AdminConfigurationPolicy < ApplicationPolicy
   def index?
-    technical_operator?
+    superadmin?
   end
 
   def show?
-    technical_operator?
+    superadmin?
   end
 
   def update?
-    technical_operator?
+    superadmin?
   end
 
   def create?

--- a/app/policies/admin_configuration_policy.rb
+++ b/app/policies/admin_configuration_policy.rb
@@ -1,10 +1,10 @@
 class AdminConfigurationPolicy < ApplicationPolicy
   def index?
-    superadmin?
+    technical_operator? || auditor?
   end
 
   def show?
-    superadmin?
+    technical_operator? || auditor?
   end
 
   def update?

--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -34,6 +34,10 @@ class ApplicationPolicy
     user&.technical_operator? || false
   end
 
+  def superadmin?
+    user&.superadmin? || false
+  end
+
   def hmrc_admin?
     user&.hmrc_admin? || false
   end

--- a/app/policies/rollback_policy.rb
+++ b/app/policies/rollback_policy.rb
@@ -1,11 +1,11 @@
-# Rollback: SUPERADMIN execute/download/recover, AUDITOR index (history only), HMRC_ADMIN hidden, GUEST hidden
+# Rollback: SUPERADMIN execute/download/recover, TECHNICAL_OPERATOR/AUDITOR history access, HMRC_ADMIN hidden, GUEST hidden
 class RollbackPolicy < ApplicationPolicy
   def index?
-    superadmin? || auditor?
+    technical_operator? || auditor?
   end
 
   def show?
-    superadmin? || auditor?
+    technical_operator? || auditor?
   end
 
   def create?

--- a/app/policies/rollback_policy.rb
+++ b/app/policies/rollback_policy.rb
@@ -1,14 +1,14 @@
-# Rollback: TECHNICAL_OPERATOR execute/download/recover, HMRC_ADMIN hidden, AUDITOR index (history only), GUEST hidden
+# Rollback: SUPERADMIN execute/download/recover, AUDITOR index (history only), HMRC_ADMIN hidden, GUEST hidden
 class RollbackPolicy < ApplicationPolicy
   def index?
-    technical_operator? || auditor?
+    superadmin? || auditor?
   end
 
   def show?
-    technical_operator? || auditor?
+    superadmin? || auditor?
   end
 
   def create?
-    technical_operator?
+    superadmin?
   end
 end

--- a/app/policies/update_policy.rb
+++ b/app/policies/update_policy.rb
@@ -1,23 +1,23 @@
-# Updates (Daily Tariff Files): TECHNICAL_OPERATOR monitor/diagnose/clear cache, HMRC_ADMIN hidden, AUDITOR read-only, GUEST hidden
+# Updates (Daily Tariff Files): SUPERADMIN full control, AUDITOR read-only, HMRC_ADMIN hidden, GUEST hidden
 class UpdatePolicy < ApplicationPolicy
   def index?
-    technical_operator? || auditor?
+    superadmin? || auditor?
   end
 
   def show?
-    technical_operator? || auditor?
+    superadmin? || auditor?
   end
 
   # Actions like download, apply_and_clear_cache, resend_cds_update_notification
   def download?
-    technical_operator?
+    superadmin?
   end
 
   def apply_and_clear_cache?
-    technical_operator?
+    superadmin?
   end
 
   def resend_cds_update_notification?
-    technical_operator?
+    superadmin?
   end
 end

--- a/app/policies/update_policy.rb
+++ b/app/policies/update_policy.rb
@@ -1,11 +1,11 @@
-# Updates (Daily Tariff Files): SUPERADMIN full control, AUDITOR read-only, HMRC_ADMIN hidden, GUEST hidden
+# Updates (Daily Tariff Files): SUPERADMIN destructive actions, TECHNICAL_OPERATOR/AUDITOR read-only, HMRC_ADMIN hidden, GUEST hidden
 class UpdatePolicy < ApplicationPolicy
   def index?
-    superadmin? || auditor?
+    technical_operator? || auditor?
   end
 
   def show?
-    superadmin? || auditor?
+    technical_operator? || auditor?
   end
 
   # Actions like download, apply_and_clear_cache, resend_cds_update_notification

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -6,8 +6,38 @@ class UserPolicy < ApplicationPolicy
     basic_auth_override? || technical_operator?
   end
 
-  def assign_superadmin?
-    superadmin?
+  def assignable_roles
+    return [] unless role_management_access?
+    return User::VALID_ROLES if superadmin?
+
+    User::VALID_ROLES.select { |role| role_at_or_below_ceiling?(role) }
+  end
+
+  def role_option_enabled?(role)
+    return false unless role_management_access?
+    return false if locked_higher_role?
+
+    assignable_roles.include?(role.to_s)
+  end
+
+  def role_submittable?(role)
+    requested_role = role.to_s
+
+    return false unless role_management_access?
+    return false unless User::VALID_ROLES.include?(requested_role)
+    return true if superadmin?
+    return true if locked_higher_role? && unchanged_role?(requested_role)
+    return false if locked_higher_role?
+
+    assignable_roles.include?(requested_role)
+  end
+
+  def locked_higher_role?
+    return false unless record.respond_to?(:current_role)
+    return false unless record.persisted?
+    return false if superadmin?
+
+    higher_than_ceiling?(record.current_role)
   end
 
   def create?
@@ -27,6 +57,30 @@ class UserPolicy < ApplicationPolicy
   end
 
 private
+
+  def unchanged_role?(role)
+    record.respond_to?(:current_role) && record.current_role == role
+  end
+
+  def role_management_access?
+    basic_auth_override? || technical_operator?
+  end
+
+  def current_user_role_index
+    @current_user_role_index ||= User.role_assignment_index(user&.current_role)
+  end
+
+  def role_at_or_below_ceiling?(role)
+    role_index = User.role_assignment_index(role)
+
+    current_user_role_index.present? && role_index.present? && role_index >= current_user_role_index
+  end
+
+  def higher_than_ceiling?(role)
+    role_index = User.role_assignment_index(role)
+
+    current_user_role_index.present? && role_index.present? && role_index < current_user_role_index
+  end
 
   def basic_auth_override?
     return false unless TradeTariffAdmin.basic_session_authentication?

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -6,6 +6,10 @@ class UserPolicy < ApplicationPolicy
     basic_auth_override? || technical_operator?
   end
 
+  def assign_superadmin?
+    superadmin?
+  end
+
   def create?
     basic_auth_override? || superadmin?
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,6 +1,5 @@
 # User Management: SUPERADMIN can create/delete users, TECHNICAL_OPERATOR can view/update users
-# Exception: Basic auth allows user management regardless of role (testing mode)
-# Basic auth override only works when basic auth is enabled and for non-guest users
+# Exception: Basic auth allows user management through the synthetic SUPERADMIN user
 class UserPolicy < ApplicationPolicy
   def index?
     basic_auth_override? || technical_operator?
@@ -84,8 +83,8 @@ private
 
   def basic_auth_override?
     return false unless TradeTariffAdmin.basic_session_authentication?
-    return false if user&.guest?
+    return false unless user&.basic_auth_user?
 
-    true
+    superadmin?
   end
 end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -1,4 +1,4 @@
-# User Management: ONLY TECHNICAL_OPERATOR may manage users
+# User Management: SUPERADMIN can create/delete users, TECHNICAL_OPERATOR can view/update users
 # Exception: Basic auth allows user management regardless of role (testing mode)
 # Basic auth override only works when basic auth is enabled and for non-guest users
 class UserPolicy < ApplicationPolicy
@@ -7,7 +7,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def create?
-    basic_auth_override? || technical_operator?
+    basic_auth_override? || superadmin?
   end
 
   def show?
@@ -19,7 +19,7 @@ class UserPolicy < ApplicationPolicy
   end
 
   def destroy?
-    basic_auth_override? || technical_operator?
+    basic_auth_override? || superadmin?
   end
 
 private

--- a/app/views/rollbacks/index.html.erb
+++ b/app/views/rollbacks/index.html.erb
@@ -35,4 +35,6 @@
   </p>
 <% end %>
 
-<%= link_to 'New Rollback', new_rollback_path, class: 'govuk-button' %>
+<% if policy(Rollback).create? %>
+  <%= link_to 'New Rollback', new_rollback_path, class: 'govuk-button' %>
+<% end %>

--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -10,9 +10,11 @@
       <p class="govuk-body"><%= number_to_human_size(@tariff_update.filesize) %></p>
     </dd>
     <dd class="govuk-summary-list__actions">
-      <a class="govuk-link" href="#">
-        <%= link_to "Download", @tariff_update.file_presigned_url, target: "_blank", title: @tariff_update.filename %>
-      </a>
+      <% if policy(Update).download? %>
+        <a class="govuk-link" href="#">
+          <%= link_to "Download", @tariff_update.file_presigned_url, target: "_blank", title: @tariff_update.filename %>
+        </a>
+      <% end %>
     </dd>
   </div>
   <div class="govuk-summary-list__row">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,8 +1,9 @@
 <% submit_text = user.persisted? ? "Update user" : "Add user" %>
 
 <%= govuk_form_for user, error_summary: { presenter: FullMessageErrorSummaryPresenter.new(user) } do |f| %>
-  <% assignable_roles = policy(user).assign_superadmin? ? User::VALID_ROLES : User::VALID_ROLES - [User::SUPERADMIN] %>
-  <% role_options = assignable_roles.index_with { |role| format_role_name(role) } %>
+  <% user_policy = policy(user) %>
+  <% selected_role = user.role.presence || User::GUEST %>
+  <% preserve_locked_role = user.persisted? && user_policy.locked_higher_role? && user_policy.role_submittable?(selected_role) %>
 
   <%= f.govuk_text_field :name,
                          label: { text: "Name" },
@@ -20,12 +21,20 @@
                            width: "two-thirds" %>
   <% end %>
 
-  <%= f.govuk_collection_radio_buttons :role,
-                                       role_options,
-                                       :first,
-                                       :last,
-                                       legend: { text: "Role" },
-                                       hint: { text: "Select a role for this user. Only one role can be assigned at a time." } %>
+  <%= f.hidden_field :role, value: selected_role if preserve_locked_role %>
+
+  <%= f.govuk_radio_buttons_fieldset :role,
+                                     legend: { text: "Role" },
+                                     hint: { text: "Select a role for this user. Only one role can be assigned at a time." } do %>
+    <% User::VALID_ROLES.each_with_index do |role, index| %>
+      <%= f.govuk_radio_button :role,
+                               role,
+                               label: { text: format_role_name(role) },
+                               checked: selected_role == role,
+                               disabled: !user_policy.role_option_enabled?(role),
+                               link_errors: index.zero? %>
+    <% end %>
+  <% end %>
 
   <%= submit_and_back_buttons f, users_path, submit: submit_text %>
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,7 +1,8 @@
 <% submit_text = user.persisted? ? "Update user" : "Add user" %>
 
 <%= govuk_form_for user, error_summary: { presenter: FullMessageErrorSummaryPresenter.new(user) } do |f| %>
-  <% role_options = User::VALID_ROLES.index_with { |role| format_role_name(role) } %>
+  <% assignable_roles = policy(user).assign_superadmin? ? User::VALID_ROLES : User::VALID_ROLES - [User::SUPERADMIN] %>
+  <% role_options = assignable_roles.index_with { |role| format_role_name(role) } %>
 
   <%= f.govuk_text_field :name,
                          label: { text: "Name" },

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,8 +1,17 @@
 <h2>Manage Users</h2>
 
 <p>
-  Use this page to manage users and roles.
+  Use this page to manage user roles.
+  <% unless policy(User.new).update? %>
+    Only technical operators and superadmins can change user roles.
+  <% end %>
 </p>
+
+<% if policy(User.new).update? && !policy(User.new).create? %>
+  <p>
+    Only superadmins can add or remove users.
+  </p>
+<% end %>
 
 <% if policy(User.new).create? %>
   <p>

--- a/spec/factories/user_factory.rb
+++ b/spec/factories/user_factory.rb
@@ -7,6 +7,10 @@ FactoryBot.define do
     # Default user has GUEST role (assigned by User model before_create callback)
     # No need to remove it - GUEST is the valid default
 
+    trait :superadmin do
+      role { User::SUPERADMIN }
+    end
+
     trait :technical_operator do
       role { User::TECHNICAL_OPERATOR }
     end

--- a/spec/features/rollbacks_spec.rb
+++ b/spec/features/rollbacks_spec.rb
@@ -1,6 +1,6 @@
-# rubocop:disable RSpec/NoExpectationExample, RSpec/LetSetup
+# rubocop:disable RSpec/NoExpectationExample
 RSpec.describe "Rollbacks management" do
-  let!(:user) { create :user, :technical_operator }
+  let(:current_user) { create(:user, :superadmin) }
 
   describe "Rollback creation" do
     let(:rollback) { build :rollback }
@@ -27,4 +27,4 @@ RSpec.describe "Rollbacks management" do
     end
   end
 end
-# rubocop:enable RSpec/NoExpectationExample, RSpec/LetSetup
+# rubocop:enable RSpec/NoExpectationExample

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -77,9 +77,11 @@ RSpec.describe NavigationHelper, type: :helper do
                          "News",
                          "Live Issues",
                          "Quotas",
+                         "Updates",
                          "Reports",
+                         "Rollbacks",
                        ],
-                       classification: ["Search References", "Descriptions", "Intercepts", "Recent changes"],
+                       classification: ["Search References", "Descriptions", "Configuration", "Intercepts", "Recent changes"],
                        manage_users: nil
     end
 
@@ -107,7 +109,7 @@ RSpec.describe NavigationHelper, type: :helper do
                          "Updates",
                          "Rollbacks",
                        ],
-                       classification: ["Search References"]
+                       classification: ["Search References", "Configuration"]
     end
 
     context "with UK service and guest role" do
@@ -126,7 +128,7 @@ RSpec.describe NavigationHelper, type: :helper do
       let(:user) { build(:user, :technical_operator) }
 
       include_examples "visible sections and items",
-                       ott_admin: ["Section & chapter notes", "Reports"],
+                       ott_admin: ["Section & chapter notes", "Updates", "Reports", "Rollbacks"],
                        classification: ["Search References", "Descriptions", "Recent changes"],
                        spimm: [
                          "Category Assessments",

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -77,11 +77,9 @@ RSpec.describe NavigationHelper, type: :helper do
                          "News",
                          "Live Issues",
                          "Quotas",
-                         "Updates",
                          "Reports",
-                         "Rollbacks",
                        ],
-                       classification: ["Search References", "Descriptions", "Configuration", "Intercepts", "Recent changes"],
+                       classification: ["Search References", "Descriptions", "Intercepts", "Recent changes"],
                        manage_users: nil
     end
 
@@ -128,7 +126,7 @@ RSpec.describe NavigationHelper, type: :helper do
       let(:user) { build(:user, :technical_operator) }
 
       include_examples "visible sections and items",
-                       ott_admin: ["Section & chapter notes", "Updates", "Reports", "Rollbacks"],
+                       ott_admin: ["Section & chapter notes", "Reports"],
                        classification: ["Search References", "Descriptions", "Recent changes"],
                        spimm: [
                          "Category Assessments",
@@ -251,7 +249,7 @@ RSpec.describe NavigationHelper, type: :helper do
     include_context "with UK service"
 
     let(:user) { build(:user, :technical_operator) }
-    let(:request_path) { "/tariff_updates" }
+    let(:request_path) { "/notes/1" }
 
     it "returns true for OTT Admin when path matches" do
       section = helper.visible_navigation_sections.find { |s| s.key == :ott_admin }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -2,6 +2,12 @@ RSpec.describe User do
   describe "#technical_operator?" do
     subject(:user) { create(:user, *traits) }
 
+    context "when user has superadmin role" do
+      let(:traits) { [:superadmin] }
+
+      it { is_expected.to be_technical_operator }
+    end
+
     context "when user has technical operator role" do
       let(:traits) { [:technical_operator] }
 
@@ -12,6 +18,22 @@ RSpec.describe User do
       let(:traits) { [] }
 
       it { is_expected.not_to be_technical_operator }
+    end
+  end
+
+  describe "#superadmin?" do
+    subject(:user) { create(:user, *traits) }
+
+    context "when user has superadmin role" do
+      let(:traits) { [:superadmin] }
+
+      it { is_expected.to be_superadmin }
+    end
+
+    context "when user does not have superadmin role" do
+      let(:traits) { [:technical_operator] }
+
+      it { is_expected.not_to be_superadmin }
     end
   end
 
@@ -130,6 +152,7 @@ RSpec.describe User do
 
     describe "role constants" do
       it "defines all required role constants", :aggregate_failures do
+        expect(User::SUPERADMIN).to eq("SUPERADMIN")
         expect(User::TECHNICAL_OPERATOR).to eq("TECHNICAL_OPERATOR")
         expect(User::HMRC_ADMIN).to eq("HMRC_ADMIN")
         expect(User::AUDITOR).to eq("AUDITOR")
@@ -137,7 +160,7 @@ RSpec.describe User do
       end
 
       it "includes all roles in VALID_ROLES" do
-        expect(User::VALID_ROLES).to contain_exactly(User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR, User::GUEST)
+        expect(User::VALID_ROLES).to contain_exactly(User::SUPERADMIN, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR, User::GUEST)
       end
     end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -312,9 +312,10 @@ RSpec.describe User do
 
       it "sets correct uid, email and name", :aggregate_failures do
         user = described_class.basic_auth_user!
-        expect(user.uid).to eq("basic_auth_user")
-        expect(user.email).to eq("basic_auth@trade-tariff-admin.local")
-        expect(user.name).to eq("basic_auth_user")
+        expect(user.uid).to eq(User::BASIC_AUTH_UID)
+        expect(user.email).to eq(User::BASIC_AUTH_EMAIL)
+        expect(user.name).to eq(User::BASIC_AUTH_NAME)
+        expect(user).to be_basic_auth_user
       end
 
       it "sets disabled and remotely_signed_out to false", :aggregate_failures do
@@ -327,8 +328,8 @@ RSpec.describe User do
     context "when user already exists" do
       let!(:existing_user) do
         create(:user,
-               uid: "basic_auth_user",
-               email: "basic_auth@trade-tariff-admin.local",
+               uid: User::BASIC_AUTH_UID,
+               email: User::BASIC_AUTH_EMAIL,
                name: "Existing Name",
                disabled: true,
                remotely_signed_out: true,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -305,9 +305,9 @@ RSpec.describe User do
         }.to change(described_class, :count).by(1)
       end
 
-      it "sets TECHNICAL_OPERATOR role" do
+      it "sets SUPERADMIN role" do
         user = described_class.basic_auth_user!
-        expect(user.role).to eq(User::TECHNICAL_OPERATOR)
+        expect(user.role).to eq(User::SUPERADMIN)
       end
 
       it "sets correct uid, email and name", :aggregate_failures do
@@ -341,11 +341,11 @@ RSpec.describe User do
         }.not_to change(described_class, :count)
       end
 
-      it "preserves existing name and role", :aggregate_failures do
+      it "preserves existing name and promotes the role to superadmin", :aggregate_failures do
         described_class.basic_auth_user!
         existing_user.reload
         expect(existing_user.name).to eq("Existing Name")
-        expect(existing_user.role).to eq(User::GUEST)
+        expect(existing_user.role).to eq(User::SUPERADMIN)
       end
 
       it "preserves existing disabled and remotely_signed_out flags", :aggregate_failures do

--- a/spec/policies/admin_configuration_policy_spec.rb
+++ b/spec/policies/admin_configuration_policy_spec.rb
@@ -1,47 +1,48 @@
+# rubocop:disable RSpec/RepeatedExample
 RSpec.describe AdminConfigurationPolicy do
   subject(:policy) { described_class }
 
   let(:configuration) { AdminConfiguration.new(name: "test") }
 
   permissions :index?, :show? do
-    it "grants access to superadmin" do
+    it "grants superadmin read access" do
       user = create(:user, :superadmin)
       expect(policy).to permit(user, configuration)
     end
 
-    it "grants access to technical operator" do
+    it "grants technical operator read access" do
       user = create(:user, :technical_operator)
       expect(policy).to permit(user, configuration)
     end
 
-    it "grants access to auditor" do
+    it "grants auditor read access" do
       user = create(:user, :auditor)
       expect(policy).to permit(user, configuration)
     end
 
-    it "denies access to hmrc admin" do
+    it "denies hmrc admin read access" do
       user = create(:user, :hmrc_admin)
       expect(policy).not_to permit(user, configuration)
     end
 
-    it "denies access to guest user" do
+    it "denies guest read access" do
       user = create(:user, :guest)
       expect(policy).not_to permit(user, configuration)
     end
   end
 
   permissions :update? do
-    it "grants access to superadmin" do
+    it "grants superadmin update access" do
       user = create(:user, :superadmin)
       expect(policy).to permit(user, configuration)
     end
 
-    it "denies access to technical operator" do
+    it "denies technical operator update access" do
       user = create(:user, :technical_operator)
       expect(policy).not_to permit(user, configuration)
     end
 
-    it "denies access to auditor" do
+    it "denies auditor update access" do
       user = create(:user, :auditor)
       expect(policy).not_to permit(user, configuration)
     end
@@ -54,3 +55,4 @@ RSpec.describe AdminConfigurationPolicy do
     end
   end
 end
+# rubocop:enable RSpec/RepeatedExample

--- a/spec/policies/admin_configuration_policy_spec.rb
+++ b/spec/policies/admin_configuration_policy_spec.rb
@@ -4,8 +4,8 @@ RSpec.describe AdminConfigurationPolicy do
   let(:configuration) { AdminConfiguration.new(name: "test") }
 
   permissions :index?, :show?, :update? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(policy).to permit(user, configuration)
     end
 
@@ -19,6 +19,11 @@ RSpec.describe AdminConfigurationPolicy do
       expect(policy).not_to permit(user, configuration)
     end
 
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
+      expect(policy).not_to permit(user, configuration)
+    end
+
     it "denies access to guest user" do
       user = create(:user, :guest)
       expect(policy).not_to permit(user, configuration)
@@ -26,8 +31,8 @@ RSpec.describe AdminConfigurationPolicy do
   end
 
   permissions :create?, :destroy? do
-    it "denies access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "denies access to superadmin" do
+      user = create(:user, :superadmin)
       expect(policy).not_to permit(user, configuration)
     end
   end

--- a/spec/policies/admin_configuration_policy_spec.rb
+++ b/spec/policies/admin_configuration_policy_spec.rb
@@ -3,9 +3,19 @@ RSpec.describe AdminConfigurationPolicy do
 
   let(:configuration) { AdminConfiguration.new(name: "test") }
 
-  permissions :index?, :show?, :update? do
+  permissions :index?, :show? do
     it "grants access to superadmin" do
       user = create(:user, :superadmin)
+      expect(policy).to permit(user, configuration)
+    end
+
+    it "grants access to technical operator" do
+      user = create(:user, :technical_operator)
+      expect(policy).to permit(user, configuration)
+    end
+
+    it "grants access to auditor" do
+      user = create(:user, :auditor)
       expect(policy).to permit(user, configuration)
     end
 
@@ -14,9 +24,16 @@ RSpec.describe AdminConfigurationPolicy do
       expect(policy).not_to permit(user, configuration)
     end
 
-    it "denies access to auditor" do
-      user = create(:user, :auditor)
+    it "denies access to guest user" do
+      user = create(:user, :guest)
       expect(policy).not_to permit(user, configuration)
+    end
+  end
+
+  permissions :update? do
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
+      expect(policy).to permit(user, configuration)
     end
 
     it "denies access to technical operator" do
@@ -24,8 +41,8 @@ RSpec.describe AdminConfigurationPolicy do
       expect(policy).not_to permit(user, configuration)
     end
 
-    it "denies access to guest user" do
-      user = create(:user, :guest)
+    it "denies access to auditor" do
+      user = create(:user, :auditor)
       expect(policy).not_to permit(user, configuration)
     end
   end

--- a/spec/policies/application_policy_spec.rb
+++ b/spec/policies/application_policy_spec.rb
@@ -27,6 +27,21 @@ RSpec.describe ApplicationPolicy do
   end
 
   describe "role helper methods" do
+    context "with superadmin" do
+      let(:user) { create(:user, :superadmin) }
+
+      it "returns true for elevated role checks", :aggregate_failures do
+        expect(policy.superadmin?).to be(true)
+        expect(policy.technical_operator?).to be(true)
+      end
+
+      it "returns false for other roles", :aggregate_failures do
+        expect(policy.hmrc_admin?).to be(false)
+        expect(policy.auditor?).to be(false)
+        expect(policy.guest?).to be(false)
+      end
+    end
+
     context "with technical operator" do
       let(:user) { create(:user, :technical_operator) }
 
@@ -69,6 +84,7 @@ RSpec.describe ApplicationPolicy do
       let(:user) { nil }
 
       it "returns false for all role checks", :aggregate_failures do
+        expect(policy.superadmin?).to be(false)
         expect(policy.technical_operator?).to be(false)
         expect(policy.hmrc_admin?).to be(false)
         expect(policy.auditor?).to be(false)
@@ -78,6 +94,12 @@ RSpec.describe ApplicationPolicy do
   end
 
   describe "#can_access_xi?" do
+    it "returns true for superadmin" do
+      user = create(:user, :superadmin)
+      policy = described_class.new(user, record)
+      expect(policy.can_access_xi?).to be(true)
+    end
+
     it "returns true for technical operator" do
       user = create(:user, :technical_operator)
       policy = described_class.new(user, record)

--- a/spec/policies/rbac_comprehensive_spec.rb
+++ b/spec/policies/rbac_comprehensive_spec.rb
@@ -297,10 +297,18 @@ RSpec.describe "RBAC Comprehensive Rules" do
       allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(true)
     end
 
-    it "allows user management for non-guest users", :aggregate_failures do
+    it "allows user management for the synthetic basic-auth user", :aggregate_failures do
+      basic_auth_user = User.basic_auth_user!
+      expect(UserPolicy.new(basic_auth_user, User.new).index?).to be(true)
+      expect(UserPolicy.new(basic_auth_user, User.new).update?).to be(true)
+      expect(UserPolicy.new(basic_auth_user, User.new).create?).to be(true)
+      expect(UserPolicy.new(basic_auth_user, User.new).destroy?).to be(true)
+    end
+
+    it "does not grant user management to other non-guest users", :aggregate_failures do
       hmrc_admin = create(:user, :hmrc_admin)
-      expect(UserPolicy.new(hmrc_admin, User.new).index?).to be(true)
-      expect(UserPolicy.new(hmrc_admin, User.new).update?).to be(true)
+      expect(UserPolicy.new(hmrc_admin, User.new).index?).to be(false)
+      expect(UserPolicy.new(hmrc_admin, User.new).update?).to be(false)
     end
 
     it "denies user management for guest users even with basic auth", :aggregate_failures do

--- a/spec/policies/rbac_comprehensive_spec.rb
+++ b/spec/policies/rbac_comprehensive_spec.rb
@@ -199,15 +199,13 @@ RSpec.describe "RBAC Comprehensive Rules" do
       expect(QuotaPolicy.new(technical_operator, Quota.new).destroy?).to be(true)
     end
 
-    it "allows full access to updates", :aggregate_failures do
-      expect(UpdatePolicy.new(technical_operator, Update.new).index?).to be(true)
-      expect(UpdatePolicy.new(technical_operator, Update.new).download?).to be(true)
-      expect(UpdatePolicy.new(technical_operator, Update.new).apply_and_clear_cache?).to be(true)
+    it "denies access to updates" do
+      expect(UpdatePolicy.new(technical_operator, Update.new).index?).to be(false)
     end
 
-    it "allows full access to rollbacks", :aggregate_failures do
-      expect(RollbackPolicy.new(technical_operator, Rollback.new).index?).to be(true)
-      expect(RollbackPolicy.new(technical_operator, Rollback.new).create?).to be(true)
+    it "denies access to rollbacks", :aggregate_failures do
+      expect(RollbackPolicy.new(technical_operator, Rollback.new).index?).to be(false)
+      expect(RollbackPolicy.new(technical_operator, Rollback.new).create?).to be(false)
     end
 
     it "allows full access to XI services", :aggregate_failures do
@@ -222,15 +220,36 @@ RSpec.describe "RBAC Comprehensive Rules" do
       expect(GoodsNomenclatureLabelPolicy.new(technical_operator, GoodsNomenclatureLabel.new).update?).to be(true)
     end
 
-    it "allows access to user management", :aggregate_failures do
+    it "allows view and update access to user management", :aggregate_failures do
       expect(UserPolicy.new(technical_operator, User.new).index?).to be(true)
       expect(UserPolicy.new(technical_operator, User.new).update?).to be(true)
+      expect(UserPolicy.new(technical_operator, User.new).create?).to be(false)
+      expect(UserPolicy.new(technical_operator, User.new).destroy?).to be(false)
+    end
+  end
+
+  describe "SUPERADMIN role - technical operator plus user lifecycle" do
+    let(:superadmin) { create(:user, :superadmin) }
+
+    it "inherits technical operator access for content management", :aggregate_failures do
+      expect(SectionNotePolicy.new(superadmin, SectionNote.new).index?).to be(true)
+      expect(SearchReferencePolicy.new(superadmin, SearchReference.new).create?).to be(true)
+      expect(AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test")).update?).to be(true)
+      expect(UpdatePolicy.new(superadmin, Update.new).apply_and_clear_cache?).to be(true)
+      expect(RollbackPolicy.new(superadmin, Rollback.new).create?).to be(true)
+    end
+
+    it "allows full access to user management", :aggregate_failures do
+      expect(UserPolicy.new(superadmin, User.new).index?).to be(true)
+      expect(UserPolicy.new(superadmin, User.new).update?).to be(true)
+      expect(UserPolicy.new(superadmin, User.new).create?).to be(true)
+      expect(UserPolicy.new(superadmin, User.new).destroy?).to be(true)
     end
   end
 
   describe "XI Service access restriction" do
-    it "only TECHNICAL_OPERATOR and AUDITOR can access XI services", :aggregate_failures do
-      allowed = [create(:user, :technical_operator), create(:user, :auditor)]
+    it "only privileged operators and AUDITOR can access XI services", :aggregate_failures do
+      allowed = [create(:user, :superadmin), create(:user, :technical_operator), create(:user, :auditor)]
       denied = [create(:user, :hmrc_admin), create(:user, :guest)]
       index = ->(user) { GreenLanes::CategoryAssessmentPolicy.new(user, double).index? }
       expect(allowed.map(&index)).to all(be(true))

--- a/spec/policies/rbac_comprehensive_spec.rb
+++ b/spec/policies/rbac_comprehensive_spec.rb
@@ -88,6 +88,10 @@ RSpec.describe "RBAC Comprehensive Rules" do
       expect(RollbackPolicy.new(hmrc_admin, Rollback.new).index?).to be(false)
     end
 
+    it "denies access to admin configuration" do
+      expect(AdminConfigurationPolicy.new(hmrc_admin, AdminConfiguration.new(name: "test")).index?).to be(false)
+    end
+
     it "denies access to XI services (hidden)", :aggregate_failures do
       expect(GreenLanes::CategoryAssessmentPolicy.new(hmrc_admin, double).index?).to be(false)
       expect(GreenLanes::ExemptionPolicy.new(hmrc_admin, double).index?).to be(false)
@@ -150,6 +154,12 @@ RSpec.describe "RBAC Comprehensive Rules" do
       expect(RollbackPolicy.new(auditor, Rollback.new).create?).to be(false)
     end
 
+    it "allows read-only access to admin configuration", :aggregate_failures do
+      expect(AdminConfigurationPolicy.new(auditor, AdminConfiguration.new(name: "test")).index?).to be(true)
+      expect(AdminConfigurationPolicy.new(auditor, AdminConfiguration.new(name: "test")).show?).to be(true)
+      expect(AdminConfigurationPolicy.new(auditor, AdminConfiguration.new(name: "test")).update?).to be(false)
+    end
+
     it "allows read-only access to XI services", :aggregate_failures do
       expect(GreenLanes::CategoryAssessmentPolicy.new(auditor, double).index?).to be(true)
       expect(GreenLanes::CategoryAssessmentPolicy.new(auditor, double).show?).to be(true)
@@ -199,13 +209,22 @@ RSpec.describe "RBAC Comprehensive Rules" do
       expect(QuotaPolicy.new(technical_operator, Quota.new).destroy?).to be(true)
     end
 
-    it "denies access to updates" do
-      expect(UpdatePolicy.new(technical_operator, Update.new).index?).to be(false)
+    it "allows read-only access to updates", :aggregate_failures do
+      expect(UpdatePolicy.new(technical_operator, Update.new).index?).to be(true)
+      expect(UpdatePolicy.new(technical_operator, Update.new).show?).to be(true)
+      expect(UpdatePolicy.new(technical_operator, Update.new).download?).to be(false)
     end
 
-    it "denies access to rollbacks", :aggregate_failures do
-      expect(RollbackPolicy.new(technical_operator, Rollback.new).index?).to be(false)
+    it "allows read-only access to rollbacks", :aggregate_failures do
+      expect(RollbackPolicy.new(technical_operator, Rollback.new).index?).to be(true)
+      expect(RollbackPolicy.new(technical_operator, Rollback.new).show?).to be(true)
       expect(RollbackPolicy.new(technical_operator, Rollback.new).create?).to be(false)
+    end
+
+    it "allows read-only access to admin configuration", :aggregate_failures do
+      expect(AdminConfigurationPolicy.new(technical_operator, AdminConfiguration.new(name: "test")).index?).to be(true)
+      expect(AdminConfigurationPolicy.new(technical_operator, AdminConfiguration.new(name: "test")).show?).to be(true)
+      expect(AdminConfigurationPolicy.new(technical_operator, AdminConfiguration.new(name: "test")).update?).to be(false)
     end
 
     it "allows full access to XI services", :aggregate_failures do
@@ -234,8 +253,14 @@ RSpec.describe "RBAC Comprehensive Rules" do
     it "inherits technical operator access for content management", :aggregate_failures do
       expect(SectionNotePolicy.new(superadmin, SectionNote.new).index?).to be(true)
       expect(SearchReferencePolicy.new(superadmin, SearchReference.new).create?).to be(true)
+      expect(AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test")).index?).to be(true)
+      expect(AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test")).show?).to be(true)
       expect(AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test")).update?).to be(true)
+      expect(UpdatePolicy.new(superadmin, Update.new).index?).to be(true)
+      expect(UpdatePolicy.new(superadmin, Update.new).show?).to be(true)
       expect(UpdatePolicy.new(superadmin, Update.new).apply_and_clear_cache?).to be(true)
+      expect(RollbackPolicy.new(superadmin, Rollback.new).index?).to be(true)
+      expect(RollbackPolicy.new(superadmin, Rollback.new).show?).to be(true)
       expect(RollbackPolicy.new(superadmin, Rollback.new).create?).to be(true)
     end
 

--- a/spec/policies/rbac_comprehensive_spec.rb
+++ b/spec/policies/rbac_comprehensive_spec.rb
@@ -250,25 +250,35 @@ RSpec.describe "RBAC Comprehensive Rules" do
   describe "SUPERADMIN role - technical operator plus user lifecycle" do
     let(:superadmin) { create(:user, :superadmin) }
 
-    it "inherits technical operator access for content management", :aggregate_failures do
-      expect(SectionNotePolicy.new(superadmin, SectionNote.new).index?).to be(true)
-      expect(SearchReferencePolicy.new(superadmin, SearchReference.new).create?).to be(true)
-      expect(AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test")).index?).to be(true)
-      expect(AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test")).show?).to be(true)
-      expect(AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test")).update?).to be(true)
-      expect(UpdatePolicy.new(superadmin, Update.new).index?).to be(true)
-      expect(UpdatePolicy.new(superadmin, Update.new).show?).to be(true)
-      expect(UpdatePolicy.new(superadmin, Update.new).apply_and_clear_cache?).to be(true)
-      expect(RollbackPolicy.new(superadmin, Rollback.new).index?).to be(true)
-      expect(RollbackPolicy.new(superadmin, Rollback.new).show?).to be(true)
-      expect(RollbackPolicy.new(superadmin, Rollback.new).create?).to be(true)
+    it "inherits content management access", :aggregate_failures do
+      expect([SectionNotePolicy.new(superadmin, SectionNote.new).index?,
+              SearchReferencePolicy.new(superadmin, SearchReference.new).create?]).to all(be(true))
     end
 
-    it "allows full access to user management", :aggregate_failures do
-      expect(UserPolicy.new(superadmin, User.new).index?).to be(true)
-      expect(UserPolicy.new(superadmin, User.new).update?).to be(true)
-      expect(UserPolicy.new(superadmin, User.new).create?).to be(true)
-      expect(UserPolicy.new(superadmin, User.new).destroy?).to be(true)
+    it "allows full access to admin configuration" do
+      policy = AdminConfigurationPolicy.new(superadmin, AdminConfiguration.new(name: "test"))
+      expect([policy.index?, policy.show?, policy.update?]).to all(be(true))
+    end
+
+    it "allows full access to updates" do
+      expect([
+        UpdatePolicy.new(superadmin, Update.new).index?,
+        UpdatePolicy.new(superadmin, Update.new).show?,
+        UpdatePolicy.new(superadmin, Update.new).apply_and_clear_cache?,
+      ]).to all(be(true))
+    end
+
+    it "allows full access to rollbacks" do
+      expect([
+        RollbackPolicy.new(superadmin, Rollback.new).index?,
+        RollbackPolicy.new(superadmin, Rollback.new).show?,
+        RollbackPolicy.new(superadmin, Rollback.new).create?,
+      ]).to all(be(true))
+    end
+
+    it "allows full access to user management" do
+      policy = UserPolicy.new(superadmin, User.new)
+      expect([policy.index?, policy.update?, policy.create?, policy.destroy?]).to all(be(true))
     end
   end
 

--- a/spec/policies/rollback_policy_spec.rb
+++ b/spec/policies/rollback_policy_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe RollbackPolicy do
       expect(rollback_policy).to permit(user, rollback)
     end
 
-    it "grants access to auditor" do
-      user = create(:user, :auditor)
+    it "grants access to technical operator" do
+      user = create(:user, :technical_operator)
       expect(rollback_policy).to permit(user, rollback)
     end
 
-    it "denies access to technical operator" do
-      user = create(:user, :technical_operator)
-      expect(rollback_policy).not_to permit(user, rollback)
+    it "grants access to auditor" do
+      user = create(:user, :auditor)
+      expect(rollback_policy).to permit(user, rollback)
     end
 
     it "denies access to hmrc admin" do

--- a/spec/policies/rollback_policy_spec.rb
+++ b/spec/policies/rollback_policy_spec.rb
@@ -5,14 +5,19 @@ RSpec.describe RollbackPolicy do
   let(:rollback) { Rollback.new }
 
   permissions :index?, :show? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(rollback_policy).to permit(user, rollback)
     end
 
     it "grants access to auditor" do
       user = create(:user, :auditor)
       expect(rollback_policy).to permit(user, rollback)
+    end
+
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
+      expect(rollback_policy).not_to permit(user, rollback)
     end
 
     it "denies access to hmrc admin" do
@@ -27,13 +32,18 @@ RSpec.describe RollbackPolicy do
   end
 
   permissions :create? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(rollback_policy).to permit(user, rollback)
     end
 
     it "denies access to auditor" do
       user = create(:user, :auditor)
+      expect(rollback_policy).not_to permit(user, rollback)
+    end
+
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
       expect(rollback_policy).not_to permit(user, rollback)
     end
 

--- a/spec/policies/update_policy_spec.rb
+++ b/spec/policies/update_policy_spec.rb
@@ -5,14 +5,19 @@ RSpec.describe UpdatePolicy do
   let(:update) { Update.new }
 
   permissions :index?, :show? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(update_policy).to permit(user, update)
     end
 
     it "grants access to auditor" do
       user = create(:user, :auditor)
       expect(update_policy).to permit(user, update)
+    end
+
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
+      expect(update_policy).not_to permit(user, update)
     end
 
     it "denies access to hmrc admin" do
@@ -27,13 +32,18 @@ RSpec.describe UpdatePolicy do
   end
 
   permissions :download?, :apply_and_clear_cache?, :resend_cds_update_notification? do
-    it "grants access to technical operator" do
-      user = create(:user, :technical_operator)
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
       expect(update_policy).to permit(user, update)
     end
 
     it "denies access to auditor" do
       user = create(:user, :auditor)
+      expect(update_policy).not_to permit(user, update)
+    end
+
+    it "denies access to technical operator" do
+      user = create(:user, :technical_operator)
       expect(update_policy).not_to permit(user, update)
     end
 

--- a/spec/policies/update_policy_spec.rb
+++ b/spec/policies/update_policy_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe UpdatePolicy do
       expect(update_policy).to permit(user, update)
     end
 
-    it "grants access to auditor" do
-      user = create(:user, :auditor)
+    it "grants access to technical operator" do
+      user = create(:user, :technical_operator)
       expect(update_policy).to permit(user, update)
     end
 
-    it "denies access to technical operator" do
-      user = create(:user, :technical_operator)
-      expect(update_policy).not_to permit(user, update)
+    it "grants access to auditor" do
+      user = create(:user, :auditor)
+      expect(update_policy).to permit(user, update)
     end
 
     it "denies access to hmrc admin" do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,6 +1,26 @@
 RSpec.describe UserPolicy do
   subject(:user_policy) { described_class }
 
+  permissions :create?, :destroy? do
+    context "when not using basic auth" do
+      before do
+        allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(false)
+      end
+
+      it "grants access to superadmin" do
+        user = create(:user, :superadmin)
+        target_user = create(:user)
+        expect(user_policy).to permit(user, target_user)
+      end
+
+      it "denies access to technical operator" do
+        user = create(:user, :technical_operator)
+        target_user = create(:user)
+        expect(user_policy).not_to permit(user, target_user)
+      end
+    end
+  end
+
   permissions :update? do
     context "when using basic auth" do
       before do
@@ -42,6 +62,12 @@ RSpec.describe UserPolicy do
     context "when not using basic auth" do
       before do
         allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(false)
+      end
+
+      it "grants access to superadmin" do
+        user = create(:user, :superadmin)
+        target_user = create(:user)
+        expect(user_policy).to permit(user, target_user)
       end
 
       it "grants access to technical operator" do

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,37 +1,8 @@
 RSpec.describe UserPolicy do
   subject(:user_policy) { described_class }
 
-  permissions :assign_superadmin? do
-    context "when not using basic auth" do
-      before do
-        allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(false)
-      end
-
-      it "grants access to superadmin" do
-        user = create(:user, :superadmin)
-        target_user = create(:user)
-        expect(user_policy).to permit(user, target_user)
-      end
-
-      it "denies access to technical operator" do
-        user = create(:user, :technical_operator)
-        target_user = create(:user)
-        expect(user_policy).not_to permit(user, target_user)
-      end
-    end
-
-    context "when using basic auth" do
-      before do
-        allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(true)
-      end
-
-      it "still denies access to hmrc admin" do
-        user = create(:user, :hmrc_admin)
-        target_user = create(:user)
-        expect(user_policy).not_to permit(user, target_user)
-      end
-    end
-  end
+  let(:target_user) { create(:user, :guest) }
+  let(:policy) { described_class.new(current_user, target_user) }
 
   permissions :create?, :destroy? do
     context "when not using basic auth" do
@@ -41,13 +12,11 @@ RSpec.describe UserPolicy do
 
       it "grants access to superadmin" do
         user = create(:user, :superadmin)
-        target_user = create(:user)
         expect(user_policy).to permit(user, target_user)
       end
 
       it "denies access to technical operator" do
         user = create(:user, :technical_operator)
-        target_user = create(:user)
         expect(user_policy).not_to permit(user, target_user)
       end
     end
@@ -61,33 +30,22 @@ RSpec.describe UserPolicy do
 
       it "grants access to non-guest users" do
         user = create(:user, :technical_operator)
-        target_user = create(:user)
         expect(user_policy).to permit(user, target_user)
       end
 
       it "grants access to hmrc admin users" do
         user = create(:user, :hmrc_admin)
-        target_user = create(:user)
         expect(user_policy).to permit(user, target_user)
       end
 
       it "grants access to auditor users" do
         user = create(:user, :auditor)
-        target_user = create(:user)
         expect(user_policy).to permit(user, target_user)
       end
 
       it "denies access to guest users even with basic auth" do
         user = create(:user, :guest)
-        target_user = create(:user)
         expect(user_policy).not_to permit(user, target_user)
-      end
-
-      it "denies access when basic auth is not enabled" do
-        allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(false)
-        user = create(:user, :technical_operator)
-        target_user = create(:user)
-        expect(user_policy).to permit(user, target_user) # Still works via technical_operator check
       end
     end
 
@@ -98,32 +56,136 @@ RSpec.describe UserPolicy do
 
       it "grants access to superadmin" do
         user = create(:user, :superadmin)
-        target_user = create(:user)
         expect(user_policy).to permit(user, target_user)
       end
 
       it "grants access to technical operator" do
         user = create(:user, :technical_operator)
-        target_user = create(:user)
         expect(user_policy).to permit(user, target_user)
       end
 
       it "denies access to hmrc admin" do
         user = create(:user, :hmrc_admin)
-        target_user = create(:user)
         expect(user_policy).not_to permit(user, target_user)
       end
 
       it "denies access to auditor" do
         user = create(:user, :auditor)
-        target_user = create(:user)
         expect(user_policy).not_to permit(user, target_user)
       end
 
       it "denies access to guest user" do
         user = create(:user, :guest)
-        target_user = create(:user)
         expect(user_policy).not_to permit(user, target_user)
+      end
+    end
+  end
+
+  describe "#assignable_roles" do
+    before do
+      allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(basic_auth_enabled)
+    end
+
+    let(:basic_auth_enabled) { false }
+
+    context "when the current user is superadmin" do
+      let(:current_user) { create(:user, :superadmin) }
+
+      it "returns all roles" do
+        expect(policy.assignable_roles).to eq(User::VALID_ROLES)
+      end
+    end
+
+    context "when the current user is technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it "returns technical operator and lower roles" do
+        expect(policy.assignable_roles).to eq([User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR, User::GUEST])
+      end
+    end
+
+    context "when the current user is hmrc admin using basic auth" do
+      let(:basic_auth_enabled) { true }
+      let(:current_user) { create(:user, :hmrc_admin) }
+
+      it "returns hmrc admin and lower roles" do
+        expect(policy.assignable_roles).to eq([User::HMRC_ADMIN, User::AUDITOR, User::GUEST])
+      end
+    end
+  end
+
+  describe "#role_option_enabled?" do
+    before do
+      allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(false)
+    end
+
+    let(:current_user) { create(:user, :technical_operator) }
+
+    context "when editing a guest user" do
+      it "enables roles at or below the user's ceiling", :aggregate_failures do
+        expect(policy.role_option_enabled?(User::TECHNICAL_OPERATOR)).to be(true)
+        expect(policy.role_option_enabled?(User::HMRC_ADMIN)).to be(true)
+        expect(policy.role_option_enabled?(User::SUPERADMIN)).to be(false)
+      end
+    end
+
+    context "when editing a superadmin" do
+      let(:target_user) { create(:user, :superadmin) }
+
+      it "disables all role options because the role is locked", :aggregate_failures do
+        expect(policy.locked_higher_role?).to be(true)
+        expect(policy.role_option_enabled?(User::SUPERADMIN)).to be(false)
+        expect(policy.role_option_enabled?(User::HMRC_ADMIN)).to be(false)
+      end
+    end
+  end
+
+  describe "#role_submittable?" do
+    before do
+      allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(basic_auth_enabled)
+    end
+
+    let(:basic_auth_enabled) { false }
+
+    context "when the current user is technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it "denies escalation to superadmin" do
+        expect(policy.role_submittable?(User::SUPERADMIN)).to be(false)
+      end
+    end
+
+    context "when a technical operator edits an existing superadmin" do
+      let(:current_user) { create(:user, :technical_operator) }
+      let(:target_user) { create(:user, :superadmin) }
+
+      it "allows preserving the superadmin role" do
+        expect(policy.role_submittable?(User::SUPERADMIN)).to be(true)
+      end
+
+      it "denies changing the superadmin role" do
+        expect(policy.role_submittable?(User::HMRC_ADMIN)).to be(false)
+      end
+    end
+
+    context "when the current user is superadmin" do
+      let(:current_user) { create(:user, :superadmin) }
+
+      it "allows assigning any role" do
+        expect(policy.role_submittable?(User::SUPERADMIN)).to be(true)
+      end
+    end
+
+    context "when the current user is hmrc admin using basic auth" do
+      let(:basic_auth_enabled) { true }
+      let(:current_user) { create(:user, :hmrc_admin) }
+
+      it "allows assigning hmrc admin" do
+        expect(policy.role_submittable?(User::HMRC_ADMIN)).to be(true)
+      end
+
+      it "denies assigning technical operator" do
+        expect(policy.role_submittable?(User::TECHNICAL_OPERATOR)).to be(false)
       end
     end
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -28,19 +28,14 @@ RSpec.describe UserPolicy do
         allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(true)
       end
 
-      it "grants access to non-guest users" do
-        user = create(:user, :technical_operator)
+      it "grants access to the synthetic basic-auth user" do
+        user = User.basic_auth_user!
         expect(user_policy).to permit(user, target_user)
       end
 
-      it "grants access to hmrc admin users" do
+      it "does not grant access to other non-guest users" do
         user = create(:user, :hmrc_admin)
-        expect(user_policy).to permit(user, target_user)
-      end
-
-      it "grants access to auditor users" do
-        user = create(:user, :auditor)
-        expect(user_policy).to permit(user, target_user)
+        expect(user_policy).not_to permit(user, target_user)
       end
 
       it "denies access to guest users even with basic auth" do
@@ -104,12 +99,12 @@ RSpec.describe UserPolicy do
       end
     end
 
-    context "when the current user is hmrc admin using basic auth" do
+    context "when the current user is the synthetic basic-auth user" do
       let(:basic_auth_enabled) { true }
-      let(:current_user) { create(:user, :hmrc_admin) }
+      let(:current_user) { User.basic_auth_user! }
 
-      it "returns hmrc admin and lower roles" do
-        expect(policy.assignable_roles).to eq([User::HMRC_ADMIN, User::AUDITOR, User::GUEST])
+      it "returns all roles" do
+        expect(policy.assignable_roles).to eq(User::VALID_ROLES)
       end
     end
   end
@@ -176,16 +171,16 @@ RSpec.describe UserPolicy do
       end
     end
 
-    context "when the current user is hmrc admin using basic auth" do
+    context "when the current user is the synthetic basic-auth user" do
       let(:basic_auth_enabled) { true }
-      let(:current_user) { create(:user, :hmrc_admin) }
+      let(:current_user) { User.basic_auth_user! }
 
-      it "allows assigning hmrc admin" do
-        expect(policy.role_submittable?(User::HMRC_ADMIN)).to be(true)
+      it "allows assigning superadmin" do
+        expect(policy.role_submittable?(User::SUPERADMIN)).to be(true)
       end
 
-      it "denies assigning technical operator" do
-        expect(policy.role_submittable?(User::TECHNICAL_OPERATOR)).to be(false)
+      it "allows assigning technical operator" do
+        expect(policy.role_submittable?(User::TECHNICAL_OPERATOR)).to be(true)
       end
     end
   end

--- a/spec/policies/user_policy_spec.rb
+++ b/spec/policies/user_policy_spec.rb
@@ -1,6 +1,38 @@
 RSpec.describe UserPolicy do
   subject(:user_policy) { described_class }
 
+  permissions :assign_superadmin? do
+    context "when not using basic auth" do
+      before do
+        allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(false)
+      end
+
+      it "grants access to superadmin" do
+        user = create(:user, :superadmin)
+        target_user = create(:user)
+        expect(user_policy).to permit(user, target_user)
+      end
+
+      it "denies access to technical operator" do
+        user = create(:user, :technical_operator)
+        target_user = create(:user)
+        expect(user_policy).not_to permit(user, target_user)
+      end
+    end
+
+    context "when using basic auth" do
+      before do
+        allow(TradeTariffAdmin).to receive(:basic_session_authentication?).and_return(true)
+      end
+
+      it "still denies access to hmrc admin" do
+        user = create(:user, :hmrc_admin)
+        target_user = create(:user)
+        expect(user_policy).not_to permit(user, target_user)
+      end
+    end
+  end
+
   permissions :create?, :destroy? do
     context "when not using basic auth" do
       before do

--- a/spec/requests/classification_configurations_controller_spec.rb
+++ b/spec/requests/classification_configurations_controller_spec.rb
@@ -354,6 +354,28 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         expect(session.dig("flash", "flashes", "alert")).to eq("Configuration not found.")
       end
     end
+
+    context "when current user is technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it "allows read-only access" do
+        rendered_page
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include("Edit")
+      end
+    end
+
+    context "when current user is auditor" do
+      let(:current_user) { create(:user, :auditor) }
+
+      it "allows read-only access" do
+        rendered_page
+
+        expect(response).to have_http_status(:success)
+        expect(response.body).not_to include("Edit")
+      end
+    end
   end
 
   describe "GET #edit" do
@@ -866,11 +888,84 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
     end
   end
 
-  context "when user is auditor (unauthorized)" do
-    let(:current_user) { create(:user, :auditor) }
-    let(:make_request) { get classification_configurations_path }
+  context "when user is technical operator (read-only)" do
+    let(:current_user) { create(:user, :technical_operator) }
 
-    it { is_expected.to have_http_status :forbidden }
+    describe "GET #index" do
+      before do
+        stub_api_request("/admin_configurations")
+          .and_return(collection_response)
+      end
+
+      let(:make_request) { get classification_configurations_path }
+
+      it { is_expected.to have_http_status :success }
+    end
+
+    describe "GET #edit" do
+      before do
+        stub_api_request("/admin_configurations/#{config_name}")
+          .and_return(config_response)
+      end
+
+      let(:make_request) { get edit_classification_configuration_path(config_name) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+
+    describe "PATCH #update" do
+      before do
+        stub_api_request("/admin_configurations/#{config_name}")
+          .and_return(config_response)
+      end
+
+      let(:make_request) do
+        patch classification_configuration_path(config_name),
+              params: { classification_configuration: { value: "Updated prompt text" } }
+      end
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+  end
+
+  context "when user is auditor (read-only)" do
+    let(:current_user) { create(:user, :auditor) }
+
+    describe "GET #index" do
+      before do
+        stub_api_request("/admin_configurations")
+          .and_return(collection_response)
+      end
+
+      let(:make_request) { get classification_configurations_path }
+
+      it { is_expected.to have_http_status :success }
+    end
+
+    describe "GET #edit" do
+      before do
+        stub_api_request("/admin_configurations/#{config_name}")
+          .and_return(config_response)
+      end
+
+      let(:make_request) { get edit_classification_configuration_path(config_name) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+
+    describe "PATCH #update" do
+      before do
+        stub_api_request("/admin_configurations/#{config_name}")
+          .and_return(config_response)
+      end
+
+      let(:make_request) do
+        patch classification_configuration_path(config_name),
+              params: { classification_configuration: { value: "Updated prompt text" } }
+      end
+
+      it { is_expected.to have_http_status :forbidden }
+    end
   end
 
   context "when user is guest (unauthorized)" do

--- a/spec/requests/classification_configurations_controller_spec.rb
+++ b/spec/requests/classification_configurations_controller_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
   include_context "with authenticated user"
 
-  let(:current_user) { create(:user, :technical_operator) }
+  let(:current_user) { create(:user, :superadmin) }
   let(:config_name) { "expansion_prompt" }
   let(:config_attributes) do
     {

--- a/spec/requests/rollbacks_controller_spec.rb
+++ b/spec/requests/rollbacks_controller_spec.rb
@@ -44,6 +44,24 @@ RSpec.describe RollbacksController do
     end
   end
 
+  context "when using no-auth synthetic user" do
+    include_context "with no-auth synthetic user"
+
+    it "can access rollback creation" do
+      get new_rollback_path
+
+      expect(response).to have_http_status(:success)
+    end
+
+    it "can create rollbacks" do
+      stub_api_request("/rollbacks", :post).to_return(api_created_response)
+
+      post rollbacks_path, params: { rollback: { date: Time.zone.today.to_s, keep: true, reason: "Test rollback" } }
+
+      expect(response).to redirect_to(rollbacks_path)
+    end
+  end
+
   context "when unauthorised" do
     let(:current_user) { create(:user, :guest) }
 

--- a/spec/requests/rollbacks_controller_spec.rb
+++ b/spec/requests/rollbacks_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe RollbacksController do
   subject(:rendered_page) { make_request && response }
 
   include_context "with authenticated user"
+  let(:current_user) { create(:user, :superadmin) }
 
   describe "GET #index" do
     before do
@@ -30,5 +31,12 @@ RSpec.describe RollbacksController do
 
     it { is_expected.to have_http_status :forbidden }
     it { is_expected.to have_attributes body: /contact your Delivery Manager/ }
+  end
+
+  context "when technical operator" do
+    let(:current_user) { create(:user, :technical_operator) }
+    let(:make_request) { get rollbacks_path }
+
+    it { is_expected.to have_http_status :forbidden }
   end
 end

--- a/spec/requests/rollbacks_controller_spec.rb
+++ b/spec/requests/rollbacks_controller_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe RollbacksController do
   include_context "with authenticated user"
   let(:current_user) { create(:user, :superadmin) }
 
+  def stub_rollbacks_index
+    stub_api_request("/rollbacks?page=1").and_return \
+      jsonapi_response :rollbacks, attributes_for_list(:rollback, 3)
+  end
+
   describe "GET #index" do
-    before do
-      stub_api_request("/rollbacks?page=1").and_return \
-        jsonapi_response :rollbacks, attributes_for_list(:rollback, 3)
-    end
+    before { stub_rollbacks_index }
 
     let(:make_request) { get rollbacks_path }
 
@@ -37,14 +39,20 @@ RSpec.describe RollbacksController do
     let(:current_user) { create(:user, :technical_operator) }
     let(:make_request) { get rollbacks_path }
 
+    before { stub_rollbacks_index }
+
     it { is_expected.to have_http_status :success }
+    it { is_expected.not_to have_attributes body: /New Rollback/ }
   end
 
   context "when auditor" do
     let(:current_user) { create(:user, :auditor) }
     let(:make_request) { get rollbacks_path }
 
+    before { stub_rollbacks_index }
+
     it { is_expected.to have_http_status :success }
+    it { is_expected.not_to have_attributes body: /New Rollback/ }
   end
 
   describe "POST #create" do

--- a/spec/requests/rollbacks_controller_spec.rb
+++ b/spec/requests/rollbacks_controller_spec.rb
@@ -37,6 +37,25 @@ RSpec.describe RollbacksController do
     let(:current_user) { create(:user, :technical_operator) }
     let(:make_request) { get rollbacks_path }
 
-    it { is_expected.to have_http_status :forbidden }
+    it { is_expected.to have_http_status :success }
+  end
+
+  context "when auditor" do
+    let(:current_user) { create(:user, :auditor) }
+    let(:make_request) { get rollbacks_path }
+
+    it { is_expected.to have_http_status :success }
+  end
+
+  describe "POST #create" do
+    let(:make_request) do
+      post rollbacks_path, params: { rollback: { date: Time.zone.today.to_s, keep: true, reason: "Test rollback" } }
+    end
+
+    context "when technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
   end
 end

--- a/spec/requests/rollbacks_controller_spec.rb
+++ b/spec/requests/rollbacks_controller_spec.rb
@@ -17,6 +17,24 @@ RSpec.describe RollbacksController do
     it { is_expected.to have_http_status :success }
   end
 
+  describe "GET #new" do
+    let(:make_request) { get new_rollback_path }
+
+    it { is_expected.to have_http_status :success }
+
+    context "when technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+
+    context "when auditor" do
+      let(:current_user) { create(:user, :auditor) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+  end
+
   context "when unauthenticated" do
     let(:authenticate_user) { false }
     let(:extra_session) { {} }
@@ -56,12 +74,24 @@ RSpec.describe RollbacksController do
   end
 
   describe "POST #create" do
+    before do
+      stub_api_request("/rollbacks", :post).to_return(api_created_response)
+    end
+
     let(:make_request) do
       post rollbacks_path, params: { rollback: { date: Time.zone.today.to_s, keep: true, reason: "Test rollback" } }
     end
 
+    it { is_expected.to redirect_to(rollbacks_path) }
+
     context "when technical operator" do
       let(:current_user) { create(:user, :technical_operator) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+
+    context "when auditor" do
+      let(:current_user) { create(:user, :auditor) }
 
       it { is_expected.to have_http_status :forbidden }
     end

--- a/spec/requests/tariff_updates_controller_spec.rb
+++ b/spec/requests/tariff_updates_controller_spec.rb
@@ -2,6 +2,7 @@ RSpec.describe TariffUpdatesController do
   subject(:rendered_page) { make_request && response }
 
   include_context "with authenticated user"
+  let(:current_user) { create(:user, :superadmin) }
 
   describe "GET #index" do
     before do
@@ -30,6 +31,13 @@ RSpec.describe TariffUpdatesController do
 
     it { is_expected.to have_http_status :forbidden }
     it { is_expected.to have_attributes body: /contact your Delivery Manager/ }
+  end
+
+  context "when technical operator" do
+    let(:current_user) { create(:user, :technical_operator) }
+    let(:make_request) { get tariff_updates_path }
+
+    it { is_expected.to have_http_status :forbidden }
   end
 
   describe "POST #download" do

--- a/spec/requests/tariff_updates_controller_spec.rb
+++ b/spec/requests/tariff_updates_controller_spec.rb
@@ -48,6 +48,55 @@ RSpec.describe TariffUpdatesController do
     end
   end
 
+  context "when using no-auth synthetic user" do
+    include_context "with no-auth synthetic user"
+
+    it "shows the rollback link on the updates page", :aggregate_failures do
+      stub_tariff_updates_index([rollbackable_update])
+
+      get tariff_updates_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("Rollback to 2026-04-01")
+    end
+
+    it "shows the direct update download link", :aggregate_failures do
+      update_id = "2026-04-01_TGB22037"
+      stub_tariff_update_show(update_id, rollbackable_update)
+
+      get tariff_update_path(update_id)
+
+      expect(response).to have_http_status(:success)
+      expect(response.body).to include("https://example.com/2026-04-01_TGB22037.xml")
+    end
+
+    it "can schedule a download" do
+      TradeTariffAdmin::ServiceChooser.service_choice = "uk"
+      stub_api_request("/admin/downloads", :post).to_return(status: 200, body: "", headers: {})
+
+      post "/tariff_updates/download"
+
+      expect(response).to redirect_to(tariff_updates_path)
+    end
+
+    it "can apply updates and clear cache" do
+      TradeTariffAdmin::ServiceChooser.service_choice = "uk"
+      stub_api_request("/admin/applies", :post).to_return(status: 200, body: "", headers: {})
+
+      post "/tariff_updates/apply_and_clear_cache"
+
+      expect(response).to redirect_to(tariff_updates_path)
+    end
+
+    it "can resend CDS update notifications" do
+      stub_api_request("/admin/cds_update_notifications", :post).to_return(status: 200, body: "", headers: {})
+
+      post "/tariff_updates/resend_cds_update_notification", params: { cds_update_notification: { filename: "filename" } }
+
+      expect(response).to redirect_to(tariff_updates_path)
+    end
+  end
+
   context "when unauthorised" do
     let(:current_user) { create(:user, :guest) }
 

--- a/spec/requests/tariff_updates_controller_spec.rb
+++ b/spec/requests/tariff_updates_controller_spec.rb
@@ -3,10 +3,24 @@ RSpec.describe TariffUpdatesController do
 
   include_context "with authenticated user"
   let(:current_user) { create(:user, :superadmin) }
+  let(:rollbackable_update) do
+    attributes_for(
+      :update,
+      state: "A",
+      issue_date: "2026-04-01",
+      filename: "2026-04-01_TGB22037.xml",
+      file_presigned_url: "https://example.com/2026-04-01_TGB22037.xml",
+    )
+  end
 
-  def stub_tariff_updates_index
+  def stub_tariff_updates_index(updates = attributes_for_list(:update, 3))
     stub_api_request("/updates?page=1").and_return \
-      jsonapi_response :tariff_updates, attributes_for_list(:update, 3)
+      jsonapi_response(:tariff_updates, updates)
+  end
+
+  def stub_tariff_update_show(update_id, update_attributes)
+    stub_api_request("/updates/#{update_id}").and_return \
+      jsonapi_response(:update, update_attributes)
   end
 
   describe "GET #index" do
@@ -15,6 +29,14 @@ RSpec.describe TariffUpdatesController do
     let(:make_request) { get tariff_updates_path }
 
     it { is_expected.to have_http_status :success }
+
+    it "shows the rollback link to superadmin when applicable" do
+      stub_tariff_updates_index([rollbackable_update])
+
+      get tariff_updates_path
+
+      expect(response.body).to include("Rollback to 2026-04-01")
+    end
   end
 
   context "when unauthenticated" do
@@ -42,6 +64,14 @@ RSpec.describe TariffUpdatesController do
     before { stub_tariff_updates_index }
 
     it { is_expected.to have_http_status :success }
+
+    it "does not show the rollback link on the updates page" do
+      stub_tariff_updates_index([rollbackable_update])
+
+      get tariff_updates_path
+
+      expect(response.body).not_to include("Rollback to 2026-04-01")
+    end
   end
 
   context "when auditor" do
@@ -51,6 +81,51 @@ RSpec.describe TariffUpdatesController do
     before { stub_tariff_updates_index }
 
     it { is_expected.to have_http_status :success }
+
+    it "does not show the rollback link on the updates page" do
+      stub_tariff_updates_index([rollbackable_update])
+
+      get tariff_updates_path
+
+      expect(response.body).not_to include("Rollback to 2026-04-01")
+    end
+  end
+
+  describe "GET #show" do
+    let(:update_id) { "2026-04-01_TGB22037" }
+    let(:make_request) { get tariff_update_path(update_id) }
+
+    before do
+      stub_tariff_update_show(update_id, rollbackable_update)
+    end
+
+    it { is_expected.to have_http_status :success }
+
+    it "shows the download link to superadmin" do
+      make_request
+
+      expect(response.body).to include("https://example.com/2026-04-01_TGB22037.xml")
+    end
+
+    context "when technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it "hides the download link" do
+        make_request
+
+        expect(response.body).not_to include("https://example.com/2026-04-01_TGB22037.xml")
+      end
+    end
+
+    context "when auditor" do
+      let(:current_user) { create(:user, :auditor) }
+
+      it "hides the download link" do
+        make_request
+
+        expect(response.body).not_to include("https://example.com/2026-04-01_TGB22037.xml")
+      end
+    end
   end
 
   describe "POST #download" do

--- a/spec/requests/tariff_updates_controller_spec.rb
+++ b/spec/requests/tariff_updates_controller_spec.rb
@@ -37,7 +37,14 @@ RSpec.describe TariffUpdatesController do
     let(:current_user) { create(:user, :technical_operator) }
     let(:make_request) { get tariff_updates_path }
 
-    it { is_expected.to have_http_status :forbidden }
+    it { is_expected.to have_http_status :success }
+  end
+
+  context "when auditor" do
+    let(:current_user) { create(:user, :auditor) }
+    let(:make_request) { get tariff_updates_path }
+
+    it { is_expected.to have_http_status :success }
   end
 
   describe "POST #download" do
@@ -51,6 +58,16 @@ RSpec.describe TariffUpdatesController do
 
       expect(response).to redirect_to(tariff_updates_path) # it stays on the same page
       expect(flash[:notice]).to eq("Download was scheduled")
+    end
+
+    context "when technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it "returns forbidden" do
+        post "/tariff_updates/download"
+
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 
@@ -66,6 +83,16 @@ RSpec.describe TariffUpdatesController do
       expect(response).to redirect_to(tariff_updates_path)
       expect(flash[:notice]).to eq("Apply & ClearCache was scheduled")
     end
+
+    context "when technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it "returns forbidden" do
+        post "/tariff_updates/apply_and_clear_cache"
+
+        expect(response).to have_http_status(:forbidden)
+      end
+    end
   end
 
   describe "POST #resend_cds_update_notification" do
@@ -80,6 +107,16 @@ RSpec.describe TariffUpdatesController do
     it "displays success message" do
       rendered_page
       expect(flash[:notice]).to eq("CDS Updates notification was scheduled")
+    end
+
+    context "when technical operator" do
+      let(:current_user) { create(:user, :technical_operator) }
+
+      it "returns forbidden" do
+        post "/tariff_updates/resend_cds_update_notification", params: { cds_update_notification: { filename: "filename" } }
+
+        expect(response).to have_http_status(:forbidden)
+      end
     end
   end
 end

--- a/spec/requests/tariff_updates_controller_spec.rb
+++ b/spec/requests/tariff_updates_controller_spec.rb
@@ -4,11 +4,13 @@ RSpec.describe TariffUpdatesController do
   include_context "with authenticated user"
   let(:current_user) { create(:user, :superadmin) }
 
+  def stub_tariff_updates_index
+    stub_api_request("/updates?page=1").and_return \
+      jsonapi_response :tariff_updates, attributes_for_list(:update, 3)
+  end
+
   describe "GET #index" do
-    before do
-      stub_api_request("/updates?page=1").and_return \
-        jsonapi_response :tariff_updates, attributes_for_list(:update, 3)
-    end
+    before { stub_tariff_updates_index }
 
     let(:make_request) { get tariff_updates_path }
 
@@ -37,12 +39,16 @@ RSpec.describe TariffUpdatesController do
     let(:current_user) { create(:user, :technical_operator) }
     let(:make_request) { get tariff_updates_path }
 
+    before { stub_tariff_updates_index }
+
     it { is_expected.to have_http_status :success }
   end
 
   context "when auditor" do
     let(:current_user) { create(:user, :auditor) }
     let(:make_request) { get tariff_updates_path }
+
+    before { stub_tariff_updates_index }
 
     it { is_expected.to have_http_status :success }
   end

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -223,7 +223,7 @@ RSpec.describe UsersController do
       it "does not update the user role" do
         expect {
           update_request(name: "Updated User", role: User::SUPERADMIN)
-        }.not_to change { target_user.reload.current_role }
+        }.not_to(change { target_user.reload.current_role })
       end
     end
 

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -355,7 +355,7 @@ RSpec.describe UsersController do
       allow(Rails.env).to receive(:production?).and_return(false)
     end
 
-    let(:current_user) { create(:user, :hmrc_admin) }
+    let(:current_user) { User.basic_auth_user! }
 
     describe "GET #index" do
       let(:make_request) { get users_path }
@@ -396,7 +396,7 @@ RSpec.describe UsersController do
              params: { user: new_user_params.merge(role: User::SUPERADMIN) }
       end
 
-      it { is_expected.to have_http_status :forbidden }
+      it { is_expected.to redirect_to users_path }
     end
 
     describe "PATCH #update when assigning superadmin" do
@@ -405,7 +405,12 @@ RSpec.describe UsersController do
               params: { user: { name: target_user.name, role: User::SUPERADMIN } }
       end
 
-      it { is_expected.to have_http_status :forbidden }
+      it { is_expected.to redirect_to users_path }
+
+      it "updates the role" do
+        make_request
+        expect(target_user.reload.current_role).to eq(User::SUPERADMIN)
+      end
     end
 
     describe "PATCH #update when assigning technical operator" do
@@ -414,7 +419,7 @@ RSpec.describe UsersController do
               params: { user: { name: target_user.name, role: User::TECHNICAL_OPERATOR } }
       end
 
-      it { is_expected.to have_http_status :forbidden }
+      it { is_expected.to redirect_to users_path }
     end
 
     describe "POST #create" do
@@ -432,7 +437,45 @@ RSpec.describe UsersController do
              params: { user: new_user_params.merge(role: User::TECHNICAL_OPERATOR) }
       end
 
-      it { is_expected.to have_http_status :forbidden }
+      it { is_expected.to redirect_to users_path }
+    end
+
+    describe "DELETE #destroy" do
+      let(:make_request) { delete user_path(target_user) }
+
+      it { is_expected.to redirect_to users_path }
+    end
+  end
+
+  context "when using no-auth synthetic user" do
+    include_context "with no-auth synthetic user"
+
+    describe "POST #create with superadmin role" do
+      let(:make_request) do
+        post users_path,
+             params: { user: new_user_params.merge(role: User::SUPERADMIN) }
+      end
+
+      it { is_expected.to redirect_to users_path }
+
+      it "creates a superadmin user", :aggregate_failures do
+        expect { make_request }.to change(User, :count).by(1)
+        expect(User.order(:created_at).last.current_role).to eq(User::SUPERADMIN)
+      end
+    end
+
+    describe "PATCH #update when assigning superadmin" do
+      let(:make_request) do
+        patch user_path(target_user),
+              params: { user: { name: target_user.name, role: User::SUPERADMIN } }
+      end
+
+      it { is_expected.to redirect_to users_path }
+
+      it "updates the role" do
+        make_request
+        expect(target_user.reload.current_role).to eq(User::SUPERADMIN)
+      end
     end
 
     describe "DELETE #destroy" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -37,15 +37,30 @@ RSpec.describe UsersController do
 
     it { is_expected.to have_http_status :success }
 
-    it "displays fields for name and role selection without superadmin", :aggregate_failures do
+    it "displays all roles and disables superadmin", :aggregate_failures do
       rendered_page
-      expect(response.body).to include("Name", "radio", User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
-      expect(response.body).not_to include(User::SUPERADMIN)
+      document = Nokogiri::HTML(response.body)
+
+      expect(response.body).to include("Name", "radio", User::SUPERADMIN, User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
+      expect(document.at_css("input[type='radio'][value='SUPERADMIN']")["disabled"]).to eq("disabled")
+      expect(document.at_css("input[type='radio'][value='HMRC_ADMIN']")["disabled"]).to be_nil
     end
 
     it "preselects the current role" do
       rendered_page
       expect(response.body).to include("checked")
+    end
+
+    context "when editing a superadmin" do
+      let(:target_user) { create(:user, :superadmin) }
+
+      it "disables every role option and preserves the current role", :aggregate_failures do
+        rendered_page
+        document = Nokogiri::HTML(response.body)
+
+        expect(document.css("input[type='radio'][name='user[role]']")).to all(satisfy { |input| input["disabled"] == "disabled" })
+        expect(document.at_css("input[type='hidden'][name='user[role]'][value='SUPERADMIN']")).not_to be_nil
+      end
     end
 
     context "when current user is superadmin" do
@@ -55,6 +70,13 @@ RSpec.describe UsersController do
         rendered_page
 
         expect(response.body).to include(User::SUPERADMIN)
+      end
+
+      it "enables the superadmin role option" do
+        rendered_page
+        document = Nokogiri::HTML(response.body)
+
+        expect(document.at_css("input[type='radio'][value='SUPERADMIN']")["disabled"]).to be_nil
       end
     end
   end
@@ -227,6 +249,29 @@ RSpec.describe UsersController do
       end
     end
 
+    context "when editing an existing superadmin" do
+      let(:target_user) { create(:user, :superadmin) }
+
+      it "allows updating the name while preserving the role", :aggregate_failures do
+        update_request(name: "Updated User", role: User::SUPERADMIN)
+
+        expect(response).to redirect_to(users_path)
+        expect(target_user.reload).to have_attributes(name: "Updated User", current_role: User::SUPERADMIN, role: User::SUPERADMIN)
+      end
+
+      it "forbids changing the superadmin role" do
+        update_request(name: "Updated User", role: User::HMRC_ADMIN)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not change the superadmin role" do
+        expect {
+          update_request(name: "Updated User", role: User::HMRC_ADMIN)
+        }.not_to(change { target_user.reload.current_role })
+      end
+    end
+
     context "with a blank name" do
       it "returns unprocessable content" do
         update_request(name: "", role: User::HMRC_ADMIN)
@@ -338,7 +383,7 @@ RSpec.describe UsersController do
 
       it { is_expected.to redirect_to users_path }
 
-      it "allows role update regardless of user role" do
+      it "allows role update within the user's ceiling" do
         make_request
         target_user.reload
         expect(target_user.current_role).to eq(User::HMRC_ADMIN)
@@ -363,6 +408,15 @@ RSpec.describe UsersController do
       it { is_expected.to have_http_status :forbidden }
     end
 
+    describe "PATCH #update when assigning technical operator" do
+      let(:make_request) do
+        patch user_path(target_user),
+              params: { user: { name: target_user.name, role: User::TECHNICAL_OPERATOR } }
+      end
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+
     describe "POST #create" do
       let(:make_request) do
         post users_path,
@@ -370,6 +424,15 @@ RSpec.describe UsersController do
       end
 
       it { is_expected.to redirect_to users_path }
+    end
+
+    describe "POST #create with technical operator role" do
+      let(:make_request) do
+        post users_path,
+             params: { user: new_user_params.merge(role: User::TECHNICAL_OPERATOR) }
+      end
+
+      it { is_expected.to have_http_status :forbidden }
     end
 
     describe "DELETE #destroy" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -37,14 +37,25 @@ RSpec.describe UsersController do
 
     it { is_expected.to have_http_status :success }
 
-    it "displays fields for name and role selection", :aggregate_failures do
+    it "displays fields for name and role selection without superadmin", :aggregate_failures do
       rendered_page
-      expect(response.body).to include("Name", "radio", User::SUPERADMIN, User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
+      expect(response.body).to include("Name", "radio", User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
+      expect(response.body).not_to include(User::SUPERADMIN)
     end
 
     it "preselects the current role" do
       rendered_page
       expect(response.body).to include("checked")
+    end
+
+    context "when current user is superadmin" do
+      let(:current_user) { create(:user, :superadmin) }
+
+      it "shows the superadmin role option" do
+        rendered_page
+
+        expect(response.body).to include(User::SUPERADMIN)
+      end
     end
   end
 
@@ -136,6 +147,18 @@ RSpec.describe UsersController do
         expect(response.body).to include("There is a problem", "Name can&#39;t be blank")
       end
     end
+
+    context "when creating a superadmin" do
+      let(:new_user_params) do
+        super().merge(role: User::SUPERADMIN)
+      end
+
+      it "creates the user with the superadmin role" do
+        make_request
+
+        expect(User.order(:created_at).last.current_role).to eq(User::SUPERADMIN)
+      end
+    end
   end
 
   describe "PATCH #update" do
@@ -187,6 +210,20 @@ RSpec.describe UsersController do
         update_request(name: target_user.name, role: User::AUDITOR)
 
         expect(target_user.reload).to have_attributes(current_role: User::AUDITOR, role: User::AUDITOR)
+      end
+    end
+
+    context "when technical operator tries to assign superadmin" do
+      it "returns forbidden" do
+        update_request(name: "Updated User", role: User::SUPERADMIN)
+
+        expect(response).to have_http_status(:forbidden)
+      end
+
+      it "does not update the user role" do
+        expect {
+          update_request(name: "Updated User", role: User::SUPERADMIN)
+        }.not_to change { target_user.reload.current_role }
       end
     end
 
@@ -296,7 +333,7 @@ RSpec.describe UsersController do
     describe "PATCH #update" do
       let(:make_request) do
         patch user_path(target_user),
-              params: { user: { role: User::HMRC_ADMIN } }
+              params: { user: { name: target_user.name, role: User::HMRC_ADMIN } }
       end
 
       it { is_expected.to redirect_to users_path }
@@ -306,6 +343,24 @@ RSpec.describe UsersController do
         target_user.reload
         expect(target_user.current_role).to eq(User::HMRC_ADMIN)
       end
+    end
+
+    describe "POST #create with superadmin role" do
+      let(:make_request) do
+        post users_path,
+             params: { user: new_user_params.merge(role: User::SUPERADMIN) }
+      end
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+
+    describe "PATCH #update when assigning superadmin" do
+      let(:make_request) do
+        patch user_path(target_user),
+              params: { user: { name: target_user.name, role: User::SUPERADMIN } }
+      end
+
+      it { is_expected.to have_http_status :forbidden }
     end
 
     describe "POST #create" do

--- a/spec/requests/users_controller_spec.rb
+++ b/spec/requests/users_controller_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe UsersController do
   end
 
   describe "GET #new" do
+    let(:current_user) { create(:user, :superadmin) }
     let(:make_request) { get new_user_path }
 
     it { is_expected.to have_http_status :success }
@@ -27,7 +28,7 @@ RSpec.describe UsersController do
     it "displays fields for name, email and role selection", :aggregate_failures do
       rendered_page
 
-      expect(response.body).to include("Name", "Email address", "radio", User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
+      expect(response.body).to include("Name", "Email address", "radio", User::SUPERADMIN, User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
     end
   end
 
@@ -38,7 +39,7 @@ RSpec.describe UsersController do
 
     it "displays fields for name and role selection", :aggregate_failures do
       rendered_page
-      expect(response.body).to include("Name", "radio", User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
+      expect(response.body).to include("Name", "radio", User::SUPERADMIN, User::GUEST, User::TECHNICAL_OPERATOR, User::HMRC_ADMIN, User::AUDITOR)
     end
 
     it "preselects the current role" do
@@ -48,6 +49,7 @@ RSpec.describe UsersController do
   end
 
   describe "POST #create" do
+    let(:current_user) { create(:user, :superadmin) }
     let(:make_request) do
       post users_path,
            params: { user: new_user_params }
@@ -204,6 +206,7 @@ RSpec.describe UsersController do
   end
 
   describe "DELETE #destroy" do
+    let(:current_user) { create(:user, :superadmin) }
     let(:make_request) { delete user_path(target_user) }
 
     it { is_expected.to redirect_to users_path }
@@ -245,8 +248,20 @@ RSpec.describe UsersController do
     it { is_expected.to have_http_status :forbidden }
   end
 
-  context "when non-technical operator tries to remove a user" do
+  context "when technical operator tries to add a user" do
+    let(:make_request) { get new_user_path }
+
+    it { is_expected.to have_http_status :forbidden }
+  end
+
+  context "when non-superadmin tries to remove a user" do
     let(:current_user) { create(:user, :hmrc_admin) }
+    let(:make_request) { delete user_path(target_user) }
+
+    it { is_expected.to have_http_status :forbidden }
+  end
+
+  context "when technical operator tries to remove a user" do
     let(:make_request) { delete user_path(target_user) }
 
     it { is_expected.to have_http_status :forbidden }

--- a/spec/support/shared_contexts/with_no_auth_synthetic_user.rb
+++ b/spec/support/shared_contexts/with_no_auth_synthetic_user.rb
@@ -1,0 +1,11 @@
+RSpec.shared_context "with no-auth synthetic user" do
+  let(:current_user) { User.basic_auth_user! }
+
+  before do
+    allow(TradeTariffAdmin).to receive_messages(
+      authenticate_with_passwordless?: false,
+      basic_session_authentication?: false,
+      no_authentication?: true,
+    )
+  end
+end


### PR DESCRIPTION
### Jira link

OTTIMP-463

### What?

Adds a `SUPERADMIN` role for the highest-risk admin portal actions while keeping `SUPERADMIN` inside the existing role model.

- `SUPERADMIN` inherits `TECHNICAL_OPERATOR` permissions via the shared role helper.
- Admin user create/delete is restricted to `SUPERADMIN`.
- Role assignment is ordered: users can assign their own role level or lower; only `SUPERADMIN` can assign `SUPERADMIN`.
- Technical operators can still view/update users, but cannot promote users to `SUPERADMIN` or change an existing superadmin's role.
- Configuration, tariff update mutations, and rollback creation are restricted to `SUPERADMIN`; technical operators and auditors keep read-only access where applicable.
- Basic/no-auth mode uses the synthetic `basic_auth_user`, which this PR now makes `SUPERADMIN` for local and basic-auth testing.

### Why?

The admin portal has high-risk actions that can change guided search behaviour or operational state. This PR keeps normal technical-operator access available for day-to-day work while separating destructive/admin-lifecycle permissions into a smaller superadmin role.

### Testing

Covered by model, policy, request, helper, and feature specs for the new role, role assignment rules, user-management split, and update/rollback/configuration access changes.
