### PR TITLE
BAU: Linkify section note previews

### DIFF
--- a/app/models/section_note.rb
+++ b/app/models/section_note.rb
@@ -11,7 +11,8 @@ class SectionNote
 
   def section_title; end
 
-  def preview(...)
-    Govspeak::Document.new(content, sanitize: true).to_html.html_safe
+  def preview(field_name = :content, **options)
+    content = public_send(field_name)
+    GovspeakPreview.new(content, **options).render if content.present?
   end
 end

--- a/app/views/notes/sections/section_notes/_fields.html.erb
+++ b/app/views/notes/sections/section_notes/_fields.html.erb
@@ -1,3 +1,3 @@
-<%= govuk_markdown_area f, :content, rows: 12 %>
+<%= govuk_markdown_area f, :content, rows: 12, linkify_code_references: true %>
 
 <%= submit_and_back_buttons f, notes_sections_path %>

--- a/spec/features/section_notes_spec.rb
+++ b/spec/features/section_notes_spec.rb
@@ -20,6 +20,8 @@ RSpec.describe "Section Note management" do
 
     specify do
       ensure_on new_notes_section_section_note_path(section)
+      expect(page).to have_css '.hott-markdown-preview[data-preview-linkify-code-references="true"]'
+
       fill_in "Content", with: section_note.content
       click_button "Create Section note"
       verify current_path == dashboard_path
@@ -44,6 +46,8 @@ RSpec.describe "Section Note management" do
 
     specify do
       ensure_on edit_notes_section_section_note_path(section)
+      expect(page).to have_css '.hott-markdown-preview[data-preview-linkify-code-references="true"]'
+
       fill_in "Content", with: "new content"
       click_button "Update Section note"
       verify current_path == dashboard_path

--- a/spec/models/section_note_spec.rb
+++ b/spec/models/section_note_spec.rb
@@ -1,0 +1,12 @@
+RSpec.describe SectionNote do
+  describe "#preview" do
+    subject(:preview) { section_note.preview(:content, linkify_code_references: true) }
+
+    let(:section_note) { described_class.new(content: "Chapter 01 and 0101") }
+    let(:page) { Capybara.string(preview) }
+
+    it "links code references when enabled" do
+      expect(page).to have_link "Chapter 01", href: "#{TradeTariffAdmin.frontend_host}/search?q=01"
+    end
+  end
+end


### PR DESCRIPTION
## What changed

- Enabled automatic goods code linkification for section note markdown previews.
- Updated `SectionNote#preview` to use the shared `GovspeakPreview` path, matching description intercept previews.
- Added coverage for section note preview linkification and the section note form preview data attribute.

## Why

Section note previews should show goods nomenclature code links in the same way as description intercept message previews, so admins see the same behaviour while editing.