### PR TITLE
AI-659: Refine description intercept admin UI

### DIFF
--- a/app/controllers/description_intercepts_controller.rb
+++ b/app/controllers/description_intercepts_controller.rb
@@ -91,6 +91,7 @@ private
       :excluded,
       :message,
       :escalate_to_webchat,
+      aliases: [],
       sources: [],
       filter_prefixes: [],
     )
@@ -98,6 +99,7 @@ private
     permitted[:excluded] = ActiveModel::Type::Boolean.new.cast(permitted[:excluded]) if permitted.key?(:excluded)
     permitted[:escalate_to_webchat] = ActiveModel::Type::Boolean.new.cast(permitted[:escalate_to_webchat]) if permitted.key?(:escalate_to_webchat)
     permitted[:message] = permitted[:message].presence if permitted.key?(:message)
+    permitted[:aliases] = Array(permitted[:aliases]).reject(&:blank?)
     permitted[:sources] = Array(permitted[:sources]).reject(&:blank?)
     permitted[:filter_prefixes] = Array(permitted[:filter_prefixes]).reject(&:blank?)
 

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -16,6 +16,7 @@ class DescriptionIntercept
              :guidance_location,
              :filter_prefixes,
              :sources,
+             :aliases,
              :created_at
 
   boolean_attributes :excluded,
@@ -101,5 +102,13 @@ class DescriptionIntercept
 
   def filter_prefixes_label
     Array(filter_prefixes).join(", ").presence || "-"
+  end
+
+  def aliases_label
+    aliases_array.join(", ").presence || "-"
+  end
+
+  def aliases_array
+    Array(aliases).reject(&:blank?)
   end
 end

--- a/app/views/description_intercepts/_form.html.erb
+++ b/app/views/description_intercepts/_form.html.erb
@@ -18,6 +18,33 @@
                          label: { text: "", hidden: true },
                          hint: { text: "The term or phrase that should trigger this intercept." } %>
 
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Aliases</h2>
+  <div class="govuk-form-group">
+    <label class="govuk-label govuk-label--s" for="description-intercept-alias-field">Add an alias</label>
+    <div id="description-intercept-alias-hint" class="govuk-hint">Optional alternative terms that should trigger this intercept.</div>
+    <div class="govuk-button-group">
+      <input class="govuk-input govuk-!-width-one-half"
+             id="description-intercept-alias-field"
+             type="text"
+             aria-describedby="description-intercept-alias-hint"
+             data-description-intercept-form-target="aliasInput"
+             data-action="keydown.enter->description-intercept-form#addAlias">
+      <button type="button" class="govuk-button govuk-button--secondary" data-action="click->description-intercept-form#addAlias">Add alias</button>
+    </div>
+    <input type="hidden" name="description_intercept[aliases][]" value="">
+    <div class="description-intercept-short-code-list" data-description-intercept-form-target="selectedAliases">
+      <% description_intercept.aliases_array.each do |alias_value| %>
+        <div class="description-intercept-short-code-pill" data-alias-item="true">
+          <div class="description-intercept-short-code-pill__content">
+            <strong class="govuk-tag govuk-tag--grey"><%= alias_value %></strong>
+          </div>
+          <button type="button" class="description-intercept-short-code-pill__remove" data-action="click->description-intercept-form#removeAlias" aria-label="Remove <%= alias_value %>">Remove</button>
+          <input type="hidden" name="description_intercept[aliases][]" value="<%= alias_value %>">
+        </div>
+      <% end %>
+    </div>
+  </div>
+
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Search behaviour</h2>
   <div class="govuk-form-group">
     <div class="govuk-checkboxes govuk-checkboxes--small">
@@ -90,10 +117,10 @@
     </div>
   </div>
 
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Sources</h2>
+  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Relevant Products</h2>
   <div class="govuk-form-group">
     <fieldset class="govuk-fieldset" aria-describedby="description_intercept_sources_hint">
