### PR TITLE
AI-624: Add generated content lifecycle admin controls

### DIFF
--- a/app/controllers/goods_nomenclature_labels_controller.rb
+++ b/app/controllers/goods_nomenclature_labels_controller.rb
@@ -1,4 +1,6 @@
 class GoodsNomenclatureLabelsController < AuthenticatedController
+  before_action :load_label, only: %i[score regenerate approve reject]
+
   def index
     authorize GoodsNomenclatureLabel, :index?
 
@@ -53,7 +55,62 @@ class GoodsNomenclatureLabelsController < AuthenticatedController
     redirect_to goods_nomenclature_labels_path, alert: "Label not found for commodity code #{goods_nomenclature_id}."
   end
 
+  def score
+    authorize GoodsNomenclatureLabel, :update?
+
+    @goods_nomenclature_label.generate_score
+
+    redirect_to goods_nomenclature_label_path(goods_nomenclature_id),
+                notice: "Label score generated successfully."
+  rescue Faraday::Error => e
+    Rails.logger.error("Failed to generate label score for #{goods_nomenclature_id}: #{e.class} #{e.message}")
+    redirect_to goods_nomenclature_label_path(goods_nomenclature_id),
+                alert: "Failed to generate label score: #{e.message.truncate(200)}"
+  end
+
+  def regenerate
+    authorize GoodsNomenclatureLabel, :update?
+
+    @goods_nomenclature_label.regenerate
+
+    redirect_to goods_nomenclature_label_path(goods_nomenclature_id),
+                notice: "Label regenerated successfully."
+  rescue Faraday::Error
+    redirect_to goods_nomenclature_label_path(goods_nomenclature_id),
+                alert: "Failed to regenerate label."
+  end
+
+  def approve
+    authorize GoodsNomenclatureLabel, :update?
+
+    @goods_nomenclature_label.approve
+
+    redirect_to goods_nomenclature_label_path(goods_nomenclature_id),
+                notice: "Label approved."
+  rescue Faraday::Error
+    redirect_to goods_nomenclature_label_path(goods_nomenclature_id),
+                alert: "Failed to approve label."
+  end
+
+  def reject
+    authorize GoodsNomenclatureLabel, :update?
+
+    @goods_nomenclature_label.reject
+
+    redirect_to goods_nomenclature_label_path(goods_nomenclature_id),
+                notice: "Label marked for review."
+  rescue Faraday::Error
+    redirect_to goods_nomenclature_label_path(goods_nomenclature_id),
+                alert: "Failed to reject label."
+  end
+
 private
+
+  def load_label
+    @goods_nomenclature_label = find_label(skip_oid: true)
+  rescue Faraday::ResourceNotFound
+    redirect_to goods_nomenclature_labels_path, alert: "Label not found for commodity code #{goods_nomenclature_id}."
+  end
 
   def find_label(skip_oid: false)
     opts = {}

--- a/app/models/concerns/record_date_formatting.rb
+++ b/app/models/concerns/record_date_formatting.rb
@@ -1,0 +1,20 @@
+module RecordDateFormatting
+  def formatted_created_at
+    formatted_record_date(created_at)
+  end
+
+  def formatted_updated_at
+    formatted_record_date(updated_at)
+  end
+
+private
+
+  def formatted_record_date(value)
+    return "-" if value.blank?
+
+    date = Date.parse(value.to_s)
+    date == Date.current ? "Today" : date.to_formatted_s(:govuk)
+  rescue ArgumentError
+    value.to_s
+  end
+end

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -1,5 +1,6 @@
 class DescriptionIntercept
   include ApiEntity
+  include RecordDateFormatting
 
   GUIDANCE_LEVELS = %w[info warning error].freeze
   GUIDANCE_LOCATIONS = %w[interstitial results question].freeze
@@ -74,15 +75,6 @@ class DescriptionIntercept
 
   def filtering?
     filter_prefixes.present?
-  end
-
-  def formatted_created_at
-    return "-" if created_at.blank?
-
-    date = Date.parse(created_at.to_s)
-    date == Date.current ? "Today" : date.to_formatted_s(:govuk)
-  rescue ArgumentError
-    created_at.to_s
   end
 
   def behaviour_summary

--- a/app/models/goods_nomenclature_label.rb
+++ b/app/models/goods_nomenclature_label.rb
@@ -1,5 +1,6 @@
 class GoodsNomenclatureLabel
   include ApiEntity
+  include RecordDateFormatting
 
   set_singular_path "admin/goods_nomenclatures/:goods_nomenclature_id/goods_nomenclature_label"
 
@@ -17,7 +18,12 @@ class GoodsNomenclatureLabel
              :score,
              :nomenclature_type,
              :original_description,
