### PR TITLE
Restore update file downloads for operators

### DIFF
--- a/app/controllers/tariff_updates_controller.rb
+++ b/app/controllers/tariff_updates_controller.rb
@@ -10,7 +10,7 @@ class TariffUpdatesController < AuthenticatedController
   end
 
   def download
-    authorize Update, :download?
+    authorize Update, :schedule_download?
     @download = Download.build
     @download.save
 

--- a/app/policies/update_policy.rb
+++ b/app/policies/update_policy.rb
@@ -1,15 +1,18 @@
-# Updates (Daily Tariff Files): SUPERADMIN destructive actions, TECHNICAL_OPERATOR/AUDITOR read-only, HMRC_ADMIN hidden, GUEST hidden
+# Updates (Daily Tariff Files): SUPERADMIN destructive actions, TECHNICAL_OPERATOR/AUDITOR extract/read-only, HMRC_ADMIN hidden, GUEST hidden
 class UpdatePolicy < ApplicationPolicy
   def index?
-    technical_operator? || auditor?
+    safe_update_access?
   end
 
   def show?
-    technical_operator? || auditor?
+    safe_update_access?
   end
 
-  # Actions like download, apply_and_clear_cache, resend_cds_update_notification
-  def download?
+  def download_file?
+    safe_update_access?
+  end
+
+  def schedule_download?
     superadmin?
   end
 
@@ -19,5 +22,11 @@ class UpdatePolicy < ApplicationPolicy
 
   def resend_cds_update_notification?
     superadmin?
+  end
+
+private
+
+  def safe_update_access?
+    technical_operator? || auditor?
   end
 end

--- a/app/views/tariff_updates/_actions.html.erb
+++ b/app/views/tariff_updates/_actions.html.erb
@@ -6,7 +6,7 @@
   <br>
 <% end %>
 
-<% if tariff_update.filename.present? && policy(Update).download? %>
+<% if tariff_update.filename.present? && policy(Update).download_file? %>
   <%= link_to "Download #{tariff_update.filename}", tariff_update.file_presigned_url, target: "_blank", title: tariff_update.filename %>
 <% end %>
 

--- a/app/views/tariff_updates/index.html.erb
+++ b/app/views/tariff_updates/index.html.erb
@@ -2,10 +2,10 @@
   <h2>Tariff Updates - <%= service_update_type %></h2>
 </div>
 
-<% if policy(Update).download? || policy(Update).apply_and_clear_cache? %>
+<% if policy(Update).schedule_download? || policy(Update).apply_and_clear_cache? %>
   <div class="govuk-grid-row">
     <div class="govuk-button-group">
-      <% if policy(Update).download? %>
+      <% if policy(Update).schedule_download? %>
         <%= button_to 'Download', download_tariff_updates_path, method: :post, class: 'govuk-button' %>
       <% end %>
       <% if policy(Update).apply_and_clear_cache? %>

--- a/app/views/tariff_updates/show.html.erb
+++ b/app/views/tariff_updates/show.html.erb
@@ -10,10 +10,8 @@
       <p class="govuk-body"><%= number_to_human_size(@tariff_update.filesize) %></p>
     </dd>
     <dd class="govuk-summary-list__actions">
-      <% if policy(Update).download? %>
-        <a class="govuk-link" href="#">
-          <%= link_to "Download", @tariff_update.file_presigned_url, target: "_blank", title: @tariff_update.filename %>
-        </a>
+      <% if @tariff_update.filename.present? && policy(Update).download_file? %>
+        <%= link_to "Download", @tariff_update.file_presigned_url, class: "govuk-link", target: "_blank", title: @tariff_update.filename %>
       <% end %>
     </dd>
   </div>

--- a/spec/policies/rbac_comprehensive_spec.rb
+++ b/spec/policies/rbac_comprehensive_spec.rb
@@ -145,7 +145,8 @@ RSpec.describe "RBAC Comprehensive Rules" do
     it "allows read-only access to updates", :aggregate_failures do
       expect(UpdatePolicy.new(auditor, Update.new).index?).to be(true)
       expect(UpdatePolicy.new(auditor, Update.new).show?).to be(true)
-      expect(UpdatePolicy.new(auditor, Update.new).download?).to be(false)
+      expect(UpdatePolicy.new(auditor, Update.new).download_file?).to be(true)
+      expect(UpdatePolicy.new(auditor, Update.new).schedule_download?).to be(false)
     end
 
     it "allows read-only access to rollbacks", :aggregate_failures do
@@ -212,7 +213,13 @@ RSpec.describe "RBAC Comprehensive Rules" do
     it "allows read-only access to updates", :aggregate_failures do
       expect(UpdatePolicy.new(technical_operator, Update.new).index?).to be(true)
       expect(UpdatePolicy.new(technical_operator, Update.new).show?).to be(true)
