### PR TITLE
BAU: Adds link rendering

### DIFF
--- a/app/controllers/govspeak_controller.rb
+++ b/app/controllers/govspeak_controller.rb
@@ -7,7 +7,7 @@ class GovspeakController < AuthenticatedController
     flash.keep
 
     if params[:govspeak]
-      @preview = GovspeakPreview.new(params[:govspeak])
+      @preview = GovspeakPreview.new(params[:govspeak], linkify_code_references: ActiveModel::Type::Boolean.new.cast(params[:linkify_code_references]))
 
       respond_to do |format|
         format.json { render json: { govspeak: @preview.render } }

--- a/app/helpers/govuk_helper.rb
+++ b/app/helpers/govuk_helper.rb
@@ -35,11 +35,12 @@ module GovukHelper
     end
   end
 
-  def govuk_markdown_area(form, field_name, **options, &block)
+  def govuk_markdown_area(form, field_name, linkify_code_references: false, **options, &block)
     render "application/markdown_field",
            form:,
            field_name:,
            field_options: options,
-           help_content: block_given? ? capture(&block) : nil
+           help_content: block_given? ? capture(&block) : nil,
+           linkify_code_references:
   end
 end

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -18,11 +18,11 @@ class AdminConfiguration
     name&.titleize
   end
 
-  def preview(field_name = :value)
+  def preview(field_name = :value, **options)
     return unless config_type == "markdown"
 
     content = public_send(field_name)
-    GovspeakPreview.new(content).render if content.present?
+    GovspeakPreview.new(content, **options).render if content.present?
   end
 
   def selected_option_label

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -72,9 +72,9 @@ class DescriptionIntercept
     message.present?
   end
 
-  def preview(field_name = :message)
+  def preview(field_name = :message, **options)
     content = public_send(field_name)
-    GovspeakPreview.new(content).render if content.present?
+    GovspeakPreview.new(content, **options).render if content.present?
   end
 
   def filtering?

