### PR TITLE
BAU: Rename status UI and update score labels

### DIFF
--- a/app/models/goods_nomenclature_label.rb
+++ b/app/models/goods_nomenclature_label.rb
@@ -75,20 +75,20 @@ class GoodsNomenclatureLabel
 
   def score_label(value = description_score)
     return "No score" if value.nil?
-    return "Amazing" if value >= 0.85
-    return "Good" if value >= 0.5
-    return "Okay" if value >= 0.3
+    return "Very High" if value >= 0.85
+    return "High" if value >= 0.5
+    return "Medium" if value >= 0.3
 
-    "Bad"
+    "Low"
   end
 
   def score_tag_colour(value = description_score)
     return "grey" if value.nil?
-    return "blue" if value >= 0.85
-    return "green" if value >= 0.5
+    return "green" if value >= 0.85
+    return "blue" if value >= 0.5
     return "yellow" if value >= 0.3
 
-    "red"
+    "grey"
   end
 
   # Store goods_nomenclature_id for path building

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -93,20 +93,20 @@ class GoodsNomenclatureSelfText
 
   def score_label(value = combined_score)
     return "No score" if value.nil?
-    return "Amazing" if value >= 0.85
-    return "Good" if value >= 0.5
-    return "Okay" if value >= 0.3
+    return "Very High" if value >= 0.85
+    return "High" if value >= 0.5
+    return "Medium" if value >= 0.3
 
-    "Bad"
+    "Low"
   end
 
   def score_tag_colour(value = combined_score)
     return "grey" if value.nil?
-    return "blue" if value >= 0.85
-    return "green" if value >= 0.5
+    return "green" if value >= 0.85
+    return "blue" if value >= 0.5
     return "yellow" if value >= 0.3
 
-    "red"
+    "grey"
   end
 
   def formatted_generated_at

--- a/app/views/goods_nomenclature_self_texts/index.html.erb
+++ b/app/views/goods_nomenclature_self_texts/index.html.erb
@@ -39,7 +39,7 @@
       <div class="govuk-details__text">
         <p class="govuk-body">Self-texts are self-contained descriptions of what each commodity code covers. They go into the search index so traders can find the right code. Non-'Other' nodes get a mechanical description built from their ancestor chain. 'Other' nodes get an AI-generated description that replaces the bare 'Other' with what the code actually covers, using sibling and parent context.</p>
 
-        <h3 class="govuk-heading-s">Statuses</h3>
+        <h3 class="govuk-heading-s">Tags</h3>
         <ul class="govuk-list govuk-list--bullet">
           <li><strong>Needs review</strong> - an admin has flagged this self-text for review</li>
           <li><strong>Stale</strong> - the commodity's hierarchy has changed since the self-text was generated, so it may no longer be accurate</li>
@@ -55,8 +55,8 @@
           <li><strong>Amazing</strong> - score 0.85 or above</li>
         </ul>
 
-        <h3 class="govuk-heading-s">Score and status are independent</h3>
-        <p class="govuk-body">A self-text can have a high score but still need review. The score measures how closely the text matches the EU reference, while the review flag is set manually by admins to mark self-texts that need attention.</p>
+        <h3 class="govuk-heading-s">Score and tags are independent</h3>
+        <p class="govuk-body">A self-text can have a high score but still need review. The score measures how closely the text matches the EU reference, while the review tag is set manually by admins to mark self-texts that need attention.</p>
       </div>
     </details>
 
@@ -134,27 +134,27 @@
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Status</legend>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Tags</legend>
             <div class="govuk-radios govuk-radios--small">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="st-status-all" name="st_status" type="radio" value="" checked