-             :has_self_text
+             :has_self_text,
+             :needs_review,
+             :approved,
+             :expired,
+             :created_at,
+             :updated_at
 
   # Label field accessors - fall back to labels JSONB for singular (show) responses
   def original_description
@@ -123,10 +129,29 @@ class GoodsNomenclatureLabel
       goods_nomenclature_sid: goods_nomenclature_sid,
       goods_nomenclature_item_id: goods_nomenclature_item_id,
       score: score,
+      needs_review: needs_review,
       stale: stale,
       manually_edited: manually_edited,
+      approved: approved,
+      expired: expired,
       description: original_description.to_s.truncate(80),
     }
+  end
+
+  def generate_score
+    api.post("admin/goods_nomenclatures/#{to_param}/goods_nomenclature_label/score")
+  end
+
+  def regenerate
+    api.post("admin/goods_nomenclatures/#{to_param}/goods_nomenclature_label/regenerate")
+  end
+
+  def approve
+    api.post("admin/goods_nomenclatures/#{to_param}/goods_nomenclature_label/approve")
+  end
+
+  def reject
+    api.post("admin/goods_nomenclatures/#{to_param}/goods_nomenclature_label/reject")
   end
 
   def self.text_to_array(text)

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -16,7 +16,6 @@ class GoodsNomenclatureSelfText
              :expired,
              :created_at,
              :updated_at,
-             :generated_at,
              :eu_self_text,
              :similarity_score,
              :coherence_score,

--- a/app/models/goods_nomenclature_self_text.rb
+++ b/app/models/goods_nomenclature_self_text.rb
@@ -1,5 +1,6 @@
 class GoodsNomenclatureSelfText
   include ApiEntity
+  include RecordDateFormatting
 
   set_singular_path "admin/goods_nomenclatures/:goods_nomenclature_id/goods_nomenclature_self_text"
 
@@ -11,6 +12,10 @@ class GoodsNomenclatureSelfText
              :needs_review,
              :manually_edited,
              :stale,
+             :approved,
+             :expired,
+             :created_at,
+             :updated_at,
              :generated_at,
              :eu_self_text,
              :similarity_score,
@@ -49,6 +54,8 @@ class GoodsNomenclatureSelfText
       needs_review: needs_review,
       stale: stale,
       manually_edited: manually_edited,
+      approved: approved,
+      expired: expired,
       self_text: self_text.to_s.truncate(80),
     }
   end
@@ -107,15 +114,6 @@ class GoodsNomenclatureSelfText
     return "yellow" if value >= 0.3
 
     "grey"
-  end
-
-  def formatted_generated_at
-    return "-" if generated_at.blank?
-
-    date = Date.parse(generated_at.to_s)
-    date == Date.current ? "Today" : date.to_formatted_s(:govuk)
-  rescue ArgumentError
-    generated_at.to_s
   end
 
   def ancestor_chain

--- a/app/views/goods_nomenclature_labels/show.html.erb
+++ b/app/views/goods_nomenclature_labels/show.html.erb
@@ -9,6 +9,34 @@
   Commodity Label <%= @goods_nomenclature_label.goods_nomenclature_item_id %>
 </h1>
 
+<% if @goods_nomenclature_label.current? && policy(@goods_nomenclature_label).update? %>
+  <div class="govuk-button-group govuk-!-margin-bottom-6">
+    <% if @goods_nomenclature_label.needs_review %>
+      <%= button_to "Approve",
+                    approve_goods_nomenclature_label_path(@goods_nomenclature_label.goods_nomenclature_item_id),
+                    method: :post,
+                    class: "govuk-button",
+                    data: { module: "govuk-button" } %>
+    <% else %>
+      <%= button_to "Needs review",
+                    reject_goods_nomenclature_label_path(@goods_nomenclature_label.goods_nomenclature_item_id),
+                    method: :post,
+                    class: "govuk-button govuk-button--secondary",
+                    data: { module: "govuk-button" } %>
+    <% end %>
+    <%= button_to "Generate score",
+                  score_goods_nomenclature_label_path(@goods_nomenclature_label.goods_nomenclature_item_id),
+                  method: :post,
+                  class: "govuk-button govuk-button--secondary",
+                  data: { module: "govuk-button" } %>
+    <%= button_to "Regenerate label",
+                  regenerate_goods_nomenclature_label_path(@goods_nomenclature_label.goods_nomenclature_item_id),
+                  method: :post,
+                  class: "govuk-button govuk-button--warning",
+                  data: { module: "govuk-button", confirm: "This will regenerate the labels using the AI model. The current labels will be overwritten. Continue?" } %>
+  </div>
+<% end %>
+
 <%= form_with model: @goods_nomenclature_label,
               url: goods_nomenclature_label_path(@goods_nomenclature_label.goods_nomenclature_item_id),
               method: :patch,