--- a/app/models/goods_nomenclature_code_linkifier.rb
+++ b/app/models/goods_nomenclature_code_linkifier.rb
@@ -1,0 +1,85 @@
+class GoodsNomenclatureCodeLinkifier
+  Pattern = Data.define(:regexp, :code_from_match)
+
+  SPACED_TERMINATORS = /(?=\s|;|,|$|\.|\)|\z)/
+  PUNCTUATION_TERMINATORS = /(?=;|,|$|\)|\z|<br>|<\/br>)/
+  CODE_BOUNDARY_START = /(?<![A-Za-z0-9.\/-])/
+  CODE_BOUNDARY_END = /(?![A-Za-z0-9.\/-])/
+  HEADING_CODE = /(?:0[1-9]|[1-9]\d)(?:0[1-9]|[1-9]\d)/
+
+  PATTERNS = [
+    Pattern.new(/chapter\s+(\d{2})#{SPACED_TERMINATORS}/i, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\.(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\s(\d{2})\s(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}#{match[3]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\s(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{10}|\d{8}|\d{6}|\d{2})#{CODE_BOUNDARY_END}/, ->(match) { match[1] }),
+    Pattern.new(/\A(#{HEADING_CODE})#{SPACED_TERMINATORS}/, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(#{HEADING_CODE})#{PUNCTUATION_TERMINATORS}/, ->(match) { match[1] }),
+  ].freeze
+
+  def initialize(html, frontend_host: TradeTariffAdmin.frontend_host, service_path: nil)
+    @html = html.to_s
+    @frontend_host = frontend_host.chomp("/")
+    @service_path = service_path || current_service_path
+  end
+
+  def render
+    fragment = Nokogiri::HTML::DocumentFragment.parse(@html)
+
+    fragment.xpath(".//text()[normalize-space()] | ./text()[normalize-space()]").each do |node|
+      next if node.ancestors.any? { |ancestor| ancestor.name == "a" }
+
+      replacement = linkify_text(node.text)
+      next if replacement == CGI.escapeHTML(node.text)
+
+      node.replace(Nokogiri::HTML::DocumentFragment.parse(replacement))
+    end
+
+    fragment.to_html
+  end
+
+private
+
+  def linkify_text(text)
+    html = +""
+    position = 0
+
+    while position < text.length
+      pattern, match = next_match(text, position)
+
+      unless match
+        html << CGI.escapeHTML(text[position..])
+        break
+      end
+
+      html << CGI.escapeHTML(text[position...match.begin(0)])
+      html << link_for(match[0], pattern.code_from_match.call(match))
+      position = match.end(0)
+    end
+
+    html
+  end
+
+  def next_match(text, position)
+    PATTERNS.each_with_object([nil, nil]) do |pattern, best|
+      match = pattern.regexp.match(text, position)
+      next unless match
+
+      if best[1].nil? || match.begin(0) < best[1].begin(0)
+        best[0] = pattern
+        best[1] = match
+      end
+    end
+  end
+
+  def link_for(text, code)
+    href = "#{@frontend_host}#{@service_path}/search?#{Rack::Utils.build_query(q: code)}"
+    link_text = %(#{CGI.escapeHTML(text)} <span class="govuk-visually-hidden">(opens in new tab)</span>)
+
+    %(<a class="govuk-link" href="#{CGI.escapeHTML(href)}" rel="noreferrer noopener" target="_blank">#{link_text}</a>)
+  end
+
+  def current_service_path
+    TradeTariffAdmin::ServiceChooser.uk? ? "" : "/xi"
+  end
+end

--- a/app/models/govspeak_preview.rb
+++ b/app/models/govspeak_preview.rb
@@ -1,10 +1,14 @@
 class GovspeakPreview
-  def initialize(content)
+  def initialize(content, linkify_code_references: false)
     @content = content.to_s
+    @linkify_code_references = linkify_code_references
   end
 
   def render
-    govspeak.to_html.html_safe
+    html = govspeak.to_html
+    html = GoodsNomenclatureCodeLinkifier.new(html).render if @linkify_code_references
+
+    html.html_safe
   end
 
 private

--- a/app/models/news/item.rb
+++ b/app/models/news/item.rb
@@ -32,10 +32,10 @@ module News
       @collection_ids = Array(ids).map(&:presence).compact.uniq.map(&:to_i)
     end
 
-    def preview(field_name = nil)
+    def preview(field_name = nil, **options)
       markdown = field_name.to_s == "precis" ? precis : content
 
-      GovspeakPreview.new(markdown).render
+      GovspeakPreview.new(markdown, **options).render
     end
 
     def generate_or_normalise_slug!

--- a/app/views/application/_markdown_field.html.erb
+++ b/app/views/application/_markdown_field.html.erb
@@ -19,8 +19,9 @@
 
       <div class="hott-markdown-preview"
         data-preview="govspeak"
-        data-preview-for="#<%= "#{form.object_name}-#{field_name}-field".gsub('_', '-') %>">
-        <%= form.object.preview(field_name) if form.object.respond_to?(:preview) %>
+        data-preview-for="#<%= "#{form.object_name}-#{field_name}-field".gsub('_', '-') %>"
+        <%= %(data-preview-linkify-code-references="true").html_safe if linkify_code_references %>>
+        <%= form.object.preview(field_name, linkify_code_references:) if form.object.respond_to?(:preview) %>
       </div>
     </div>
   </div>

--- a/app/views/description_intercepts/_form.html.erb
+++ b/app/views/description_intercepts/_form.html.erb
@@ -148,7 +148,8 @@
                             :message,
                             label: { text: "Guidance message" },
                             hint: { text: "Shown to the trader-facing frontend when this intercept matches." },
-                            rows: 5 do %>
+                            rows: 5,
+                            linkify_code_references: true do %>
       <%= govuk_details(summary_text: "Markdown and automatic short code links") do %>
         <p class="govuk-body">
           Short codes are automatically rendered as links in the frontend. You do not need to add markdown links for

--- a/app/webpacker/javascripts/markdown-preview.js
+++ b/app/webpacker/javascripts/markdown-preview.js
@@ -8,7 +8,10 @@ document.addEventListener("DOMContentLoaded", function() {
           "Content-Type": "application/json",
           "X-CSRF-Token": this.fetchCSRFToken(),
         },
-        body: JSON.stringify({ govspeak: content.value }),
+        body: JSON.stringify({
+          govspeak: content.value,
+          linkify_code_references: output.dataset.previewLinkifyCodeReferences === "true",
+        }),
       })
         .then(function(response) {
           return response.json();

--- a/spec/helpers/govuk_helper_spec.rb
+++ b/spec/helpers/govuk_helper_spec.rb
@@ -97,9 +97,11 @@ RSpec.describe GovukHelper do
   describe "govuk_markdown_area" do
     subject do
       govuk_form_for(model.new, url: "/") do |form|
-        govuk_markdown_area form, :name
+        govuk_markdown_area form, :name, **markdown_options
       end
     end
+
+    let(:markdown_options) { {} }
 
     it { is_expected.to have_css ".govuk-grid-row .govuk-grid-column-one-half", count: 2 }
     it { is_expected.to have_css ".govuk-grid-column-one-half textarea.govuk-textarea" }
@@ -108,5 +110,11 @@ RSpec.describe GovukHelper do
     it { is_expected.to have_css ".hott-markdown-preview p", text: "preview content" }
     it { is_expected.to have_css '.hott-markdown-preview[data-preview="govspeak"]' }
     it { is_expected.to have_css '.hott-markdown-preview[data-preview-for="#person-name-field"]' }
+
+    context "when code reference linkification is enabled" do
+      let(:markdown_options) { { linkify_code_references: true } }
+
+      it { is_expected.to have_css '.hott-markdown-preview[data-preview-linkify-code-references="true"]' }
+    end
   end
 end

--- a/spec/models/govspeak_preview_spec.rb
+++ b/spec/models/govspeak_preview_spec.rb
@@ -27,5 +27,93 @@ RSpec.describe GovspeakPreview do
     it "supports links to new windows" do
       expect(rendered).to match '<a href="/" target="_blank">link</a>'
     end
+
+    context "when code reference linkification is enabled" do
+      subject(:preview) { described_class.new content, linkify_code_references: true }
+
+      let(:content) { "Chapter 01, 0101, 010121, 01012100 and 0101210000" }
+      let(:page) { Capybara.string(rendered) }
+
+      it "links chapter references to frontend search" do
+        expect(page).to have_link "Chapter 01", href: "#{TradeTariffAdmin.frontend_host}/search?q=01"
+      end
+
+      it "links heading references to frontend search" do
+        expect(page).to have_link "0101", href: "#{TradeTariffAdmin.frontend_host}/search?q=0101"
+      end
+
+      it "renders heading links with the GOV.UK link class" do
+        link = page.find_link("0101", href: "#{TradeTariffAdmin.frontend_host}/search?q=0101")
+
+        expect(link[:class]).to include("govuk-link")
+      end
+
+      it "renders heading links with new tab attributes" do
+        link = page.find_link("0101", href: "#{TradeTariffAdmin.frontend_host}/search?q=0101")
+
+        expect(link[:target]).to eq("_blank")
+      end
+
+      it "renders heading links with reverse tabnabbing protection" do
+        link = page.find_link("0101", href: "#{TradeTariffAdmin.frontend_host}/search?q=0101")
+
+        expect(link[:rel]).to eq("noreferrer noopener")
+      end
+
+      it "adds visually hidden new tab text to heading links" do
+        link = page.find_link("0101", href: "#{TradeTariffAdmin.frontend_host}/search?q=0101")
+
+        expect(link).to have_css(".govuk-visually-hidden", text: "(opens in new tab)", visible: :all)
+      end
+
+      it "links subheading references to frontend search" do
+        expect(page).to have_link "010121", href: "#{TradeTariffAdmin.frontend_host}/search?q=010121"
+      end
+
+      it "links 8 digit commodity references to frontend search" do
+        expect(page).to have_link "01012100", href: "#{TradeTariffAdmin.frontend_host}/search?q=01012100"
+      end
+
+      it "links 10 digit commodity references to frontend search" do
+        expect(page).to have_link "0101210000", href: "#{TradeTariffAdmin.frontend_host}/search?q=0101210000"
+      end
+    end
+
+    context "when code reference linkification is enabled for a list item starting with a heading" do
+      subject(:preview) { described_class.new content, linkify_code_references: true }
+
+      let(:content) { "- 0101 is specific to horses" }
+      let(:page) { Capybara.string(rendered) }
+
+      it "links the heading reference" do
+        expect(page).to have_link "0101", href: "#{TradeTariffAdmin.frontend_host}/search?q=0101"
+      end
+    end
+
+    context "when code reference linkification is enabled for a 4 digit quantity followed by a unit" do
+      subject(:preview) { described_class.new content, linkify_code_references: true }
+
+      let(:content) { "- cylinder capacity <= 1000 cm3" }
+      let(:page) { Capybara.string(rendered) }
+
+      it "does not link the quantity" do
+        expect(page).to have_no_link "1000"
+      end
+    end
+
+    context "when code reference linkification is enabled for content with an existing markdown link" do
+      subject(:preview) { described_class.new content, linkify_code_references: true }
+
+      let(:content) { "[0101](https://example.com/existing) and 010121" }
+      let(:page) { Capybara.string(rendered) }
+
+      it "does not replace existing links" do
+        expect(page).to have_link "0101", href: "https://example.com/existing"
+      end
+
+      it "links plain text code references after an existing link" do
+        expect(page).to have_link "010121", href: "#{TradeTariffAdmin.frontend_host}/search?q=010121"
+      end
+    end
   end
 end

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -211,7 +211,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
 
       expect(page).to have_css ".govuk-grid-row .govuk-grid-column-one-half", count: 2
       expect(page).to have_css 'textarea.govuk-textarea[name="description_intercept[message]"]'
-      expect(page).to have_css '.hott-markdown-preview[data-preview="govspeak"][data-preview-for="#description-intercept-message-field"]'
+      expect(page).to have_css '.hott-markdown-preview[data-preview="govspeak"][data-preview-for="#description-intercept-message-field"][data-preview-linkify-code-references="true"]'
     end
 
     it "explains markdown and automatic short code links in a details component" do

--- a/spec/requests/govspeak_controller_spec.rb
+++ b/spec/requests/govspeak_controller_spec.rb
@@ -14,6 +14,18 @@ RSpec.describe GovspeakController do
     it "converts markdown to html" do
       expect(rendered_page).to have_attributes body: /h1/
     end
+
+    context "when code reference linkification is requested" do
+      before do
+        post govspeak_path(format: :json), params: { govspeak: "Chapter 01", linkify_code_references: true }
+      end
+
+      it "returns html with goods nomenclature code links" do
+        json = JSON.parse(rendered_page.body)
+
+        expect(Capybara.string(json.fetch("govspeak"))).to have_link "Chapter 01", href: "#{TradeTariffAdmin.frontend_host}/search?q=01"
+      end
+    end
   end
 
   context "when unauthorised" do


### PR DESCRIPTION
### Ticket

BAU


https://github.com/user-attachments/assets/e4e63a8d-509f-4c13-bed2-96195854c8e0


### What?

- [x] Add opt-in code reference linkification for Govspeak previews
- [x] Enable link rendering for description intercept guidance previews
- [x] Render generated links using GOV.UK new-tab guidance
- [x] Keep existing markdown links untouched
- [x] Cover chapters, headings, subheadings and commodity references

### Why?

Description intercept guidance tells admins that short codes are automatically linked on the frontend, but the admin preview did not show that behaviour. The preview now uses the same kind of DOM-aware linkification so admins can see direct goods nomenclature links before saving without accidentally rewriting links they added themselves.