-                       data-action="change->self-text-table#changeStatus" data-status="">
-                <label class="govuk-label govuk-radios__label" for="st-status-all">All</label>
+                <input class="govuk-radios__input" id="st-tags-all" name="st_tags" type="radio" value="" checked
+                       data-action="change->self-text-table#changeTags" data-status="">
+                <label class="govuk-label govuk-radios__label" for="st-tags-all">All</label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="st-status-needs-review" name="st_status" type="radio" value="needs_review"
-                       data-action="change->self-text-table#changeStatus" data-status="needs_review">
-                <label class="govuk-label govuk-radios__label" for="st-status-needs-review">Needs review</label>
+                <input class="govuk-radios__input" id="st-tags-needs-review" name="st_tags" type="radio" value="needs_review"
+                       data-action="change->self-text-table#changeTags" data-status="needs_review">
+                <label class="govuk-label govuk-radios__label" for="st-tags-needs-review">Needs review</label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="st-status-stale" name="st_status" type="radio" value="stale"
-                       data-action="change->self-text-table#changeStatus" data-status="stale">
-                <label class="govuk-label govuk-radios__label" for="st-status-stale">Stale</label>
+                <input class="govuk-radios__input" id="st-tags-stale" name="st_tags" type="radio" value="stale"
+                       data-action="change->self-text-table#changeTags" data-status="stale">
+                <label class="govuk-label govuk-radios__label" for="st-tags-stale">Stale</label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="st-status-edited" name="st_status" type="radio" value="manually_edited"
-                       data-action="change->self-text-table#changeStatus" data-status="manually_edited">
-                <label class="govuk-label govuk-radios__label" for="st-status-edited">Manually edited</label>
+                <input class="govuk-radios__input" id="st-tags-edited" name="st_tags" type="radio" value="manually_edited"
+                       data-action="change->self-text-table#changeTags" data-status="manually_edited">
+                <label class="govuk-label govuk-radios__label" for="st-tags-edited">Manually edited</label>
               </div>
             </div>
           </fieldset>
@@ -280,22 +280,22 @@
 
         <div class="govuk-form-group">
           <fieldset class="govuk-fieldset">
-            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Status</legend>
+            <legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Tags</legend>
             <div class="govuk-radios govuk-radios--small">
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="lb-status-all" name="lb_status" type="radio" value="" checked
-                       data-action="change->label-table#changeStatus" data-status="">
-                <label class="govuk-label govuk-radios__label" for="lb-status-all">All</label>
+                <input class="govuk-radios__input" id="lb-tags-all" name="lb_tags" type="radio" value="" checked
+                       data-action="change->label-table#changeTags" data-status="">
+                <label class="govuk-label govuk-radios__label" for="lb-tags-all">All</label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="lb-status-stale" name="lb_status" type="radio" value="stale"
-                       data-action="change->label-table#changeStatus" data-status="stale">
-                <label class="govuk-label govuk-radios__label" for="lb-status-stale">Stale</label>
+                <input class="govuk-radios__input" id="lb-tags-stale" name="lb_tags" type="radio" value="stale"
+                       data-action="change->label-table#changeTags" data-status="stale">
+                <label class="govuk-label govuk-radios__label" for="lb-tags-stale">Stale</label>
               </div>
               <div class="govuk-radios__item">
-                <input class="govuk-radios__input" id="lb-status-edited" name="lb_status" type="radio" value="manually_edited"
-                       data-action="change->label-table#changeStatus" data-status="manually_edited">
-                <label class="govuk-label govuk-radios__label" for="lb-status-edited">Manually edited</label>
+                <input class="govuk-radios__input" id="lb-tags-edited" name="lb_tags" type="radio" value="manually_edited"
+                       data-action="change->label-table#changeTags" data-status="manually_edited">
+                <label class="govuk-label govuk-radios__label" for="lb-tags-edited">Manually edited</label>
               </div>
             </div>
           </fieldset>

--- a/app/views/goods_nomenclature_self_texts/index.html.erb
+++ b/app/views/goods_nomenclature_self_texts/index.html.erb
@@ -49,10 +49,10 @@
         <h3 class="govuk-heading-s">Score categories</h3>
         <p class="govuk-body">The score is derived from similarity to the EU reference text and coherence checks. When both are available, they are averaged. A self-text with no score has not yet been compared against the EU reference.</p>
         <ul class="govuk-list govuk-list--bullet">
-          <li><strong>Bad</strong> - score below 0.3</li>
-          <li><strong>Okay</strong> - score 0.3 to 0.5</li>
-          <li><strong>Good</strong> - score 0.5 to 0.85</li>
-          <li><strong>Amazing</strong> - score 0.85 or above</li>
+          <li><strong>Low</strong> - score below 0.3</li>
+          <li><strong>Medium</strong> - score 0.3 to 0.5</li>
+          <li><strong>High</strong> - score 0.5 to 0.85</li>
+          <li><strong>Very High</strong> - score 0.85 or above</li>
         </ul>
 
         <h3 class="govuk-heading-s">Score and tags are independent</h3>