-      expect(UpdatePolicy.new(technical_operator, Update.new).download?).to be(false)
+      expect(UpdatePolicy.new(technical_operator, Update.new).download_file?).to be(true)
+    end
+
+    it "denies dangerous update actions", :aggregate_failures do
+      expect(UpdatePolicy.new(technical_operator, Update.new).schedule_download?).to be(false)
+      expect(UpdatePolicy.new(technical_operator, Update.new).apply_and_clear_cache?).to be(false)
+      expect(UpdatePolicy.new(technical_operator, Update.new).resend_cds_update_notification?).to be(false)
     end
 
     it "allows read-only access to rollbacks", :aggregate_failures do
@@ -261,11 +268,10 @@ RSpec.describe "RBAC Comprehensive Rules" do
     end
 
     it "allows full access to updates" do
-      expect([
-        UpdatePolicy.new(superadmin, Update.new).index?,
-        UpdatePolicy.new(superadmin, Update.new).show?,
-        UpdatePolicy.new(superadmin, Update.new).apply_and_clear_cache?,
-      ]).to all(be(true))
+      permissions = %i[index? show? download_file? schedule_download? apply_and_clear_cache?]
+      policy = UpdatePolicy.new(superadmin, Update.new)
+
+      expect(permissions.map { |permission| policy.public_send(permission) }).to all(be(true))
     end
 
     it "allows full access to rollbacks" do

--- a/spec/policies/update_policy_spec.rb
+++ b/spec/policies/update_policy_spec.rb
@@ -31,7 +31,34 @@ RSpec.describe UpdatePolicy do
     end
   end
 
-  permissions :download?, :apply_and_clear_cache?, :resend_cds_update_notification? do
+  permissions :download_file? do
+    it "grants access to superadmin" do
+      user = create(:user, :superadmin)
+      expect(update_policy).to permit(user, update)
+    end
+
+    it "grants access to technical operator" do
+      user = create(:user, :technical_operator)
+      expect(update_policy).to permit(user, update)
+    end
+
+    it "grants access to auditor" do
+      user = create(:user, :auditor)
+      expect(update_policy).to permit(user, update)
+    end
+
+    it "denies access to hmrc admin" do
+      user = create(:user, :hmrc_admin)
+      expect(update_policy).not_to permit(user, update)
+    end
+
+    it "denies access to guest user" do
+      user = create(:user, :guest)
+      expect(update_policy).not_to permit(user, update)
+    end
+  end
+
+  permissions :schedule_download?, :apply_and_clear_cache?, :resend_cds_update_notification? do
     it "grants access to superadmin" do
       user = create(:user, :superadmin)
       expect(update_policy).to permit(user, update)

--- a/spec/requests/tariff_updates_controller_spec.rb
+++ b/spec/requests/tariff_updates_controller_spec.rb
@@ -121,6 +121,15 @@ RSpec.describe TariffUpdatesController do
 
       expect(response.body).not_to include("Rollback to 2026-04-01")
     end
+
+    it "shows review inserts and direct update download links without destructive actions", :aggregate_failures do
+      stub_tariff_updates_index([rollbackable_update])
+
+      get tariff_updates_path
+
+      expect(response.body).to include("Review inserts", "Download 2026-04-01_TGB22037.xml")
+      expect(response.body).not_to include("Apply & Clear Caches", "Resend CDS Update email")
+    end
   end
 
   context "when auditor" do
@@ -159,20 +168,20 @@ RSpec.describe TariffUpdatesController do
     context "when technical operator" do
       let(:current_user) { create(:user, :technical_operator) }
 
-      it "hides the download link" do
+      it "shows the download link" do
         make_request
 
-        expect(response.body).not_to include("https://example.com/2026-04-01_TGB22037.xml")
+        expect(response.body).to include("https://example.com/2026-04-01_TGB22037.xml")
       end
     end
 
     context "when auditor" do
       let(:current_user) { create(:user, :auditor) }
 
-      it "hides the download link" do
+      it "shows the download link" do
         make_request
 
-        expect(response.body).not_to include("https://example.com/2026-04-01_TGB22037.xml")
+        expect(response.body).to include("https://example.com/2026-04-01_TGB22037.xml")
       end
     end
   end


### PR DESCRIPTION
## What
- Split update file download permission from the backend scheduled download action.
- Allow Technical Operator and Auditor roles to view update data and download existing update files.
- Keep scheduled downloads, apply/cache clear, and CDS notification resend behind Super Admin.

## Why
Technical Operator lost access to safe update file downloads when `UpdatePolicy#download?` became Super Admin-only for dangerous update operations. The same policy method was used for both existing-file download links and backend-triggering admin actions.

## Verification
- `bin/yarn install --frozen-lockfile --ignore-engines` to refresh missing local JS dependencies.
- `RAILS_ENV=test bin/webpack` to rebuild the test pack manifest.
- `bundle exec rspec spec/policies/update_policy_spec.rb spec/policies/rbac_comprehensive_spec.rb spec/requests/tariff_updates_controller_spec.rb`
- `bundle exec rubocop app/controllers/tariff_updates_controller.rb app/policies/update_policy.rb spec/policies/rbac_comprehensive_spec.rb spec/policies/update_policy_spec.rb spec/requests/tariff_updates_controller_spec.rb`
- `bundle exec rspec`

Note: `bundle exec erb_lint ...` is not available in the current bundle (`command not found: erb_lint`).