@@ -41,8 +69,40 @@
     </div>
 
     <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Record dates</dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body govuk-!-margin-bottom-1">Created: <%= @goods_nomenclature_label.formatted_created_at %></p>
+        <p class="govuk-body govuk-!-margin-bottom-0">Updated: <%= @goods_nomenclature_label.formatted_updated_at %></p>
+      </dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Input description</dt>
       <dd class="govuk-summary-list__value"><%= @goods_nomenclature_label.original_description || "-" %></dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Tags</dt>
+      <dd class="govuk-summary-list__value">
+        <% if @goods_nomenclature_label.needs_review %>
+          <strong class="govuk-tag govuk-tag--orange">Needs review</strong>
+        <% end %>
+        <% if @goods_nomenclature_label.manually_edited %>
+          <strong class="govuk-tag govuk-tag--purple">Manually edited</strong>
+        <% end %>
+        <% if @goods_nomenclature_label.stale %>
+          <strong class="govuk-tag govuk-tag--pink">Stale</strong>
+        <% end %>
+        <% if @goods_nomenclature_label.approved %>
+          <strong class="govuk-tag govuk-tag--green">Approved</strong>
+        <% end %>
+        <% if @goods_nomenclature_label.expired %>
+          <strong class="govuk-tag govuk-tag--grey">Expired</strong>
+        <% end %>
+        <% unless @goods_nomenclature_label.needs_review || @goods_nomenclature_label.manually_edited || @goods_nomenclature_label.stale || @goods_nomenclature_label.approved || @goods_nomenclature_label.expired %>
+          <strong class="govuk-tag govuk-tag--turquoise">Active</strong>
+        <% end %>
+      </dd>
     </div>
 
     <% if @goods_nomenclature_label.has_self_text %>

--- a/app/views/goods_nomenclature_labels/show.html.erb
+++ b/app/views/goods_nomenclature_labels/show.html.erb
@@ -69,11 +69,13 @@
     </div>
 
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Record dates</dt>
-      <dd class="govuk-summary-list__value">
-        <p class="govuk-body govuk-!-margin-bottom-1">Created: <%= @goods_nomenclature_label.formatted_created_at %></p>
-        <p class="govuk-body govuk-!-margin-bottom-0">Updated: <%= @goods_nomenclature_label.formatted_updated_at %></p>
-      </dd>
+      <dt class="govuk-summary-list__key">Created</dt>
+      <dd class="govuk-summary-list__value"><%= @goods_nomenclature_label.formatted_created_at %></dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Last updated</dt>
+      <dd class="govuk-summary-list__value"><%= @goods_nomenclature_label.formatted_updated_at %></dd>
     </div>
 
     <div class="govuk-summary-list__row">

--- a/app/views/goods_nomenclature_self_texts/show.html.erb
+++ b/app/views/goods_nomenclature_self_texts/show.html.erb
@@ -69,11 +69,13 @@
     </div>
 
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Record dates</dt>
-      <dd class="govuk-summary-list__value">
-        <p class="govuk-body govuk-!-margin-bottom-1">Created: <%= @self_text.formatted_created_at %></p>
-        <p class="govuk-body govuk-!-margin-bottom-0">Updated: <%= @self_text.formatted_updated_at %></p>
-      </dd>
+      <dt class="govuk-summary-list__key">Created</dt>
+      <dd class="govuk-summary-list__value"><%= @self_text.formatted_created_at %></dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Last updated</dt>
+      <dd class="govuk-summary-list__value"><%= @self_text.formatted_updated_at %></dd>
     </div>
 
     <% if @self_text.kind.present? %>

--- a/app/views/goods_nomenclature_self_texts/show.html.erb
+++ b/app/views/goods_nomenclature_self_texts/show.html.erb
@@ -69,8 +69,11 @@
     </div>
 
     <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Generated at</dt>
-      <dd class="govuk-summary-list__value"><%= @self_text.formatted_generated_at %></dd>
+      <dt class="govuk-summary-list__key">Record dates</dt>
+      <dd class="govuk-summary-list__value">
+        <p class="govuk-body govuk-!-margin-bottom-1">Created: <%= @self_text.formatted_created_at %></p>
+        <p class="govuk-body govuk-!-margin-bottom-0">Updated: <%= @self_text.formatted_updated_at %></p>
+      </dd>
     </div>
 
     <% if @self_text.kind.present? %>
@@ -92,7 +95,13 @@
         <% if @self_text.stale %>
           <strong class="govuk-tag govuk-tag--pink">Stale</strong>
         <% end %>
-        <% unless @self_text.needs_review || @self_text.manually_edited || @self_text.stale %>
+        <% if @self_text.approved %>
+          <strong class="govuk-tag govuk-tag--green">Approved</strong>
+        <% end %>
+        <% if @self_text.expired %>
+          <strong class="govuk-tag govuk-tag--grey">Expired</strong>
+        <% end %>
+        <% unless @self_text.needs_review || @self_text.manually_edited || @self_text.stale || @self_text.approved || @self_text.expired %>
           <strong class="govuk-tag govuk-tag--turquoise">Active</strong>
         <% end %>
       </dd>