@@ -106,22 +106,22 @@
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="st-score-bad" name="st_score_category" type="radio" value="bad"
                        data-action="change->self-text-table#changeScoreCategory" data-score-category="bad">
-                <label class="govuk-label govuk-radios__label" for="st-score-bad">Bad</label>
+                <label class="govuk-label govuk-radios__label" for="st-score-bad">Low</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="st-score-okay" name="st_score_category" type="radio" value="okay"
                        data-action="change->self-text-table#changeScoreCategory" data-score-category="okay">
-                <label class="govuk-label govuk-radios__label" for="st-score-okay">Okay</label>
+                <label class="govuk-label govuk-radios__label" for="st-score-okay">Medium</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="st-score-good" name="st_score_category" type="radio" value="good"
                        data-action="change->self-text-table#changeScoreCategory" data-score-category="good">
-                <label class="govuk-label govuk-radios__label" for="st-score-good">Good</label>
+                <label class="govuk-label govuk-radios__label" for="st-score-good">High</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="st-score-amazing" name="st_score_category" type="radio" value="amazing"
                        data-action="change->self-text-table#changeScoreCategory" data-score-category="amazing">
-                <label class="govuk-label govuk-radios__label" for="st-score-amazing">Amazing</label>
+                <label class="govuk-label govuk-radios__label" for="st-score-amazing">Very High</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="st-score-none" name="st_score_category" type="radio" value="no_score"
@@ -252,22 +252,22 @@
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="lb-score-bad" name="lb_score_category" type="radio" value="bad"
                        data-action="change->label-table#changeScoreCategory" data-score-category="bad">
-                <label class="govuk-label govuk-radios__label" for="lb-score-bad">Bad</label>
+                <label class="govuk-label govuk-radios__label" for="lb-score-bad">Low</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="lb-score-okay" name="lb_score_category" type="radio" value="okay"
                        data-action="change->label-table#changeScoreCategory" data-score-category="okay">
-                <label class="govuk-label govuk-radios__label" for="lb-score-okay">Okay</label>
+                <label class="govuk-label govuk-radios__label" for="lb-score-okay">Medium</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="lb-score-good" name="lb_score_category" type="radio" value="good"
                        data-action="change->label-table#changeScoreCategory" data-score-category="good">
-                <label class="govuk-label govuk-radios__label" for="lb-score-good">Good</label>
+                <label class="govuk-label govuk-radios__label" for="lb-score-good">High</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="lb-score-amazing" name="lb_score_category" type="radio" value="amazing"
                        data-action="change->label-table#changeScoreCategory" data-score-category="amazing">
-                <label class="govuk-label govuk-radios__label" for="lb-score-amazing">Amazing</label>
+                <label class="govuk-label govuk-radios__label" for="lb-score-amazing">Very High</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="lb-score-none" name="lb_score_category" type="radio" value="no_score"

--- a/app/views/goods_nomenclature_self_texts/show.html.erb
+++ b/app/views/goods_nomenclature_self_texts/show.html.erb
@@ -81,7 +81,7 @@
     <% end %>
 
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Status</dt>
+      <dt class="govuk-summary-list__key">Tags</dt>
       <dd class="govuk-summary-list__value">
         <% if @self_text.needs_review %>
           <strong class="govuk-tag govuk-tag--orange">Needs review</strong>

--- a/app/webpacker/controllers/label_table_controller.js
+++ b/app/webpacker/controllers/label_table_controller.js
@@ -162,10 +162,10 @@ export default class extends Controller {
     }
 
     var label, colour;
