### PR TITLE
AI-517: Fix heading code linkification in section note previews

### DIFF
--- a/app/models/goods_nomenclature_code_linkifier.rb
+++ b/app/models/goods_nomenclature_code_linkifier.rb
@@ -3,6 +3,7 @@ class GoodsNomenclatureCodeLinkifier
 
   SPACED_TERMINATORS = /(?=\s|;|,|$|\.|\)|\z)/
   PUNCTUATION_TERMINATORS = /(?=;|,|$|\)|\z|<br>|<\/br>)/
+  COMBINED_TERMINATORS = /(?=\s|;|,|$|\.|\)|\z|<br>|<\/br>)/
   CODE_BOUNDARY_START = /(?<![A-Za-z0-9.\/-])/
   CODE_BOUNDARY_END = /(?![A-Za-z0-9.\/-])/
   HEADING_CODE = /(?:0[1-9]|[1-9]\d)(?:0[1-9]|[1-9]\d)/
@@ -13,8 +14,9 @@ class GoodsNomenclatureCodeLinkifier
     Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\s(\d{2})\s(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}#{match[3]}" }),
     Pattern.new(/#{CODE_BOUNDARY_START}(\d{4})\s(\d{2})#{SPACED_TERMINATORS}/, ->(match) { "#{match[1]}#{match[2]}" }),
     Pattern.new(/#{CODE_BOUNDARY_START}(\d{10}|\d{8}|\d{6}|\d{2})#{CODE_BOUNDARY_END}/, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(\d{2})(?=\.\s|\.\z)/, ->(match) { match[1] }),
     Pattern.new(/\A(#{HEADING_CODE})#{SPACED_TERMINATORS}/, ->(match) { match[1] }),
-    Pattern.new(/#{CODE_BOUNDARY_START}(#{HEADING_CODE})#{PUNCTUATION_TERMINATORS}/, ->(match) { match[1] }),
+    Pattern.new(/#{CODE_BOUNDARY_START}(#{HEADING_CODE})#{COMBINED_TERMINATORS}/, ->(match) { match[1] }),
   ].freeze
 
   def initialize(html, frontend_host: TradeTariffAdmin.frontend_host, service_path: nil)
@@ -74,7 +76,7 @@ private
 
   def link_for(text, code)
     href = "#{@frontend_host}#{@service_path}/search?#{Rack::Utils.build_query(q: code)}"
-    link_text = %(#{CGI.escapeHTML(text)} <span class="govuk-visually-hidden">(opens in new tab)</span>)
+    link_text = %(#{CGI.escapeHTML(text)}<span class="govuk-visually-hidden"> (opens in new tab)</span>)
 
     %(<a class="govuk-link" href="#{CGI.escapeHTML(href)}" rel="noreferrer noopener" target="_blank">#{link_text}</a>)
   end

--- a/spec/models/goods_nomenclature_code_linkifier_spec.rb
+++ b/spec/models/goods_nomenclature_code_linkifier_spec.rb
@@ -1,0 +1,66 @@
+RSpec.describe GoodsNomenclatureCodeLinkifier do
+  let(:frontend_host) { "https://example.com" }
+
+  def render(html)
+    described_class.new(html, frontend_host:, service_path: "").render
+  end
+
+  def page(html)
+    Capybara.string(render(html))
+  end
+
+  describe "#render" do
+    context "with a Chapter keyword reference" do
+      it "linkifies the chapter" do
+        expect(page("<p>goods of Chapter 71</p>")).to have_link("Chapter 71", href: "https://example.com/search?q=71")
+      end
+    end
+
+    context "with multiple 4-digit heading codes using mixed separators" do
+      let(:html) { "<p>(headings 3207 to 3210, 3212, 3213 or 3215)</p>" }
+      let(:rendered) { page(html) }
+
+      it "linkifies codes followed by a space and word" do
+        expect(rendered).to have_link("3213", href: "https://example.com/search?q=3213")
+      end
+
+      it "linkifies codes followed by a comma" do
+        expect(rendered).to have_link("3212", href: "https://example.com/search?q=3212")
+      end
+
+      it "linkifies codes followed by a closing parenthesis" do
+        expect(rendered).to have_link("3215", href: "https://example.com/search?q=3215")
+      end
+    end
+
+    context "with a 2-digit chapter code at the end of a sentence" do
+      let(:html) { "<p>excluded from Chapters 72 to 81.</p>" }
+
+      it "linkifies the chapter code" do
+        expect(page(html)).to have_link("81", href: "https://example.com/search?q=81")
+      end
+
+      it "does not include the period in the link" do
+        expect(render(html)).to match(%r{</a>\.})
+      end
+    end
+
+    context "with a decimal number" do
+      it "does not linkify numbers before a decimal point" do
+        expect(page("<p>a thickness not exceeding one-tenth of the width exceeds 10.5mm</p>")).not_to have_link("10")
+      end
+    end
+
+    context "with a code inside an existing link" do
+      it "does not double-linkify" do
+        html = '<p><a href="/foo">3606</a></p>'
+
+        expect(render(html)).not_to match(%r{<a [^>]*>.*<a}m)
+      end
+    end
+
+    it "places the space inside the visually hidden span so there is no trailing whitespace in the link text" do
+      expect(render("<p>heading 3606</p>")).to include('3606<span class="govuk-visually-hidden"> (opens in new tab)</span>')
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

AI-517

### What?

I have added/removed/altered:

- [x] Updated `GoodsNomenclatureCodeLinkifier` to linkify 4-digit heading codes that are followed by a space and a word (e.g. `3207 to 3210` — previously only `3207` would be missed)
- [x] Added a new pattern to linkify 2-digit chapter codes at the end of a sentence (e.g. `78 to 81.` — previously `81` would be missed because of the full stop)
- [x] Moved the space in link text inside the visually hidden `<span>` so there's no trailing whitespace between a linked code and the punctuation that follows it (e.g. `3215)` no longer renders as `3215 )`)
- [x] Added a dedicated spec file for `GoodsNomenclatureCodeLinkifier` covering all the above cases

### Why?

I am doing this because:

- The section note preview was silently skipping heading codes whenever they appeared before words like "to" or "or" (e.g. in ranges like "headings 3207 to 3210, 3212, 3213 or 3215") — only the codes before commas or closing brackets were being linked
- Chapter codes at the very end of a sentence (followed by a full stop) were also never linked, because the full stop was treated as part of a decimal number guard rather than sentence punctuation
- The existing link format added a trailing space inside the anchor element, which caused a visible gap between the linked code and any immediately following punctuation like `)` or `,`

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Low risk — this is a pure display change affecting only the preview panel in the section note editor; no data is written or read differently
- The linkification logic runs client-side on already-rendered HTML, so there is no impact on stored content or API responses
- The change is additive: codes that were already being linked continue to work exactly as before, and only previously-missed codes are newly linked

*linkified behavior after change for CustomsTariffSectionNotes*
<img width="721" height="1032" alt="image" src="https://github.com/user-attachments/assets/95409f96-db26-4194-bb75-6102d5e532ff" />