-      <legend class="govuk-visually-hidden">Search sources</legend>
+      <legend class="govuk-visually-hidden">Relevant products</legend>
       <div id="description_intercept_sources_hint" class="govuk-hint">Choose where this intercept should apply.</div>
       <input type="hidden" name="description_intercept[sources][]" value="">
       <div class="govuk-checkboxes govuk-checkboxes--small">
@@ -104,7 +131,9 @@
                    type="checkbox"
                    name="description_intercept[sources][]"
                    value="<%= source %>"
-                   <%= 'checked' if Array(description_intercept.sources).include?(source) %>>
+                   <%= 'checked' if Array(description_intercept.sources).include?(source) %>
+                   data-action="change->description-intercept-form#toggleGuidance"
+                   data-description-intercept-form-target="sourceInput">
             <label class="govuk-label govuk-checkboxes__label" for="description_intercept_sources_<%= source %>"><%= DescriptionIntercept::SOURCE_LABELS[source] %></label>
           </div>
         <% end %>
@@ -112,30 +141,33 @@
     </fieldset>
   </div>
 
-  <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Guidance</h2>
-  <%= govuk_markdown_area f,
-                          :message,
-                          label: { text: "Guidance message" },
-                          hint: { text: "Shown to the trader-facing frontend when this intercept matches." },
-                          rows: 5 do %>
-    <%= govuk_details(summary_text: "Markdown and automatic short code links") do %>
-      <p class="govuk-body">
-        Short codes are automatically rendered as links in the frontend. You do not need to add markdown links for
-        chapters, headings, subheadings or commodities.
-      </p>
-      <p class="govuk-body">
-        For example, <code>01</code>, <code>0101</code>, <code>010121</code> and <code>0101210000</code> will be linked
-        automatically.
-      </p>
-      <p class="govuk-body">
-        Use the
-        <a class="govuk-link" href="https://govspeak-preview.publishing.service.gov.uk/guide" rel="noopener" target="_blank">
-          Markdown guide
-        </a>
-        for formatting such as headings, lists and emphasis.
-      </p>
+  <div data-description-intercept-form-target="guidanceFields"
+       <%= 'style="display:none"'.html_safe unless Array(description_intercept.sources).include?("guided_search") %>>
+    <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Guidance</h2>
+    <%= govuk_markdown_area f,
+                            :message,
+                            label: { text: "Guidance message" },
+                            hint: { text: "Shown to the trader-facing frontend when this intercept matches." },
+                            rows: 5 do %>
+      <%= govuk_details(summary_text: "Markdown and automatic short code links") do %>
+        <p class="govuk-body">
+          Short codes are automatically rendered as links in the frontend. You do not need to add markdown links for
+          chapters, headings, subheadings or commodities.
+        </p>
+        <p class="govuk-body">
+          For example, <code>01</code>, <code>0101</code>, <code>010121</code> and <code>0101210000</code> will be linked
+          automatically.
+        </p>
+        <p class="govuk-body">
+          Use the
+          <a class="govuk-link" href="https://govspeak-preview.publishing.service.gov.uk/guide" rel="noopener" target="_blank">
+            Markdown guide
+          </a>
+          for formatting such as headings, lists and emphasis.
+        </p>
+      <% end %>
     <% end %>
-  <% end %>
+  </div>
 
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Support</h2>
   <div class="govuk-form-group">

--- a/app/views/description_intercepts/show.html.erb
+++ b/app/views/description_intercepts/show.html.erb
@@ -10,7 +10,7 @@
 
 <div class="govuk-inset-text govuk-!-margin-bottom-6">
   <p class="govuk-body govuk-!-margin-bottom-2"><strong>Behaviour:</strong> <%= @description_intercept.behaviour_summary %></p>
-  <p class="govuk-body govuk-!-margin-bottom-0"><strong>Sources:</strong> <%= @description_intercept.sources_label %></p>
+  <p class="govuk-body govuk-!-margin-bottom-0"><strong>Relevant Products:</strong> <%= @description_intercept.sources_label %></p>
 </div>
 
 <dl class="govuk-summary-list govuk-!-margin-bottom-6">
@@ -21,8 +21,12 @@
     </dd>
   </div>
   <div class="govuk-summary-list__row">