-    if (score >= 0.85) { label = 'Amazing'; colour = 'blue'; }
-    else if (score >= 0.5) { label = 'Good'; colour = 'green'; }
-    else if (score >= 0.3) { label = 'Okay'; colour = 'yellow'; }
-    else { label = 'Bad'; colour = 'red'; }
+    if (score >= 0.85) { label = 'Very High'; colour = 'green'; }
+    else if (score >= 0.5) { label = 'High'; colour = 'blue'; }
+    else if (score >= 0.3) { label = 'Medium'; colour = 'yellow'; }
+    else { label = 'Low'; colour = 'grey'; }
 
     return {
       tag: '<strong class="govuk-tag govuk-tag--' + colour + '">' + label + '</strong>',

--- a/app/webpacker/controllers/label_table_controller.js
+++ b/app/webpacker/controllers/label_table_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
       sort: { type: String, default: 'score' },
       direction: { type: String, default: 'asc' },
       type: { type: String, default: 'commodity' },
-      status: { type: String, default: '' },
+      tags: { type: String, default: '' },
       scoreCategory: { type: String, default: '' },
       page: { type: Number, default: 1 },
       q: { type: String, default: '' },
@@ -37,8 +37,8 @@ export default class extends Controller {
     this.fetchData();
   }
 
-  changeStatus(event) {
-    this.statusValue = event.currentTarget.dataset.status;
+  changeTags(event) {
+    this.tagsValue = event.currentTarget.dataset.status;
     this.pageValue = 1;
     this.fetchData();
   }
@@ -83,8 +83,8 @@ export default class extends Controller {
       page: this.pageValue,
     });
 
-    if (this.statusValue) {
-      params.set('status', this.statusValue);
+    if (this.tagsValue) {
+      params.set('status', this.tagsValue);
     }
     if (this.scoreCategoryValue) {
       params.set('score_category', this.scoreCategoryValue);
@@ -136,7 +136,7 @@ export default class extends Controller {
       '<thead class="govuk-table__head"><tr class="govuk-table__row">' +
       '<th class="govuk-table__header label-table__code" scope="col">' + sortHeader('goods_nomenclature_item_id', 'Commodity code') + '</th>' +
       '<th class="govuk-table__header label-table__score" scope="col">' + sortHeader('score', 'Score') + '</th>' +
-      '<th class="govuk-table__header label-table__status" scope="col">Status</th>' +
+      '<th class="govuk-table__header label-table__tags" scope="col">Tags</th>' +
       '<th class="govuk-table__header label-table__description" scope="col">Description</th>' +
       '</tr></thead><tbody class="govuk-table__body">';
 
@@ -147,7 +147,7 @@ export default class extends Controller {
       html += '<tr class="govuk-table__row">' +
         '<td class="govuk-table__cell label-table__code"><a href="' + showUrl + '" class="govuk-link">' + self.escapeHtml(label.goods_nomenclature_item_id) + '</a></td>' +
         '<td class="govuk-table__cell label-table__score">' + sc.tag + '</td>' +
-        '<td class="govuk-table__cell label-table__status">' + self.statusTags(label) + '</td>' +
+        '<td class="govuk-table__cell label-table__tags">' + self.buildTags(label) + '</td>' +
         '<td class="govuk-table__cell label-table__description">' + self.escapeHtml(label.description || '') + '</td>' +
         '</tr>';
     });
@@ -173,7 +173,7 @@ export default class extends Controller {
     };
   }
 
-  statusTags(label) {
+  buildTags(label) {
     var tags = [];
 
     if (label.stale) {

--- a/app/webpacker/controllers/scored_tag_list_controller.js
+++ b/app/webpacker/controllers/scored_tag_list_controller.js
@@ -68,10 +68,10 @@ export default class extends Controller {
 
   tagColour(score) {
     if (score === null || score === undefined) return 'grey';
-    if (score >= 0.85) return 'blue';
-    if (score >= 0.5) return 'green';
+    if (score >= 0.85) return 'green';
+    if (score >= 0.5) return 'blue';
     if (score >= 0.3) return 'yellow';
-    return 'red';
+    return 'grey';
   }
 
   escapeHtml(text) {

--- a/app/webpacker/controllers/self_text_table_controller.js
+++ b/app/webpacker/controllers/self_text_table_controller.js
@@ -12,7 +12,7 @@ export default class extends Controller {
       sort: { type: String, default: 'score' },
       direction: { type: String, default: 'asc' },
       type: { type: String, default: 'commodity' },
-      status: { type: String, default: '' },
+      tags: { type: String, default: '' },
       scoreCategory: { type: String, default: '' },
       page: { type: Number, default: 1 },
       q: { type: String, default: '' },
@@ -29,8 +29,8 @@ export default class extends Controller {
     this.fetchData();
   }
 
-  changeStatus(event) {
-    this.statusValue = event.currentTarget.dataset.status;
+  changeTags(event) {
+    this.tagsValue = event.currentTarget.dataset.status;
     this.pageValue = 1;
     this.fetchData();
   }
@@ -75,8 +75,8 @@ export default class extends Controller {
       page: this.pageValue,
     });
 
-    if (this.statusValue) {
-      params.set('status', this.statusValue);
+    if (this.tagsValue) {
+      params.set('status', this.tagsValue);
     }
     if (this.scoreCategoryValue) {
       params.set('score_category', this.scoreCategoryValue);
@@ -128,7 +128,7 @@ export default class extends Controller {
       '<thead class="govuk-table__head"><tr class="govuk-table__row">' +
       '<th class="govuk-table__header self-text-table__code" scope="col">' + sortHeader('goods_nomenclature_item_id', 'Commodity code') + '</th>' +
       '<th class="govuk-table__header self-text-table__score" scope="col">' + sortHeader('score', 'Score') + '</th>' +
-      '<th class="govuk-table__header self-text-table__status" scope="col">Status</th>' +
+      '<th class="govuk-table__header self-text-table__tags" scope="col">Tags</th>' +
       '<th class="govuk-table__header self-text-table__description" scope="col">Self-text</th>' +
       '</tr></thead><tbody class="govuk-table__body">';
 
@@ -139,7 +139,7 @@ export default class extends Controller {
       html += '<tr class="govuk-table__row" data-score="' + (st.score !== null && st.score !== undefined ? st.score : '') + '" data-score-category="' + sc.category + '">' +
         '<td class="govuk-table__cell self-text-table__code"><a href="' + showUrl + '" class="govuk-link">' + self.escapeHtml(st.goods_nomenclature_item_id) + '</a></td>' +
         '<td class="govuk-table__cell self-text-table__score">' + sc.tag + '</td>' +
-        '<td class="govuk-table__cell self-text-table__status">' + self.statusTags(st) + '</td>' +
+        '<td class="govuk-table__cell self-text-table__tags">' + self.buildTags(st) + '</td>' +
         '<td class="govuk-table__cell self-text-table__description">' + self.escapeHtml(st.self_text || '') + '</td>' +
         '</tr>';
     });
@@ -165,7 +165,7 @@ export default class extends Controller {
     };
   }
 
-  statusTags(st) {
+  buildTags(st) {
     var tags = [];
 
     if (st.needs_review) {

--- a/app/webpacker/controllers/self_text_table_controller.js
+++ b/app/webpacker/controllers/self_text_table_controller.js
@@ -154,10 +154,10 @@ export default class extends Controller {
     }
 
     var label, colour;
-    if (score >= 0.85) { label = 'Amazing'; colour = 'blue'; }
-    else if (score >= 0.5) { label = 'Good'; colour = 'green'; }
-    else if (score >= 0.3) { label = 'Okay'; colour = 'yellow'; }
-    else { label = 'Bad'; colour = 'red'; }
+    if (score >= 0.85) { label = 'Very High'; colour = 'green'; }
+    else if (score >= 0.5) { label = 'High'; colour = 'blue'; }
+    else if (score >= 0.3) { label = 'Medium'; colour = 'yellow'; }
+    else { label = 'Low'; colour = 'grey'; }
 
     return {
       tag: '<strong class="govuk-tag govuk-tag--' + colour + '">' + label + '</strong>',

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -222,7 +222,7 @@ $govuk-image-url-function: frontend-image-url;
     width: 11%;
   }
 
-  &__status {
+  &__tags {
     width: 12%;
   }
 
@@ -248,7 +248,7 @@ $govuk-image-url-function: frontend-image-url;
     width: 11%;
   }
 
-  &__status {
+  &__tags {
     width: 12%;
   }
 

--- a/spec/models/goods_nomenclature_label_spec.rb
+++ b/spec/models/goods_nomenclature_label_spec.rb
@@ -116,28 +116,28 @@ RSpec.describe GoodsNomenclatureLabel do
   end
 
   describe "#score_label" do
-    it "returns Amazing for score >= 0.85" do
+    it "returns Very High for score >= 0.85" do
       record = described_class.new(description_score: 0.90)
 
-      expect(record.score_label).to eq("Amazing")
+      expect(record.score_label).to eq("Very High")
     end
 
-    it "returns Good for score >= 0.5" do
+    it "returns High for score >= 0.5" do
       record = described_class.new(description_score: 0.72)
 
-      expect(record.score_label).to eq("Good")
+      expect(record.score_label).to eq("High")
     end
 
-    it "returns Okay for score >= 0.3" do
+    it "returns Medium for score >= 0.3" do
       record = described_class.new(description_score: 0.35)
 
-      expect(record.score_label).to eq("Okay")
+      expect(record.score_label).to eq("Medium")
     end
 
-    it "returns Bad for score < 0.3" do
+    it "returns Low for score < 0.3" do
       record = described_class.new(description_score: 0.1)
 
-      expect(record.score_label).to eq("Bad")
+      expect(record.score_label).to eq("Low")
     end
 
     it "returns No score when nil" do
@@ -148,28 +148,28 @@ RSpec.describe GoodsNomenclatureLabel do
   end
 
   describe "#score_tag_colour" do
-    it "returns blue for Amazing scores" do
+    it "returns green for Very High scores" do
       record = described_class.new(description_score: 0.90)
-
-      expect(record.score_tag_colour).to eq("blue")
-    end
-
-    it "returns green for Good scores" do
-      record = described_class.new(description_score: 0.60)
 
       expect(record.score_tag_colour).to eq("green")
     end
 
-    it "returns yellow for Okay scores" do
+    it "returns blue for High scores" do
+      record = described_class.new(description_score: 0.60)
+
+      expect(record.score_tag_colour).to eq("blue")
+    end
+
+    it "returns yellow for Medium scores" do
       record = described_class.new(description_score: 0.35)
 
       expect(record.score_tag_colour).to eq("yellow")
     end
 
-    it "returns red for Bad scores" do
+    it "returns grey for Low scores" do
       record = described_class.new(description_score: 0.1)
 
-      expect(record.score_tag_colour).to eq("red")
+      expect(record.score_tag_colour).to eq("grey")
     end
 
     it "returns grey when nil" do

--- a/spec/models/goods_nomenclature_self_text_spec.rb
+++ b/spec/models/goods_nomenclature_self_text_spec.rb
@@ -79,29 +79,29 @@ RSpec.describe GoodsNomenclatureSelfText do
   end
 
   describe "#score_label" do
-    it "returns Amazing for combined score >= 0.85" do
+    it "returns Very High for combined score >= 0.85" do
       self_text.similarity_score = 0.90
       self_text.coherence_score = 0.90
 
-      expect(self_text.score_label).to eq("Amazing")
+      expect(self_text.score_label).to eq("Very High")
     end
 
-    it "returns Good for combined score >= 0.5" do
-      expect(self_text.score_label).to eq("Good")
+    it "returns High for combined score >= 0.5" do
+      expect(self_text.score_label).to eq("High")
     end
 
-    it "returns Okay for combined score >= 0.3" do
+    it "returns Medium for combined score >= 0.3" do
       self_text.similarity_score = 0.35
       self_text.coherence_score = 0.25
 
-      expect(self_text.score_label).to eq("Okay")
+      expect(self_text.score_label).to eq("Medium")
     end
 
-    it "returns Bad for combined score < 0.3" do
+    it "returns Low for combined score < 0.3" do
       self_text.similarity_score = 0.1
       self_text.coherence_score = 0.1
 
-      expect(self_text.score_label).to eq("Bad")
+      expect(self_text.score_label).to eq("Low")
     end
 
     it "returns No score when combined score is nil" do
@@ -113,15 +113,29 @@ RSpec.describe GoodsNomenclatureSelfText do
   end
 
   describe "#score_tag_colour" do
-    it "returns blue for Amazing" do
+    it "returns green for Very High" do
       self_text.similarity_score = 0.90
       self_text.coherence_score = 0.90
 
+      expect(self_text.score_tag_colour).to eq("green")
+    end
+
+    it "returns blue for High" do
       expect(self_text.score_tag_colour).to eq("blue")
     end
 
-    it "returns green for Good" do
-      expect(self_text.score_tag_colour).to eq("green")
+    it "returns yellow for Medium" do
+      self_text.similarity_score = 0.35
+      self_text.coherence_score = 0.25
+
+      expect(self_text.score_tag_colour).to eq("yellow")
+    end
+
+    it "returns grey for Low" do
+      self_text.similarity_score = 0.1
+      self_text.coherence_score = 0.1
+
+      expect(self_text.score_tag_colour).to eq("grey")
     end
 
     it "returns grey for no score" do

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -85,6 +85,28 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
         expect(rendered_page.body).to include('class="label-table-container" data-label-table-target="table"')
       end
 
+      it "labels self-text and label state filters as tags" do
+        expect(rendered_page.body).to include('<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Tags</legend>')
+        expect(rendered_page.body).to include('id="st-tags-stale"')
+        expect(rendered_page.body).to include('data-action="change->self-text-table#changeTags" data-status="stale"')
+        expect(rendered_page.body).to include('id="lb-tags-stale"')
+        expect(rendered_page.body).to include('data-action="change->label-table#changeTags" data-status="stale"')
+      end
+
+      it "uses tags terminology in the self-text table controller" do
+        controller = Rails.root.join("app/webpacker/controllers/self_text_table_controller.js").read
+
+        expect(controller).to include(%(scope="col">Tags</th>))
+        expect(controller).to include("params.set('status', this.tagsValue);")
+      end
+
+      it "uses tags terminology in the label table controller" do
+        controller = Rails.root.join("app/webpacker/controllers/label_table_controller.js").read
+
+        expect(controller).to include(%(scope="col">Tags</th>))
+        expect(controller).to include("params.set('status', this.tagsValue);")
+      end
+
       it "defines a fixed layout for the self-text table styles" do
         stylesheet = Rails.root.join("app/webpacker/packs/application.scss").read
 
@@ -225,6 +247,10 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
 
     it "displays the View labels cross-link when has_label is true" do
       expect(rendered_page.body).to include("View labels")
+    end
+
+    it "labels the state summary as tags" do
+      expect(rendered_page.body).to include(%(<dt class="govuk-summary-list__key">Tags</dt>))
     end
 
     context "when has_label is false" do

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -93,6 +93,13 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
         expect(rendered_page.body).to include('data-action="change->label-table#changeTags" data-status="stale"')
       end
 
+      it "uses the updated visible score labels while preserving backend filter values" do
+        expect(rendered_page.body).to include('for="st-score-bad">Low</label>')
+        expect(rendered_page.body).to include('for="st-score-amazing">Very High</label>')
+        expect(rendered_page.body).to include('for="lb-score-bad">Low</label>')
+        expect(rendered_page.body).to include('for="lb-score-amazing">Very High</label>')
+      end
+
       it "uses tags terminology in the self-text table controller" do
         controller = Rails.root.join("app/webpacker/controllers/self_text_table_controller.js").read
 
@@ -105,6 +112,20 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
 
         expect(controller).to include(%(scope="col">Tags</th>))
         expect(controller).to include("params.set('status', this.tagsValue);")
+      end
+
+      it "uses the updated score labels in the self-text table controller" do
+        controller = Rails.root.join("app/webpacker/controllers/self_text_table_controller.js").read
+
+        expect(controller).to include("label = 'Very High'; colour = 'green'")
+        expect(controller).to include("label = 'Low'; colour = 'grey'")
+      end
+
+      it "uses the updated score labels in the label table controller" do
+        controller = Rails.root.join("app/webpacker/controllers/label_table_controller.js").read
+
+        expect(controller).to include("label = 'Very High'; colour = 'green'")
+        expect(controller).to include("label = 'Low'; colour = 'grey'")
       end
 
       it "defines a fixed layout for the self-text table styles" do


### PR DESCRIPTION
### Jira link

BAU

### What?

- [x] Rename self-text status UI copy to tags
- [x] Rename label status UI copy to tags
- [x] Rename frontend table/controller internals from status to tags
- [x] Update score labels and colours across self-texts and labels
- [x] Keep backend-facing `status`, `score_category`, and existing API attributes unchanged
- [x] Add request and model coverage for the terminology changes

### Why?

The self-text and label screens show these values as badges, so `Tags` is clearer than `Status`. Score bands also need to use the new language: Low, Medium, High and Very High. The backend still exposes the existing category and status values, so this keeps the API contract stable while making the admin UI wording consistent.