### PR TITLE
BAU: Hide description intercept guidance level and location

### DIFF
--- a/app/controllers/description_intercepts_controller.rb
+++ b/app/controllers/description_intercepts_controller.rb
@@ -90,8 +90,6 @@ private
       :term,
       :excluded,
       :message,
-      :guidance_level,
-      :guidance_location,
       :escalate_to_webchat,
       sources: [],
       filter_prefixes: [],
@@ -100,15 +98,8 @@ private
     permitted[:excluded] = ActiveModel::Type::Boolean.new.cast(permitted[:excluded]) if permitted.key?(:excluded)
     permitted[:escalate_to_webchat] = ActiveModel::Type::Boolean.new.cast(permitted[:escalate_to_webchat]) if permitted.key?(:escalate_to_webchat)
     permitted[:message] = permitted[:message].presence if permitted.key?(:message)
-    permitted[:guidance_level] = permitted[:guidance_level].presence if permitted.key?(:guidance_level)
-    permitted[:guidance_location] = permitted[:guidance_location].presence if permitted.key?(:guidance_location)
     permitted[:sources] = Array(permitted[:sources]).reject(&:blank?)
     permitted[:filter_prefixes] = Array(permitted[:filter_prefixes]).reject(&:blank?)
-
-    if permitted[:message].blank?
-      permitted.delete(:guidance_level)
-      permitted.delete(:guidance_location)
-    end
 
     if permitted[:excluded]
       permitted.delete(:filter_prefixes)
@@ -123,6 +114,9 @@ private
     if @description_intercept.message.blank?
       @description_intercept.guidance_level = nil
       @description_intercept.guidance_location = nil
+    else
+      @description_intercept.guidance_level = "info"
+      @description_intercept.guidance_location = "interstitial"
     end
 
     @description_intercept.filter_prefixes = [] if @description_intercept.excluded?

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -29,6 +29,9 @@ class DescriptionIntercept
       attrs[:message] = nil
       attrs[:guidance_level] = nil
       attrs[:guidance_location] = nil
+    else
+      attrs[:guidance_level] = "info"
+      attrs[:guidance_location] = "interstitial"
     end
 
     # Faraday URL-encodes API payloads, which drops empty arrays entirely.
@@ -90,14 +93,6 @@ class DescriptionIntercept
 
   def escalation_tag_colour
     escalate_to_webchat? ? "blue" : "grey"
-  end
-
-  def location_label
-    guidance_location.to_s.humanize.presence || "-"
-  end
-
-  def level_label
-    guidance_level.to_s.humanize.presence || "-"
   end
 
   def sources_label

--- a/app/views/description_intercepts/_form.html.erb
+++ b/app/views/description_intercepts/_form.html.erb
@@ -117,8 +117,7 @@
                           :message,
                           label: { text: "Guidance message" },
                           hint: { text: "Shown to the trader-facing frontend when this intercept matches." },
-                          rows: 5,
-                          data: { action: "input->description-intercept-form#toggleGuidance", description_intercept_form_target: "messageInput" } do %>
+                          rows: 5 do %>
     <%= govuk_details(summary_text: "Markdown and automatic short code links") do %>
       <p class="govuk-body">
         Short codes are automatically rendered as links in the frontend. You do not need to add markdown links for
@@ -137,21 +136,6 @@
       </p>
     <% end %>
   <% end %>
-
-  <div data-description-intercept-form-target="guidanceFields">
-    <%= f.govuk_select :guidance_level,
-                       DescriptionIntercept::GUIDANCE_LEVELS,
-                       label: { text: "Guidance level" },
-                       hint: { text: "Controls how strongly the frontend should present the guidance." },
-                       include_blank: true,
-                       data: { description_intercept_form_target: "guidanceLevelInput" } %>
-    <%= f.govuk_select :guidance_location,
-                       DescriptionIntercept::GUIDANCE_LOCATIONS,
-                       label: { text: "Guidance location" },
-                       hint: { text: "Choose where the guidance message is intended to appear." },
-                       include_blank: true,
-                       data: { description_intercept_form_target: "guidanceLocationInput" } %>
-  </div>
 
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Support</h2>
   <div class="govuk-form-group">

--- a/app/views/description_intercepts/show.html.erb
+++ b/app/views/description_intercepts/show.html.erb
@@ -33,14 +33,6 @@
       <dt class="govuk-summary-list__key">Guidance</dt>
       <dd class="govuk-summary-list__value"><%= @description_intercept.message %></dd>
     </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Guidance level</dt>
-      <dd class="govuk-summary-list__value"><%= @description_intercept.level_label %></dd>
-    </div>
-    <div class="govuk-summary-list__row">
-      <dt class="govuk-summary-list__key">Guidance location</dt>
-      <dd class="govuk-summary-list__value"><%= @description_intercept.location_label %></dd>
-    </div>
   <% else %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Guidance</dt>