--- a/app/webpacker/controllers/label_table_controller.js
+++ b/app/webpacker/controllers/label_table_controller.js
@@ -176,11 +176,20 @@ export default class extends Controller {
   buildTags(label) {
     var tags = [];
 
+    if (label.needs_review) {
+      tags.push('<strong class="govuk-tag govuk-tag--orange">Needs review</strong>');
+    }
     if (label.stale) {
       tags.push('<strong class="govuk-tag govuk-tag--pink">Stale</strong>');
     }
     if (label.manually_edited) {
       tags.push('<strong class="govuk-tag govuk-tag--purple">Edited</strong>');
+    }
+    if (label.approved) {
+      tags.push('<strong class="govuk-tag govuk-tag--green">Approved</strong>');
+    }
+    if (label.expired) {
+      tags.push('<strong class="govuk-tag govuk-tag--grey">Expired</strong>');
     }
 
     return tags.length > 0 ? tags.join(' ') : '<strong class="govuk-tag govuk-tag--turquoise">Active</strong>';

--- a/app/webpacker/controllers/self_text_table_controller.js
+++ b/app/webpacker/controllers/self_text_table_controller.js
@@ -177,6 +177,12 @@ export default class extends Controller {
     if (st.manually_edited) {
       tags.push('<strong class="govuk-tag govuk-tag--purple">Edited</strong>');
     }
+    if (st.approved) {
+      tags.push('<strong class="govuk-tag govuk-tag--green">Approved</strong>');
+    }
+    if (st.expired) {
+      tags.push('<strong class="govuk-tag govuk-tag--grey">Expired</strong>');
+    }
 
     return tags.length > 0 ? tags.join(' ') : '<strong class="govuk-tag govuk-tag--turquoise">Active</strong>';
   }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,26 @@ Rails.application.routes.draw do
         to: "goods_nomenclature_labels#update",
         constraints: { goods_nomenclature_id: /\d+/ }
 
+  post "goods_nomenclature_labels/:goods_nomenclature_id/score",
+       to: "goods_nomenclature_labels#score",
+       as: :score_goods_nomenclature_label,
+       constraints: { goods_nomenclature_id: /\d+/ }
+
+  post "goods_nomenclature_labels/:goods_nomenclature_id/regenerate",
+       to: "goods_nomenclature_labels#regenerate",
+       as: :regenerate_goods_nomenclature_label,
+       constraints: { goods_nomenclature_id: /\d+/ }
+
+  post "goods_nomenclature_labels/:goods_nomenclature_id/approve",
+       to: "goods_nomenclature_labels#approve",
+       as: :approve_goods_nomenclature_label,
+       constraints: { goods_nomenclature_id: /\d+/ }
+
+  post "goods_nomenclature_labels/:goods_nomenclature_id/reject",
+       to: "goods_nomenclature_labels#reject",
+       as: :reject_goods_nomenclature_label,
+       constraints: { goods_nomenclature_id: /\d+/ }
+
   resources :goods_nomenclature_self_texts, only: %i[index] do
     collection do
       get :search

--- a/spec/models/goods_nomenclature_label_spec.rb
+++ b/spec/models/goods_nomenclature_label_spec.rb
@@ -9,7 +9,12 @@ RSpec.describe GoodsNomenclatureLabel do
       producline_suffix: "80",
       stale: false,
       manually_edited: false,
+      needs_review: false,
+      approved: false,
+      expired: false,
       context_hash: "abc123",
+      created_at: "2025-06-15T10:00:00Z",
+      updated_at: "#{Time.zone.today.iso8601}T10:00:00Z",
       labels: {
         "original_description" => "Live horses",
         "description" => "Horses (live)",
@@ -179,6 +184,22 @@ RSpec.describe GoodsNomenclatureLabel do
     end
   end
 
+  describe "record date formatting" do
+    it "formats created_at" do
+      expect(label.formatted_created_at).to eq("15 June 2025")
+    end
+
+    it "returns Today when updated_at is today" do
+      expect(label.formatted_updated_at).to eq("Today")
+    end
+
+    it "returns dash when a date is blank" do
+      label.updated_at = nil
+
+      expect(label.formatted_updated_at).to eq("-")
+    end
+  end
+
   describe "#to_param" do
     it "returns goods_nomenclature_id when set" do
       label.goods_nomenclature_id = "0101210000"
@@ -188,6 +209,62 @@ RSpec.describe GoodsNomenclatureLabel do
 
     it "falls back to goods_nomenclature_item_id" do
       expect(label.to_param).to eq("0101210000")
+    end
+  end
+
+  describe "#as_listing_json" do
+    it "includes lifecycle tag fields" do
+      record = described_class.new(attributes.merge(lifecycle_tag_attributes))
+
+      expect(record.as_listing_json).to include(lifecycle_tag_attributes)
+    end
+  end
+
+  def lifecycle_tag_attributes
+    { needs_review: true, manually_edited: true, stale: true, approved: true, expired: true }
+  end
+
+  describe "#generate_score" do
+    it "posts to the label score endpoint" do
+      stub_api_request("/goods_nomenclatures/0101210000/goods_nomenclature_label/score", :post)
+        .and_return(status: 200, body: {}.to_json)
+
+      label.generate_score
+
+      expect(WebMock).to have_requested(:post, /goods_nomenclatures\/0101210000\/goods_nomenclature_label\/score/)
+    end
+  end
+
+  describe "#regenerate" do
+    it "posts to the label regenerate endpoint" do
+      stub_api_request("/goods_nomenclatures/0101210000/goods_nomenclature_label/regenerate", :post)
+        .and_return(status: 200, body: {}.to_json)
+
+      label.regenerate
+
+      expect(WebMock).to have_requested(:post, /goods_nomenclatures\/0101210000\/goods_nomenclature_label\/regenerate/)
+    end
+  end
+
+  describe "#approve" do
+    it "posts to the label approve endpoint" do
+      stub_api_request("/goods_nomenclatures/0101210000/goods_nomenclature_label/approve", :post)
+        .and_return(status: 200, body: {}.to_json)
+
+      label.approve
+
+      expect(WebMock).to have_requested(:post, /goods_nomenclatures\/0101210000\/goods_nomenclature_label\/approve/)
+    end
+  end
+
+  describe "#reject" do
+    it "posts to the label reject endpoint" do
+      stub_api_request("/goods_nomenclatures/0101210000/goods_nomenclature_label/reject", :post)
+        .and_return(status: 200, body: {}.to_json)
+
+      label.reject
+
+      expect(WebMock).to have_requested(:post, /goods_nomenclatures\/0101210000\/goods_nomenclature_label\/reject/)
     end
   end
 end

--- a/spec/models/goods_nomenclature_self_text_spec.rb
+++ b/spec/models/goods_nomenclature_self_text_spec.rb
@@ -23,13 +23,18 @@ RSpec.describe GoodsNomenclatureSelfText do
       expired: false,
       created_at: "2025-06-15T10:00:00Z",
       updated_at: "#{Time.zone.today.iso8601}T10:00:00Z",
-      generated_at: "2025-06-15T10:00:00Z",
       eu_self_text: "Horses, live, for breeding",
       similarity_score: 0.72,
       coherence_score: 0.68,
       nomenclature_type: "commodity",
       score: 0.70,
     }
+  end
+
+  describe "attributes" do
+    it "does not expose generated_at separately from created_at" do
+      expect(self_text).not_to respond_to(:generated_at)
+    end
   end
 
   describe "#combined_score" do

--- a/spec/models/goods_nomenclature_self_text_spec.rb
+++ b/spec/models/goods_nomenclature_self_text_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe GoodsNomenclatureSelfText do
       needs_review: false,
       manually_edited: false,
       stale: false,
+      approved: false,
+      expired: false,
+      created_at: "2025-06-15T10:00:00Z",
+      updated_at: "#{Time.zone.today.iso8601}T10:00:00Z",
       generated_at: "2025-06-15T10:00:00Z",
       eu_self_text: "Horses, live, for breeding",
       similarity_score: 0.72,
@@ -146,17 +150,19 @@ RSpec.describe GoodsNomenclatureSelfText do
     end
   end
 
-  describe "#formatted_generated_at" do
-    it "returns the formatted date" do
-      self_text.generated_at = "2025-06-15T10:00:00Z"
-
-      expect(self_text.formatted_generated_at).not_to eq("-")
+  describe "record date formatting" do
+    it "formats created_at" do
+      expect(self_text.formatted_created_at).to eq("15 June 2025")
     end
 
-    it "returns dash when generated_at is blank" do
-      self_text.generated_at = nil
+    it "returns Today when updated_at is today" do
+      expect(self_text.formatted_updated_at).to eq("Today")
+    end
 
-      expect(self_text.formatted_generated_at).to eq("-")
+    it "returns dash when a date is blank" do
+      self_text.created_at = nil
+
+      expect(self_text.formatted_created_at).to eq("-")
     end
   end
 
@@ -224,6 +230,18 @@ RSpec.describe GoodsNomenclatureSelfText do
 
       expect(record.to_param).to eq("99999")
     end
+  end
+
+  describe "#as_listing_json" do
+    it "includes lifecycle tag fields" do
+      record = described_class.new(attributes.merge(lifecycle_tag_attributes))
+
+      expect(record.as_listing_json).to include(lifecycle_tag_attributes)
+    end
+  end
+
+  def lifecycle_tag_attributes
+    { needs_review: true, manually_edited: true, stale: true, approved: true, expired: true }
   end
 
   describe ".find" do

--- a/spec/requests/goods_nomenclature_labels_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_labels_controller_spec.rb
@@ -176,9 +176,10 @@ RSpec.describe GoodsNomenclatureLabelsController, type: :request do
     # rubocop:enable RSpec/MultipleExpectations
 
     it "displays the record dates" do # rubocop:disable RSpec/MultipleExpectations
-      expect(rendered_page.body).to include("Record dates")
-      expect(rendered_page.body).to include("Created: 15 June 2025")
-      expect(rendered_page.body).to include("Updated: Today")
+      expect(rendered_page.body).to include("Created", "15 June 2025", "Last updated", "Today")
+      expect(rendered_page.body).not_to include("Record dates")
+      expect(rendered_page.body).not_to include("Created:")
+      expect(rendered_page.body).not_to include("Updated:")
     end
 
     it "displays the View self-text cross-link when has_self_text is true" do

--- a/spec/requests/goods_nomenclature_labels_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_labels_controller_spec.rb
@@ -13,7 +13,12 @@ RSpec.describe GoodsNomenclatureLabelsController, type: :request do
       "producline_suffix" => "80",
       "stale" => false,
       "manually_edited" => false,
+      "needs_review" => false,
+      "approved" => false,
+      "expired" => false,
       "context_hash" => "abc123",
+      "created_at" => "2025-06-15T10:00:00Z",
+      "updated_at" => "#{Time.zone.today.iso8601}T10:00:00Z",
       "labels" => {
         "original_description" => "Live horses",
         "description" => "Horses (live)",
@@ -170,8 +175,48 @@ RSpec.describe GoodsNomenclatureLabelsController, type: :request do
     end
     # rubocop:enable RSpec/MultipleExpectations
 
+    it "displays the record dates" do # rubocop:disable RSpec/MultipleExpectations
+      expect(rendered_page.body).to include("Record dates")
+      expect(rendered_page.body).to include("Created: 15 June 2025")
+      expect(rendered_page.body).to include("Updated: Today")
+    end
+
     it "displays the View self-text cross-link when has_self_text is true" do
       expect(rendered_page.body).to include("View self-text")
+    end
+
+    it "displays the lifecycle action buttons" do # rubocop:disable RSpec/MultipleExpectations
+      expect(rendered_page.body).to include("Needs review")
+      expect(rendered_page.body).to include("Generate score")
+      expect(rendered_page.body).to include("Regenerate label")
+    end
+
+    context "when the label needs review" do
+      let(:label_attributes) { super().merge("needs_review" => true) }
+
+      it "displays the approve action" do
+        expect(rendered_page.body).to include("Approve")
+      end
+    end
+
+    context "when the label has lifecycle tags" do
+      let(:label_attributes) do
+        super().merge(
+          "needs_review" => true,
+          "manually_edited" => true,
+          "stale" => true,
+          "approved" => true,
+          "expired" => true,
+        )
+      end
+
+      it "displays all lifecycle tags" do # rubocop:disable RSpec/MultipleExpectations
+        expect(rendered_page.body).to include("Needs review")
+        expect(rendered_page.body).to include("Manually edited")
+        expect(rendered_page.body).to include("Stale")
+        expect(rendered_page.body).to include("Approved")
+        expect(rendered_page.body).to include("Expired")
+      end
     end
 
     context "when has_self_text is false" do
@@ -215,6 +260,11 @@ RSpec.describe GoodsNomenclatureLabelsController, type: :request do
       it "does not display the save button" do
         expect(rendered_page.body).not_to include("Save changes")
       end
+
+      it "hides the action buttons" do # rubocop:disable RSpec/MultipleExpectations
+        expect(rendered_page.body).not_to include("Generate score")
+        expect(rendered_page.body).not_to include("Regenerate label")
+      end
     end
 
     context "when label not found" do
@@ -228,6 +278,154 @@ RSpec.describe GoodsNomenclatureLabelsController, type: :request do
       it "shows an error message" do
         rendered_page
         expect(session.dig("flash", "flashes", "alert")).to include("Label not found")
+      end
+    end
+  end
+
+  describe "POST #score" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label", backend: "uk")
+        .and_return(label_response)
+    end
+
+    let(:make_request) { post score_goods_nomenclature_label_path(commodity_code) }
+
+    context "when successful" do
+      before do
+        stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label/score", :post, backend: "uk")
+          .and_return(status: 200, body: {}.to_json)
+      end
+
+      it { is_expected.to redirect_to(goods_nomenclature_label_path(commodity_code)) }
+
+      it "shows a success message" do
+        rendered_page
+        expect(session.dig("flash", "flashes", "notice")).to eq("Label score generated successfully.")
+      end
+    end
+
+    context "when API fails" do
+      before do
+        stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label/score", :post, backend: "uk")
+          .and_return(status: 500, body: { error: "Server error" }.to_json)
+      end
+
+      it { is_expected.to redirect_to(goods_nomenclature_label_path(commodity_code)) }
+
+      it "shows an error message" do
+        rendered_page
+        expect(session.dig("flash", "flashes", "alert")).to include("Failed to generate label score")
+      end
+    end
+  end
+
+  describe "POST #regenerate" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label", backend: "uk")
+        .and_return(label_response)
+    end
+
+    let(:make_request) { post regenerate_goods_nomenclature_label_path(commodity_code) }
+
+    context "when successful" do
+      before do
+        stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label/regenerate", :post, backend: "uk")
+          .and_return(status: 200, body: {}.to_json)
+      end
+
+      it { is_expected.to redirect_to(goods_nomenclature_label_path(commodity_code)) }
+
+      it "shows a success message" do
+        rendered_page
+        expect(session.dig("flash", "flashes", "notice")).to eq("Label regenerated successfully.")
+      end
+    end
+
+    context "when API fails" do
+      before do
+        stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label/regenerate", :post, backend: "uk")
+          .and_return(status: 500, body: { error: "Server error" }.to_json)
+      end
+
+      it { is_expected.to redirect_to(goods_nomenclature_label_path(commodity_code)) }
+
+      it "shows an error message" do
+        rendered_page
+        expect(session.dig("flash", "flashes", "alert")).to eq("Failed to regenerate label.")
+      end
+    end
+  end
+
+  describe "POST #approve" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label", backend: "uk")
+        .and_return(label_response)
+    end
+
+    let(:make_request) { post approve_goods_nomenclature_label_path(commodity_code) }
+
+    context "when successful" do
+      before do
+        stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label/approve", :post, backend: "uk")
+          .and_return(status: 200, body: {}.to_json)
+      end
+
+      it { is_expected.to redirect_to(goods_nomenclature_label_path(commodity_code)) }
+
+      it "shows a success message" do
+        rendered_page
+        expect(session.dig("flash", "flashes", "notice")).to eq("Label approved.")
+      end
+    end
+
+    context "when API fails" do
+      before do
+        stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label/approve", :post, backend: "uk")
+          .and_return(status: 500, body: { error: "Server error" }.to_json)
+      end
+
+      it { is_expected.to redirect_to(goods_nomenclature_label_path(commodity_code)) }
+
+      it "shows an error message" do
+        rendered_page
+        expect(session.dig("flash", "flashes", "alert")).to eq("Failed to approve label.")
+      end
+    end
+  end
+
+  describe "POST #reject" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label", backend: "uk")
+        .and_return(label_response)
+    end
+
+    let(:make_request) { post reject_goods_nomenclature_label_path(commodity_code) }
+
+    context "when successful" do
+      before do
+        stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label/reject", :post, backend: "uk")
+          .and_return(status: 200, body: {}.to_json)
+      end
+
+      it { is_expected.to redirect_to(goods_nomenclature_label_path(commodity_code)) }
+
+      it "shows a success message" do
+        rendered_page
+        expect(session.dig("flash", "flashes", "notice")).to eq("Label marked for review.")
+      end
+    end
+
+    context "when API fails" do
+      before do
+        stub_api_request("/goods_nomenclatures/#{commodity_code}/goods_nomenclature_label/reject", :post, backend: "uk")
+          .and_return(status: 500, body: { error: "Server error" }.to_json)
+      end
+
+      it { is_expected.to redirect_to(goods_nomenclature_label_path(commodity_code)) }
+
+      it "shows an error message" do
+        rendered_page
+        expect(session.dig("flash", "flashes", "alert")).to eq("Failed to reject label.")
       end
     end
   end

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -277,9 +277,10 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
     end
 
     it "displays the record dates" do # rubocop:disable RSpec/MultipleExpectations
-      expect(rendered_page.body).to include("Record dates")
-      expect(rendered_page.body).to include("Created: 15 June 2025")
-      expect(rendered_page.body).to include("Updated: Today")
+      expect(rendered_page.body).to include("Created", "15 June 2025", "Last updated", "Today")
+      expect(rendered_page.body).not_to include("Record dates")
+      expect(rendered_page.body).not_to include("Created:")
+      expect(rendered_page.body).not_to include("Updated:")
     end
 
     it "labels the state summary as tags" do

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
       "expired" => false,
       "created_at" => "2025-06-15T10:00:00Z",
       "updated_at" => "#{Time.zone.today.iso8601}T10:00:00Z",
-      "generated_at" => "2025-06-15T10:00:00Z",
       "eu_self_text" => "Horses, live, for breeding",
       "similarity_score" => 0.72,
       "coherence_score" => 0.68,

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -25,6 +25,10 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
       "needs_review" => false,
       "manually_edited" => false,
       "stale" => false,
+      "approved" => false,
+      "expired" => false,
+      "created_at" => "2025-06-15T10:00:00Z",
+      "updated_at" => "#{Time.zone.today.iso8601}T10:00:00Z",
       "generated_at" => "2025-06-15T10:00:00Z",
       "eu_self_text" => "Horses, live, for breeding",
       "similarity_score" => 0.72,
@@ -105,6 +109,8 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
 
         expect(controller).to include(%(scope="col">Tags</th>))
         expect(controller).to include("params.set('status', this.tagsValue);")
+        expect(controller).to include("st.approved")
+        expect(controller).to include("st.expired")
       end
 
       it "uses tags terminology in the label table controller" do
@@ -112,6 +118,7 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
 
         expect(controller).to include(%(scope="col">Tags</th>))
         expect(controller).to include("params.set('status', this.tagsValue);")
+        expect(controller).to include("label.needs_review", "label.approved", "label.expired")
       end
 
       it "uses the updated score labels in the self-text table controller" do
@@ -270,8 +277,23 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
       expect(rendered_page.body).to include("View labels")
     end
 
+    it "displays the record dates" do # rubocop:disable RSpec/MultipleExpectations
+      expect(rendered_page.body).to include("Record dates")
+      expect(rendered_page.body).to include("Created: 15 June 2025")
+      expect(rendered_page.body).to include("Updated: Today")
+    end
+
     it "labels the state summary as tags" do
       expect(rendered_page.body).to include(%(<dt class="govuk-summary-list__key">Tags</dt>))
+    end
+
+    context "when the self-text has approved and expired tags" do
+      let(:self_text_attributes) { super().merge("approved" => true, "expired" => true) }
+
+      it "displays the approved and expired tags" do # rubocop:disable RSpec/MultipleExpectations
+        expect(rendered_page.body).to include("Approved")
+        expect(rendered_page.body).to include("Expired")
+      end
     end
 
     context "when has_label is false" do


### PR DESCRIPTION
## What

<img width="1675" height="1045" alt="image" src="https://github.com/user-attachments/assets/880d1112-ec14-411d-a158-53b2f1739c1b" />

Adds the admin UI support for the generated content lifecycle transitions introduced in the backend:

- Adds label lifecycle actions for score, regenerate, approve and reject.
- Shows label lifecycle action buttons on the label detail page.
- Shows label and self-text lifecycle tags for needs review, manually edited, stale, approved and expired.
- Carries the new lifecycle flags through listing JSON and table tag rendering.
- Uses the label commodity code, not the label SID, when calling backend label lifecycle endpoints.

## Why

Operators need to manage the generated content lifecycle from the admin app, including approving reviewed records, marking suspect labels for review, regenerating labels, and seeing when generated rows are approved or expired.

The backend label lifecycle endpoints resolve labels by goods nomenclature item id, so the admin app must call them with the commodity code rather than the generated label SID.

## Lifecycle controls

```mermaid
flowchart LR
    %% UI pages
    SELF_TEXT_PAGE[Self-text detail page]
    LABEL_PAGE[Label detail page]

    %% Operator actions
    NEEDS_REVIEW[Needs review]
    APPROVE[Approve]
    SCORE[Generate score]
    REGENERATE[Regenerate content]

    %% Backend outcomes
    REVIEW_TAG[Needs review tag]
    APPROVED_TAG[Approved tag]
    SCORE_REFRESH[Scores refreshed]
    GENERATED_TAGS[Generated replacement]

    %% Side effects
    BACKEND_API[Backend admin API]
    SEARCH_REFRESH[Search refresh]

    %% Page actions
    SELF_TEXT_PAGE --> NEEDS_REVIEW
    SELF_TEXT_PAGE --> APPROVE
    SELF_TEXT_PAGE --> SCORE
    SELF_TEXT_PAGE --> REGENERATE

    LABEL_PAGE --> NEEDS_REVIEW
    LABEL_PAGE --> APPROVE
    LABEL_PAGE --> SCORE
    LABEL_PAGE --> REGENERATE

    %% API calls
    NEEDS_REVIEW --> BACKEND_API
    APPROVE --> BACKEND_API
    SCORE --> BACKEND_API
    REGENERATE --> BACKEND_API

    %% User-visible outcomes
    BACKEND_API --> REVIEW_TAG
    BACKEND_API --> APPROVED_TAG
    BACKEND_API --> SCORE_REFRESH
    BACKEND_API --> GENERATED_TAGS

    %% Content-changing side effects
    GENERATED_TAGS --> SEARCH_REFRESH
    SCORE_REFRESH --> SEARCH_REFRESH
```