-    <dt class="govuk-summary-list__key">Sources</dt>
+    <dt class="govuk-summary-list__key">Relevant Products</dt>
     <dd class="govuk-summary-list__value"><%= @description_intercept.sources_label %></dd>
+  </div>
+  <div class="govuk-summary-list__row">
+    <dt class="govuk-summary-list__key">Aliases</dt>
+    <dd class="govuk-summary-list__value"><%= @description_intercept.aliases_label %></dd>
   </div>
   <div class="govuk-summary-list__row">
     <dt class="govuk-summary-list__key">Search behaviour</dt>

--- a/app/webpacker/controllers/description_intercept_form_controller.js
+++ b/app/webpacker/controllers/description_intercept_form_controller.js
@@ -11,6 +11,10 @@ export default class extends Controller {
       "filteringHint",
       "autocompleteContainer",
       "selectedShortCodes",
+      "sourceInput",
+      "guidanceFields",
+      "aliasInput",
+      "selectedAliases",
     ];
   }
 
@@ -23,6 +27,7 @@ export default class extends Controller {
   connect() {
     this.initializeAutocomplete();
     this.toggleFiltering();
+    this.toggleGuidance();
   }
 
   toggleExcluded() {
@@ -43,6 +48,18 @@ export default class extends Controller {
     this.filteringFieldsTarget.style.display = visible ? '' : 'none';
     this.toggleSelectedShortCodeInputs(visible);
     this.toggleAutocompleteAvailability();
+  }
+
+  toggleGuidance() {
+    if (!this.hasGuidanceFieldsTarget) {
+      return;
+    }
+
+    this.guidanceFieldsTarget.style.display = this.guidedSearchSelected() ? '' : 'none';
+  }
+
+  guidedSearchSelected() {
+    return this.sourceInputTargets.some((input) => input.value === 'guided_search' && input.checked);
   }
 
   initializeAutocomplete() {
@@ -120,6 +137,26 @@ export default class extends Controller {
     event.currentTarget.closest("[data-short-code-item]").remove();
   }
 
+  addAlias(event) {
+    event.preventDefault();
+
+    const alias = this.aliasInputTarget.value.trim();
+    if (!alias || this.aliasValues().includes(alias)) return;
+
+    this.selectedAliasesTarget.appendChild(this.buildSelectedAlias(alias));
+    this.aliasInputTarget.value = '';
+    this.aliasInputTarget.focus();
+  }
+
+  removeAlias(event) {
+    event.preventDefault();
+    event.currentTarget.closest("[data-alias-item]").remove();
+  }
+
+  aliasValues() {
+    return Array.from(this.selectedAliasesTarget.querySelectorAll('input[type="hidden"]')).map((input) => input.value);
+  }
+
   toggleAutocompleteAvailability() {
     if (!this.autocompleteInput) {
       return;
@@ -194,6 +231,39 @@ export default class extends Controller {
     input.type = "hidden";
     input.name = "description_intercept[filter_prefixes][]";
     input.value = code;
+
+    wrapper.appendChild(content);
+    wrapper.appendChild(removeButton);
+    wrapper.appendChild(input);
+
+    return wrapper;
+  }
+
+  buildSelectedAlias(alias) {
+    const wrapper = document.createElement("div");
+    wrapper.setAttribute("data-alias-item", "true");
+    wrapper.className = "description-intercept-short-code-pill";
+
+    const content = document.createElement("div");
+    content.className = "description-intercept-short-code-pill__content";
+
+    const tag = document.createElement("strong");
+    tag.className = "govuk-tag govuk-tag--grey";
+    tag.textContent = alias;
+
+    content.appendChild(tag);
+
+    const removeButton = document.createElement("button");
+    removeButton.type = "button";
+    removeButton.className = "description-intercept-short-code-pill__remove";
+    removeButton.textContent = "Remove";
+    removeButton.setAttribute("aria-label", "Remove " + alias);
+    removeButton.addEventListener("click", (event) => this.removeAlias(event));
+
+    const input = document.createElement("input");
+    input.type = "hidden";
+    input.name = "description_intercept[aliases][]";
+    input.value = alias;
 
     wrapper.appendChild(content);
     wrapper.appendChild(removeButton);

--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1773840656,
-        "narHash": "sha256-9tpvMGFteZnd3gRQZFlRCohVpqooygFuy9yjuyRL2C0=",
+        "lastModified": 1777270315,
+        "narHash": "sha256-yKB4G6cKsQsWN7M6rZGk6gkJPDNPIzT05y4qzRyCDlI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "9cf7092bdd603554bd8b63c216e8943cf9b12512",
+        "rev": "6368eda62c9775c38ef7f714b2555a741c20c72d",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1774079451,
-        "narHash": "sha256-r6KaQPo7CL10nQiVnwsVmyHvRQ4JwxQhnVwDazaKefI=",
+        "lastModified": 1776289224,
+        "narHash": "sha256-23ThpEISX0mQhkFl6U+sY03IFgEPoLyS4kG7xGzoJgA=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "4afa97cc68c4f4d62a8bf40f89b606a13e5bbdc0",
+        "rev": "72dc1140cea40ef216f6566b272d5b44bdf95ab3",
         "type": "github"
       },
       "original": {

--- a/spec/models/description_intercept_spec.rb
+++ b/spec/models/description_intercept_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe DescriptionIntercept do
       escalate_to_webchat: true,
       filter_prefixes: %w[1201 2309],
       sources: %w[guided_search fpo_search],
+      aliases: ["pet food", "animal nutrition"],
       created_at: "2026-04-15T10:30:00Z",
     }
   end
@@ -54,6 +55,18 @@ RSpec.describe DescriptionIntercept do
       intercept.filter_prefixes = []
 
       expect(intercept.filtering?).to be(false)
+    end
+  end
+
+  describe "#aliases_label" do
+    it "returns a comma separated label" do
+      expect(intercept.aliases_label).to eq("pet food, animal nutrition")
+    end
+
+    it "returns a dash when no aliases are present" do
+      intercept.aliases = []
+
+      expect(intercept.aliases_label).to eq("-")
     end
   end
 

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       "escalate_to_webchat" => true,
       "filter_prefixes" => %w[1201 2309],
       "sources" => %w[guided_search],
+      "aliases" => ["pet food", "animal nutrition"],
       "created_at" => "2026-04-15T10:30:00Z",
     }
   end
@@ -104,6 +105,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     it "shows the new form" do
       expect(rendered_page.body).to include("New description intercept")
       expect(rendered_page.body).to include("Create description intercept")
+      expect(rendered_page.body).to include("Relevant Products")
       expect(rendered_page.body).not_to include("Guidance level")
       expect(rendered_page.body).not_to include("Guidance location")
     end
@@ -142,7 +144,9 @@ RSpec.describe DescriptionInterceptsController, type: :request do
 
     it "shows the full intercept summary" do
       expect(rendered_page.body).to include("Filters to selected short codes")
+      expect(rendered_page.body).to include("Relevant Products")
       expect(rendered_page.body).to include("Guided search")
+      expect(rendered_page.body).to include("pet food, animal nutrition")
       expect(rendered_page.body).to include("Soya bean flour and meal")
       expect(rendered_page.body).to include("Preparations of a kind used in animal feeding")
       expect(rendered_page.body).to include("Enabled")
@@ -192,6 +196,11 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       expect(rendered_page.body).to include("Save changes")
       expect(rendered_page.body).to include("Allow HMRC support escalation")
       expect(rendered_page.body).to include("Guidance message")
+      expect(rendered_page.body).to include("Add alias")
+      expect(rendered_page.body).to include("pet food")
+      expect(rendered_page.body).to include("animal nutrition")
+      expect(rendered_page.body).to include('name="description_intercept[aliases][]" value="pet food"')
+      expect(rendered_page.body).to include('aria-label="Remove pet food"')
       expect(rendered_page.body).to include("Selected short codes")
       expect(rendered_page.body).not_to include("Guidance level")
       expect(rendered_page.body).not_to include("Guidance location")
@@ -244,6 +253,17 @@ RSpec.describe DescriptionInterceptsController, type: :request do
         expect(rendered_page.body).to include("Filtering is unavailable while exclude search results is selected.")
       end
     end
+
+    context "when guided search is not selected" do
+      let(:intercept_attributes) { super().merge("sources" => %w[fpo_search]) }
+
+      it "hides guidance fields without clearing the existing value" do
+        page = Capybara.string(rendered_page.body)
+
+        expect(page).to have_css '[data-description-intercept-form-target="guidanceFields"][style="display:none"]', visible: :all
+        expect(page).to have_css 'textarea[name="description_intercept[message]"]', text: "Ask the trader to pick a more specific feed type.", visible: :all
+      end
+    end
   end
 
   describe "POST #create" do
@@ -252,6 +272,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
         description_intercept: {
           term: "new animal feed",
           excluded: "0",
+          aliases: ["pet food", "animal nutrition"],
           message: "New guidance",
           guidance_level: "info",
           guidance_location: "results",
@@ -268,6 +289,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
           .with { |request|
             attrs = Rack::Utils.parse_nested_query(request.body).dig("data", "attributes")
             attrs["message"] == "New guidance" &&
+              attrs["aliases"] == ["pet food", "animal nutrition"] &&
               attrs["guidance_level"] == "info" &&
               attrs["guidance_location"] == "interstitial"
           }
@@ -298,6 +320,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
           description_intercept: {
             term: "parked intercept",
             excluded: "0",
+            aliases: [""],
             message: "",
             escalate_to_webchat: "0",
             sources: [""],
@@ -472,6 +495,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
         description_intercept: {
           term: "animal feed",
           excluded: "0",
+          aliases: ["updated feed", "livestock feed"],
           message: "Updated guidance",
           guidance_level: "info",
           guidance_location: "question",
@@ -488,6 +512,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
           .with { |request|
             attrs = Rack::Utils.parse_nested_query(request.body).dig("data", "attributes")
             attrs["message"] == "Updated guidance" &&
+              attrs["aliases"] == ["updated feed", "livestock feed"] &&
               attrs["guidance_level"] == "info" &&
               attrs["guidance_location"] == "interstitial"
           }

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -5,26 +5,26 @@ Terraform to deploy the service into AWS.
 ## Requirements
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >=1.12.2 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 5.100.0 |
 
 ## Modules
 
 | Name | Source | Version |
-|------|--------|---------|
+| ---- | ------ | ------- |
 | <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_iam_policy.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_document.task](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_lb_target_group.this_https](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/lb_target_group) | data source |
@@ -42,7 +42,7 @@ Terraform to deploy the service into AWS.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_autoscaling_metrics"></a> [autoscaling\_metrics](#input\_autoscaling\_metrics) | A map of autoscaling metrics. | <pre>map(object({<br/>    metric_type  = string<br/>    target_value = number<br/>  }))</pre> | <pre>{<br/>  "cpu": {<br/>    "metric_type": "ECSServiceAverageCPUUtilization",<br/>    "target_value": 40<br/>  },<br/>  "memory": {<br/>    "metric_type": "ECSServiceAverageMemoryUtilization",<br/>    "target_value": 40<br/>  }<br/>}</pre> | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |


### PR DESCRIPTION
### Jira link

[AI-659](https://transformuk.atlassian.net/browse/AI-659)

<img width="780" height="682" alt="image" src="https://github.com/user-attachments/assets/8d053a5a-a377-4603-b340-c8dc24220847" />


<img width="1218" height="624" alt="image" src="https://github.com/user-attachments/assets/05904000-6829-4833-a551-bb1e87b183bf" />


### What?

- [x] Rename description intercept Sources copy to Relevant Products
- [x] Hide guidance message content when Guided search is not selected
- [x] Add aliases to the admin form and detail view
- [x] Use add/remove alias tags rather than a textarea

### Why?

The backend now supports aliases for description intercepts. Admin users need to manage those aliases without editing a newline-delimited text area, and the guidance editor should only show for Guided search because FPO search does not use that content.