--- a/app/webpacker/controllers/description_intercept_form_controller.js
+++ b/app/webpacker/controllers/description_intercept_form_controller.js
@@ -5,10 +5,6 @@ import accessibleAutocomplete from 'accessible-autocomplete';
 export default class extends Controller {
   static get targets() {
     return [
-      "messageInput",
-      "guidanceFields",
-      "guidanceLevelInput",
-      "guidanceLocationInput",
       "excludedInput",
       "filteringToggle",
       "filteringFields",
@@ -26,20 +22,7 @@ export default class extends Controller {
 
   connect() {
     this.initializeAutocomplete();
-    this.toggleGuidance();
     this.toggleFiltering();
-  }
-
-  toggleGuidance() {
-    const visible = this.messageInputTarget.value.trim().length > 0;
-    this.guidanceFieldsTarget.style.display = visible ? "" : "none";
-    this.guidanceLevelInputTarget.disabled = !visible;
-    this.guidanceLocationInputTarget.disabled = !visible;
-
-    if (!visible) {
-      this.guidanceLevelInputTarget.value = "";
-      this.guidanceLocationInputTarget.value = "";
-    }
   }
 
   toggleExcluded() {

--- a/spec/models/description_intercept_spec.rb
+++ b/spec/models/description_intercept_spec.rb
@@ -57,6 +57,43 @@ RSpec.describe DescriptionIntercept do
     end
   end
 
+  describe "#normalize_serialized_attributes" do
+    it "defaults guidance metadata when a message is present" do
+      attrs = {
+        message: "Show this guidance message to the trader.",
+        guidance_level: "warning",
+        guidance_location: "results",
+        filter_prefixes: %w[1201],
+        sources: %w[guided_search],
+      }
+
+      intercept.normalize_serialized_attributes(attrs)
+
+      expect(attrs).to include(
+        guidance_level: "info",
+        guidance_location: "interstitial",
+      )
+    end
+
+    it "clears guidance metadata when the message is blank" do
+      attrs = {
+        message: "",
+        guidance_level: "warning",
+        guidance_location: "results",
+        filter_prefixes: %w[1201],
+        sources: %w[guided_search],
+      }
+
+      intercept.normalize_serialized_attributes(attrs)
+
+      expect(attrs).to include(
+        message: nil,
+        guidance_level: nil,
+        guidance_location: nil,
+      )
+    end
+  end
+
   describe "#formatted_created_at" do
     it "formats the timestamp as a GOV.UK date" do
       expect(intercept.formatted_created_at).to eq("15 April 2026")

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -104,6 +104,8 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     it "shows the new form" do
       expect(rendered_page.body).to include("New description intercept")
       expect(rendered_page.body).to include("Create description intercept")
+      expect(rendered_page.body).not_to include("Guidance level")
+      expect(rendered_page.body).not_to include("Guidance location")
     end
 
     it "defaults guided search to selected" do
@@ -140,13 +142,13 @@ RSpec.describe DescriptionInterceptsController, type: :request do
 
     it "shows the full intercept summary" do
       expect(rendered_page.body).to include("Filters to selected short codes")
-      expect(rendered_page.body).to include("Warning")
-      expect(rendered_page.body).to include("Results")
       expect(rendered_page.body).to include("Guided search")
       expect(rendered_page.body).to include("Soya bean flour and meal")
       expect(rendered_page.body).to include("Preparations of a kind used in animal feeding")
       expect(rendered_page.body).to include("Enabled")
       expect(rendered_page.body).to include("Not excluded")
+      expect(rendered_page.body).not_to include("Guidance level")
+      expect(rendered_page.body).not_to include("Guidance location")
     end
 
     context "when the intercept has no guidance" do
@@ -191,6 +193,8 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       expect(rendered_page.body).to include("Allow HMRC support escalation")
       expect(rendered_page.body).to include("Guidance message")
       expect(rendered_page.body).to include("Selected short codes")
+      expect(rendered_page.body).not_to include("Guidance level")
+      expect(rendered_page.body).not_to include("Guidance location")
     end
 
     it "renders the guidance message as a markdown editor with preview" do
@@ -261,6 +265,12 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     context "with valid create" do
       before do
         stub_api_request("/description_intercepts", :post)
+          .with { |request|
+            attrs = Rack::Utils.parse_nested_query(request.body).dig("data", "attributes")
+            attrs["message"] == "New guidance" &&
+              attrs["guidance_level"] == "info" &&
+              attrs["guidance_location"] == "interstitial"
+          }
           .and_return(
             status: 200,
             headers: { "content-type" => "application/json; charset=utf-8" },
@@ -475,6 +485,12 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     context "with valid update" do
       before do
         stub_api_request("/description_intercepts/#{intercept_id}", :patch)
+          .with { |request|
+            attrs = Rack::Utils.parse_nested_query(request.body).dig("data", "attributes")
+            attrs["message"] == "Updated guidance" &&
+              attrs["guidance_level"] == "info" &&
+              attrs["guidance_location"] == "interstitial"
+          }
           .and_return(intercept_response)
       end
 


### PR DESCRIPTION
### Jira link

BAU

<img width="1342" height="1133" alt="image" src="https://github.com/user-attachments/assets/38ed4990-5984-4968-9b21-e628123f0475" />


### What?

- [x] Hide guidance level and guidance location from the description intercept form
- [x] Remove guidance level and guidance location from the description intercept show page
- [x] Default guidance metadata to `info` and `interstitial` whenever a guidance message is present
- [x] Keep blank guidance clearing those metadata fields
- [x] Update request and model specs to cover the new behaviour

### Why?

The admin UI should no longer expose guidance level or guidance location for description intercepts. For now, those values should be fixed to the backend defaults so admins only manage the guidance message itself.