### PR TITLE
AI-596: Add approved generated content filters

### DIFF
--- a/app/views/goods_nomenclature_self_texts/index.html.erb
+++ b/app/views/goods_nomenclature_self_texts/index.html.erb
@@ -147,6 +147,11 @@
                 <label class="govuk-label govuk-radios__label" for="st-tags-needs-review">Needs review</label>
               </div>
               <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="st-tags-approved" name="st_tags" type="radio" value="approved"
+                       data-action="change->self-text-table#changeTags" data-status="approved">
+                <label class="govuk-label govuk-radios__label" for="st-tags-approved">Approved</label>
+              </div>
+              <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="st-tags-stale" name="st_tags" type="radio" value="stale"
                        data-action="change->self-text-table#changeTags" data-status="stale">
                 <label class="govuk-label govuk-radios__label" for="st-tags-stale">Stale</label>
@@ -286,6 +291,11 @@
                 <input class="govuk-radios__input" id="lb-tags-all" name="lb_tags" type="radio" value="" checked
                        data-action="change->label-table#changeTags" data-status="">
                 <label class="govuk-label govuk-radios__label" for="lb-tags-all">All</label>
+              </div>
+              <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="lb-tags-approved" name="lb_tags" type="radio" value="approved"
+                       data-action="change->label-table#changeTags" data-status="approved">
+                <label class="govuk-label govuk-radios__label" for="lb-tags-approved">Approved</label>
               </div>
               <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="lb-tags-stale" name="lb_tags" type="radio" value="stale"

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -90,10 +90,10 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
 
       it "labels self-text and label state filters as tags" do
         expect(rendered_page.body).to include('<legend class="govuk-fieldset__legend govuk-fieldset__legend--s">Tags</legend>')
-        expect(rendered_page.body).to include('id="st-tags-stale"')
-        expect(rendered_page.body).to include('data-action="change->self-text-table#changeTags" data-status="stale"')
-        expect(rendered_page.body).to include('id="lb-tags-stale"')
-        expect(rendered_page.body).to include('data-action="change->label-table#changeTags" data-status="stale"')
+        expect(rendered_page.body).to include('id="st-tags-approved"')
+        expect(rendered_page.body).to include('data-action="change->self-text-table#changeTags" data-status="approved"')
+        expect(rendered_page.body).to include('id="lb-tags-approved"')
+        expect(rendered_page.body).to include('data-action="change->label-table#changeTags" data-status="approved"')
       end
 
       it "uses the updated visible score labels while preserving backend filter values" do


### PR DESCRIPTION
### Jira link

[AI-596](https://transformuk.atlassian.net/browse/AI-596)

### What?

- [x] Add an Approved tag filter for self-texts
- [x] Add an Approved tag filter for labels
- [x] Send `status=approved` to the backend when operators choose the Approved filter

### Why?

Approved content is excluded from normal review listings by default in the backend. Operators still need an explicit way to inspect approved self-texts and labels when investigating a support issue.