### PR TITLE
AI-663: Add description intercept bulk import UI

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -40,7 +40,9 @@ gem "logstash-event"
 
 # Misc
 gem "bootsnap", require: false
+gem "csv", "~> 3.3"
 gem "nokogiri"
+gem "rubyzip"
 
 group :development, :test do
   gem "brakeman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,6 +110,7 @@ GEM
       bigdecimal
       rexml
     crass (1.0.6)
+    csv (3.3.5)
     database_cleaner (2.1.0)
       database_cleaner-active_record (>= 2, < 3)
     database_cleaner-active_record (2.2.2)
@@ -430,6 +431,7 @@ GEM
     ruby-lsp-rails (0.4.8)
       ruby-lsp (>= 0.26.0, < 0.27.0)
     ruby-progressbar (1.13.0)
+    rubyzip (3.3.0)
     sanitize (7.0.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.16.8)
@@ -504,6 +506,7 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
+  csv (~> 3.3)
   database_cleaner
   dotenv-rails
   factory_bot_rails
@@ -530,6 +533,7 @@ DEPENDENCIES
   rspec_junit_formatter
   rubocop-govuk
   ruby-lsp-rails
+  rubyzip
   shoulda-matchers
   simplecov
   webmock

--- a/app/controllers/description_intercepts_controller.rb
+++ b/app/controllers/description_intercepts_controller.rb
@@ -5,7 +5,9 @@ class DescriptionInterceptsController < AuthenticatedController
     authorize DescriptionIntercept, :index?
 
     respond_to do |format|
-      format.html
+      format.html do
+        load_description_intercept_templates
+      end
       format.json { render json: DescriptionIntercept.listing(params) }
     end
   end
@@ -63,6 +65,31 @@ class DescriptionInterceptsController < AuthenticatedController
     redirect_to description_intercepts_path, alert: "Description intercept not found."
   end
 
+  def bulk_import
+    authorize DescriptionIntercept, :update?
+
+    file_result = DescriptionInterceptImportFile.new(description_intercept_import_file).call
+    if file_result.success?
+      import_result = DescriptionIntercept.bulk_import(file_result.csv_content)
+      return redirect_to description_intercepts_path, notice: import_result.message if import_result.success?
+
+      @bulk_import_errors = import_result.errors
+    else
+      @bulk_import_errors = file_result.errors
+    end
+
+    load_description_intercept_templates
+    render :index, status: :unprocessable_content
+  end
+
+  def example_import
+    authorize DescriptionIntercept, :index?
+
+    send_data "term,aliases,template\ngift,\"present,gifts\",generic\n",
+              filename: "description-intercepts-example.csv",
+              type: "text/csv"
+  end
+
 private
 
   def load_description_intercept
@@ -85,10 +112,22 @@ private
     end
   end
 
+  def load_description_intercept_templates
+    @description_intercept_templates = AdminConfiguration.find("description_intercept_templates").value
+  rescue Faraday::Error => e
+    Rails.logger.error("Failed to fetch description intercept templates: #{e.message}")
+    @description_intercept_templates = {}
+  end
+
+  def description_intercept_import_file
+    params.dig(:description_intercept_import, :file)
+  end
+
   def description_intercept_params
     permitted = params.require(:description_intercept).permit(
       :term,
       :excluded,
+      :message_header,
       :message,
       :escalate_to_webchat,
       aliases: [],
@@ -98,6 +137,7 @@ private
 
     permitted[:excluded] = ActiveModel::Type::Boolean.new.cast(permitted[:excluded]) if permitted.key?(:excluded)
     permitted[:escalate_to_webchat] = ActiveModel::Type::Boolean.new.cast(permitted[:escalate_to_webchat]) if permitted.key?(:escalate_to_webchat)
+    permitted[:message_header] = permitted[:message_header].presence if permitted.key?(:message_header)
     permitted[:message] = permitted[:message].presence if permitted.key?(:message)
     permitted[:aliases] = Array(permitted[:aliases]).reject(&:blank?)
     permitted[:sources] = Array(permitted[:sources]).reject(&:blank?)
@@ -114,6 +154,7 @@ private
     return if @description_intercept.blank?
 
     if @description_intercept.message.blank?
+      @description_intercept.message_header = nil
       @description_intercept.guidance_level = nil
       @description_intercept.guidance_location = nil
     else

--- a/app/models/admin_configuration.rb
+++ b/app/models/admin_configuration.rb
@@ -1,6 +1,17 @@
 class AdminConfiguration
   include ApiEntity
 
+  OBJECT_TEMPLATE_ATTRIBUTE_ORDER = %w[
+    message_header
+    message
+    sources
+    excluded
+    escalate_to_webchat
+    guidance_level
+    guidance_location
+    filter_prefixes
+  ].freeze
+
   uk_only
 
   attributes :name,
@@ -64,6 +75,20 @@ class AdminConfiguration
     sub_values[key]
   end
 
+  def object_templates
+    return {} unless config_type == "object_template" && value.is_a?(Hash)
+
+    value
+  end
+
+  def ordered_object_template_attributes(template)
+    attributes = template["attributes"] || {}
+    ordered_keys = OBJECT_TEMPLATE_ATTRIBUTE_ORDER & attributes.keys
+    remaining_keys = attributes.keys - ordered_keys
+
+    attributes.slice(*(ordered_keys + remaining_keys.sort))
+  end
+
   def display_value
     case config_type
     when "boolean"
@@ -83,6 +108,8 @@ class AdminConfiguration
       else
         label
       end
+    when "object_template"
+      object_templates.keys.join(", ")
     when "markdown"
       preview
     else

--- a/app/models/description_intercept.rb
+++ b/app/models/description_intercept.rb
@@ -11,6 +11,7 @@ class DescriptionIntercept
   }.freeze
 
   attributes :term,
+             :message_header,
              :message,
              :guidance_level,
              :guidance_location,
@@ -27,6 +28,7 @@ class DescriptionIntercept
     # search behaviour. Send one canonical payload for new and existing records:
     # blank guidance is explicit nils, and disabled filtering is an empty array.
     if attrs[:message].blank?
+      attrs[:message_header] = nil
       attrs[:message] = nil
       attrs[:guidance_level] = nil
       attrs[:guidance_location] = nil
@@ -52,6 +54,33 @@ class DescriptionIntercept
   rescue Faraday::Error => e
     Rails.logger.error("Failed to fetch description intercepts: #{e.message}")
     { data: [], pagination: { page: 1, per_page: 20, total_count: 0, total_pages: 0 } }
+  end
+
+  def self.bulk_import(csv_content)
+    response = api.post("admin/description_intercepts/bulk_import", bulk_import_payload(csv_content))
+    body = handle_body(response)
+    attributes = body.dig("data", "attributes") || {}
+
+    BulkImportResult.new(
+      created: attributes["created"].to_i,
+      updated: attributes["updated"].to_i,
+      total: attributes["total"].to_i,
+    )
+  rescue Faraday::UnprocessableEntityError => e
+    body = handle_body(e.response)
+
+    BulkImportResult.new(errors: Array(body["errors"]))
+  end
+
+  def self.bulk_import_payload(csv_content)
+    {
+      data: {
+        type: "description_intercept_bulk_import",
+        attributes: {
+          csv: csv_content,
+        },
+      },
+    }
   end
 
   def as_listing_json
@@ -110,5 +139,24 @@ class DescriptionIntercept
 
   def aliases_array
     Array(aliases).reject(&:blank?)
+  end
+
+  class BulkImportResult
+    attr_reader :created, :updated, :total, :errors
+
+    def initialize(created: 0, updated: 0, total: 0, errors: [])
+      @created = created
+      @updated = updated
+      @total = total
+      @errors = errors
+    end
+
+    def success?
+      errors.blank?
+    end
+
+    def message
+      "Imported #{total} #{'description intercept'.pluralize(total)}: #{created} created, #{updated} updated."
+    end
   end
 end

--- a/app/models/govspeak_preview.rb
+++ b/app/models/govspeak_preview.rb
@@ -1,4 +1,6 @@
 class GovspeakPreview
+  PLACEHOLDER_PATTERN = /\{\{[a-zA-Z][a-zA-Z0-9_]*\}\}/
+
   def initialize(content, linkify_code_references: false)
     @content = content.to_s
     @linkify_code_references = linkify_code_references
@@ -7,6 +9,7 @@ class GovspeakPreview
   def render
     html = govspeak.to_html
     html = GoodsNomenclatureCodeLinkifier.new(html).render if @linkify_code_references
+    html = highlight_placeholders(html)
 
     html.html_safe
   end
@@ -19,5 +22,23 @@ private
 
   def substituted_content
     ServiceHelper.replace_service_tags(@content)
+  end
+
+  def highlight_placeholders(html)
+    fragment = Nokogiri::HTML::DocumentFragment.parse(html)
+
+    fragment.xpath(".//text() | ./text()").each do |node|
+      next unless node.text.match?(PLACEHOLDER_PATTERN)
+
+      node.replace(Nokogiri::HTML::DocumentFragment.parse(highlight_placeholder_text(node.text)))
+    end
+
+    fragment.to_html
+  end
+
+  def highlight_placeholder_text(text)
+    CGI.escapeHTML(text).gsub(PLACEHOLDER_PATTERN) do |placeholder|
+      %(<span class="placeholder">#{placeholder}</span>)
+    end
   end
 end

--- a/app/services/description_intercept_import_file.rb
+++ b/app/services/description_intercept_import_file.rb
@@ -1,0 +1,114 @@
+require "csv"
+require "zip"
+
+class DescriptionInterceptImportFile
+  Result = Data.define(:csv_content, :errors) do
+    def success?
+      errors.blank?
+    end
+  end
+
+  def initialize(upload)
+    @upload = upload
+  end
+
+  def call
+    return failure("Choose a CSV or XLSX file to upload.") if upload.blank?
+
+    if xlsx?
+      xlsx_to_csv
+    elsif csv?
+      Result.new(csv_content: upload.read, errors: [])
+    else
+      failure("Upload a CSV or XLSX file.")
+    end
+  end
+
+private
+
+  attr_reader :upload
+
+  def csv?
+    extension == ".csv" || content_type == "text/csv"
+  end
+
+  def xlsx?
+    extension == ".xlsx" || content_type == "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+  end
+
+  def extension
+    File.extname(upload.original_filename.to_s).downcase
+  end
+
+  def content_type
+    upload.content_type.to_s
+  end
+
+  def xlsx_to_csv
+    rows = []
+
+    Zip::File.open_buffer(upload.read) do |zip|
+      workbook = xml(zip, "xl/workbook.xml")
+      return failure("Upload an XLSX file with a single worksheet.") unless workbook.css("sheet").one?
+
+      shared_strings = shared_strings(zip)
+      sheet = xml(zip, "xl/worksheets/sheet1.xml")
+      rows = sheet.css("sheetData row").map do |row|
+        cells = row.css("c")
+        next [] if cells.empty?
+
+        width = cells.map { |cell| column_index(cell["r"]) }.max
+        values = Array.new(width)
+        cells.each do |cell|
+          values[column_index(cell["r"]) - 1] = cell_value(cell, shared_strings)
+        end
+        values
+      end
+    end
+
+    Result.new(csv_content: CSV.generate { |csv| rows.each { |row| csv << row } }, errors: [])
+  rescue Zip::Error, Nokogiri::XML::SyntaxError
+    failure("Upload a valid CSV or XLSX file.")
+  end
+
+  def shared_strings(zip)
+    entry = zip.find_entry("xl/sharedStrings.xml")
+    return [] if entry.blank?
+
+    xml = Nokogiri::XML(entry.get_input_stream.read)
+    xml.remove_namespaces!
+    xml.css("si").map { |item| item.css("t").map(&:text).join }
+  end
+
+  def xml(zip, path)
+    entry = zip.find_entry(path)
+    raise Zip::Error, "#{path} not found" if entry.blank?
+
+    xml = Nokogiri::XML(entry.get_input_stream.read)
+    xml.remove_namespaces!
+    xml
+  end
+
+  def cell_value(cell, shared_strings)
+    value = cell.at_css("v")&.text
+
+    if cell["t"] == "s"
+      shared_strings[value.to_i]
+    elsif cell["t"] == "inlineStr"
+      cell.css("is t").map(&:text).join
+    else
+      value
+    end
+  end
+
+  def column_index(reference)
+    column = reference.to_s[/[A-Z]+/]
+    return 1 if column.blank?
+
+    column.chars.reduce(0) { |sum, char| (sum * 26) + char.ord - 64 }
+  end
+
+  def failure(message)
+    Result.new(csv_content: nil, errors: [{ "detail" => message }])
+  end
+end

--- a/app/views/classification_configurations/_form.html.erb
+++ b/app/views/classification_configurations/_form.html.erb
@@ -101,6 +101,12 @@
     </div>
 
     <div data-config-form-target="nestedSubOptionsContainer" data-sub-values="<%= sub_values.to_json %>"></div>
+  <% when "object_template" %>
+    <%= f.govuk_text_area :value,
+                          value: configuration.value.is_a?(Hash) ? JSON.pretty_generate(configuration.value) : configuration.value,
+                          label: { text: "Template configuration" },
+                          hint: { text: "Enter a JSON object keyed by template name. Each template needs label, description and attributes." },
+                          rows: 20 %>
   <% else %>
     <%= f.govuk_text_area :value,
                           label: { text: "Value" },

--- a/app/views/classification_configurations/index.html.erb
+++ b/app/views/classification_configurations/index.html.erb
@@ -52,6 +52,11 @@
                 <label class="govuk-label govuk-radios__label" for="ct-type-options">Options</label>
               </div>
               <div class="govuk-radios__item">
+                <input class="govuk-radios__input" id="ct-type-object-template" name="ct_type" type="radio" value="object_template"
+                       data-action="change->config-table#changeType" data-config-type="object_template">
+                <label class="govuk-label govuk-radios__label" for="ct-type-object-template">Object template</label>
+              </div>
+              <div class="govuk-radios__item">
                 <input class="govuk-radios__input" id="ct-type-string" name="ct_type" type="radio" value="string"
                        data-action="change->config-table#changeType" data-config-type="string">
                 <label class="govuk-label govuk-radios__label" for="ct-type-string">String</label>
@@ -97,6 +102,11 @@
                     <% sub_values = config.value.is_a?(Hash) ? (config.value["sub_values"] || {}) : {} %>
                     <% if sub_values.values.any?(&:present?) %>
                       <span class="govuk-body-s govuk-!-margin-0">(<%= sub_values.filter_map { |k, v| "#{k.tr('_', ' ')}: #{v}" if v.present? }.join(", ") %>)</span>
+                    <% end %>
+                  <% when "object_template" %>
+                    <%= pluralize(config.object_templates.size, "template") %>
+                    <% if config.object_templates.any? %>
+                      <span class="govuk-body-s govuk-!-margin-0">(<%= truncate(config.object_templates.keys.join(", "), length: 50) %>)</span>
                     <% end %>
                   <% else %>
                     <span class="govuk-body-s govuk-!-margin-0"><%= truncate(config.value.to_s, length: 50) %></span>

--- a/app/views/classification_configurations/show.html.erb
+++ b/app/views/classification_configurations/show.html.erb
@@ -157,6 +157,56 @@
             </div>
           </details>
         <% end %>
+      <% when "object_template" %>
+        <% if @configuration.object_templates.any? %>
+          <h2 class="govuk-heading-s">Object templates</h2>
+
+          <% @configuration.object_templates.each do |key, template| %>
+            <div class="govuk-summary-card govuk-!-margin-bottom-4">
+              <div class="govuk-summary-card__title-wrapper">
+                <h3 class="govuk-summary-card__title">
+                  <%= template["label"] %>
+                  <strong class="govuk-tag govuk-tag--grey"><%= key %></strong>
+                </h3>
+              </div>
+              <div class="govuk-summary-card__content">
+                <dl class="govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-0">
+                  <div class="govuk-summary-list__row">
+                    <dt class="govuk-summary-list__key">Description</dt>
+                    <dd class="govuk-summary-list__value"><%= template["description"] %></dd>
+                  </div>
+                  <% @configuration.ordered_object_template_attributes(template).each do |attribute, value| %>
+                    <div class="govuk-summary-list__row">
+                      <dt class="govuk-summary-list__key" title="<%= attribute %>"><%= attribute.humanize %></dt>
+                      <dd class="govuk-summary-list__value">
+                        <% case value %>
+                        <% when Array %>
+                          <% if value.any? %>
+                            <ul class="govuk-list govuk-list--bullet govuk-!-margin-bottom-0">
+                              <% value.each do |item| %>
+                                <li><%= item %></li>
+                              <% end %>
+                            </ul>
+                          <% else %>
+                            None
+                          <% end %>
+                        <% when TrueClass, FalseClass %>
+                          <strong class="govuk-tag govuk-tag--<%= value ? 'green' : 'grey' %>"><%= value ? "Yes" : "No" %></strong>
+                        <% when NilClass %>
+                          None
+                        <% else %>
+                          <%= value %>
+                        <% end %>
+                      </dd>
+                    </div>
+                  <% end %>
+                </dl>
+              </div>
+            </div>
+          <% end %>
+        <% else %>
+          <p class="govuk-body">No templates configured.</p>
+        <% end %>
       <% else %>
         <pre><%= @configuration.value %></pre>
       <% end %>

--- a/app/views/description_intercepts/_form.html.erb
+++ b/app/views/description_intercepts/_form.html.erb
@@ -19,14 +19,21 @@
                          hint: { text: "The term or phrase that should trigger this intercept." } %>
 
   <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Aliases</h2>
-  <div class="govuk-form-group">
+  <% aliases_error = description_intercept.errors[:aliases].first %>
+  <div class="govuk-form-group <%= 'govuk-form-group--error' if aliases_error.present? %>">
     <label class="govuk-label govuk-label--s" for="description-intercept-alias-field">Add an alias</label>
     <div id="description-intercept-alias-hint" class="govuk-hint">Optional alternative terms that should trigger this intercept.</div>
+    <% if aliases_error.present? %>
+      <p id="description-intercept-aliases-field-error" class="govuk-error-message">
+        <span class="govuk-visually-hidden">Error:</span>
+        <%= aliases_error %>
+      </p>
+    <% end %>
     <div class="govuk-button-group">
-      <input class="govuk-input govuk-!-width-one-half"
+      <input class="govuk-input govuk-!-width-one-half <%= 'govuk-input--error' if aliases_error.present? %>"
              id="description-intercept-alias-field"
              type="text"
-             aria-describedby="description-intercept-alias-hint"
+             aria-describedby="<%= aliases_error.present? ? 'description-intercept-aliases-field-error description-intercept-alias-hint' : 'description-intercept-alias-hint' %>"
              data-description-intercept-form-target="aliasInput"
              data-action="keydown.enter->description-intercept-form#addAlias">
       <button type="button" class="govuk-button govuk-button--secondary" data-action="click->description-intercept-form#addAlias">Add alias</button>
@@ -144,6 +151,10 @@
   <div data-description-intercept-form-target="guidanceFields"
        <%= 'style="display:none"'.html_safe unless Array(description_intercept.sources).include?("guided_search") %>>
     <h2 class="govuk-heading-m govuk-!-margin-bottom-2">Guidance</h2>
+    <%= f.govuk_text_field :message_header,
+                           label: { text: "Guidance message header" },
+                           hint: { text: "Optional heading shown with the guidance message." } %>
+
     <%= govuk_markdown_area f,
                             :message,
                             label: { text: "Guidance message" },

--- a/app/views/description_intercepts/index.html.erb
+++ b/app/views/description_intercepts/index.html.erb
@@ -22,6 +22,126 @@
       <%= link_to "New description intercept", new_description_intercept_path, class: "govuk-button" %>
     </div>
 
+    <details class="govuk-details govuk-!-margin-bottom-6" <%= "open" if @bulk_import_errors.present? %>>
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">Import description intercepts from a file</span>
+      </summary>
+
+      <div class="govuk-details__text">
+        <h2 class="govuk-heading-m">Bulk import description intercepts</h2>
+
+        <% if @bulk_import_errors.present? %>
+          <div class="govuk-error-summary" data-module="govuk-error-summary">
+            <div role="alert">
+              <h2 class="govuk-error-summary__title">There is a problem with the import</h2>
+              <div class="govuk-error-summary__body">
+                <ul class="govuk-list govuk-error-summary__list">
+                  <% @bulk_import_errors.each do |error| %>
+                    <li><%= error["detail"] || error[:detail] || error.to_s %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+          </div>
+        <% end %>
+
+        <% if @description_intercept_templates.present? %>
+          <h3 class="govuk-heading-s">Available templates</h3>
+          <p class="govuk-body">Review the list of available templates before preparing your file.</p>
+
+          <table class="govuk-table govuk-!-margin-bottom-6">
+            <caption class="govuk-table__caption govuk-table__caption--s">Description intercept templates</caption>
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th class="govuk-table__header" scope="col">Template</th>
+                <th class="govuk-table__header" scope="col">Description</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              <% @description_intercept_templates.each do |name, template| %>
+                <tr class="govuk-table__row">
+                  <th class="govuk-table__header" scope="row"><code><%= name %></code></th>
+                  <td class="govuk-table__cell"><%= template["description"] || template[:description] %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        <% else %>
+          <div class="govuk-warning-text">
+            <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
+            <strong class="govuk-warning-text__text">
+              <span class="govuk-visually-hidden">Warning</span>
+              No templates are currently configured.
+            </strong>
+          </div>
+          <p class="govuk-body">
+            Add templates in
+            <%= link_to "Classification configurations", classification_configuration_path("description_intercept_templates"), class: "govuk-link" %>
+            before importing description intercepts.
+          </p>
+        <% end %>
+
+        <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
+
+        <div class="govuk-grid-row">
+          <div class="govuk-grid-column-one-half">
+            <h3 class="govuk-heading-s">Prepare your file</h3>
+            <p class="govuk-body">
+              Upload a CSV file, or an XLSX file with a single worksheet. The first row must contain
+              <code>term</code>, <code>aliases</code> and <code>template</code> columns.
+            </p>
+
+            <table class="govuk-table govuk-table--small-text-until-tablet">
+              <caption class="govuk-table__caption govuk-table__caption--s">Example CSV</caption>
+              <thead class="govuk-table__head">
+                <tr class="govuk-table__row">
+                  <th class="govuk-table__header" scope="col">term</th>
+                  <th class="govuk-table__header" scope="col">aliases</th>
+                  <th class="govuk-table__header" scope="col">template</th>
+                </tr>
+              </thead>
+              <tbody class="govuk-table__body">
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">gift</td>
+                  <td class="govuk-table__cell">present, gifts</td>
+                  <td class="govuk-table__cell">generic</td>
+                </tr>
+              </tbody>
+            </table>
+
+            <p class="govuk-body">
+              <%= link_to "Download example CSV", example_import_description_intercepts_path, class: "govuk-link" %>
+            </p>
+          </div>
+
+          <div class="govuk-grid-column-one-half">
+            <h3 class="govuk-heading-s">Upload file</h3>
+
+            <%= form_with url: bulk_import_description_intercepts_path,
+                          scope: :description_intercept_import,
+                          multipart: true,
+                          method: :post do |f| %>
+              <div class="govuk-form-group">
+                <%= f.label :file, "Import file", class: "govuk-label" %>
+                <div id="description-intercept-import-file-hint" class="govuk-hint">
+                  Use CSV or single-sheet XLSX with columns: term, aliases, template. Separate multiple aliases with commas in the aliases cell.
+                </div>
+                <%= f.file_field :file,
+                                 class: "govuk-file-upload",
+                                 disabled: @description_intercept_templates.blank?,
+                                 aria: { describedby: "description-intercept-import-file-hint" },
+                                 accept: ".csv,.xlsx,text/csv,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet" %>
+              </div>
+
+              <%= f.submit "Import description intercepts",
+                           class: "govuk-button",
+                           disabled: @description_intercept_templates.blank? %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+    </details>
+
     <div class="govuk-grid-row"
          data-controller="description-intercept-table"
          data-description-intercept-table-url-value="<%= description_intercepts_path(format: :json) %>"

--- a/app/views/description_intercepts/show.html.erb
+++ b/app/views/description_intercepts/show.html.erb
@@ -34,8 +34,16 @@
   </div>
   <% if @description_intercept.guidance? %>
     <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Guidance message header</dt>
+      <dd class="govuk-summary-list__value"><%= @description_intercept.message_header.presence || "None" %></dd>
+    </div>
+    <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">Guidance</dt>
-      <dd class="govuk-summary-list__value"><%= @description_intercept.message %></dd>
+      <dd class="govuk-summary-list__value">
+        <div class="hott-markdown-preview">
+          <%= @description_intercept.preview(linkify_code_references: true) %>
+        </div>
+      </dd>
     </div>
   <% else %>
     <div class="govuk-summary-list__row">

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -89,6 +89,20 @@ $govuk-image-url-function: frontend-image-url;
   }
 }
 
+.placeholder {
+  display: inline;
+  background: govuk-functional-colour(focus);
+  color: govuk-functional-colour(text);
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  border-radius: 11px;
+  box-shadow:
+    inset 0.47em 0 0 0 govuk-colour("white"),
+    inset -0.47em 0 0 0 govuk-colour("white"),
+    inset 0 -0.05em 0 0 govuk-colour("white"),
+    inset 0 0.26em 0 0 govuk-colour("white");
+}
+
 .table {
   .align-right {
     text-align: right;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,7 +134,12 @@ Rails.application.routes.draw do
 
   resources :classification_configurations, param: :name, only: %i[index show edit update]
 
-  resources :description_intercepts, only: %i[index new create show edit update]
+  resources :description_intercepts, only: %i[index new create show edit update] do
+    collection do
+      get :example_import
+      post :bulk_import
+    end
+  end
   resources :goods_nomenclature_autocomplete_results, only: %i[index]
 
   namespace :green_lanes, path: "green_lanes" do

--- a/spec/models/admin_configuration_spec.rb
+++ b/spec/models/admin_configuration_spec.rb
@@ -208,6 +208,72 @@ RSpec.describe AdminConfiguration do
         expect(configuration.display_value).to eq("GPT-4.1 mini")
       end
     end
+
+    context "with object_template type" do
+      let(:attributes) do
+        {
+          name: "description_intercept_templates",
+          config_type: "object_template",
+          value: {
+            "vague" => {
+              "label" => "Vague term",
+              "description" => "Use when the term is too broad to classify safely.",
+              "attributes" => { "message_header" => "Placeholder guidance heading", "excluded" => true },
+            },
+          },
+        }
+      end
+
+      it "returns the template keys" do
+        expect(configuration.display_value).to eq("vague")
+      end
+    end
+  end
+
+  describe "#object_templates" do
+    context "with object_template type" do
+      let(:attributes) do
+        {
+          name: "description_intercept_templates",
+          config_type: "object_template",
+          value: {
+            "vague" => {
+              "label" => "Vague term",
+              "description" => "Use when the term is too broad to classify safely.",
+              "attributes" => { "message_header" => "Placeholder guidance heading", "excluded" => true },
+            },
+          },
+        }
+      end
+
+      it "returns the template map" do
+        expect(configuration.object_templates.keys).to eq(%w[vague])
+      end
+    end
+
+    context "with another type" do
+      it "returns an empty map" do
+        expect(configuration.object_templates).to eq({})
+      end
+    end
+  end
+
+  describe "#ordered_object_template_attributes" do
+    let(:template) do
+      {
+        "attributes" => {
+          "guidance_location" => "interstitial",
+          "custom" => "value",
+          "message" => "Message",
+          "excluded" => true,
+          "sources" => %w[guided_search],
+        },
+      }
+    end
+
+    it "uses the preferred domain order before unknown attributes" do
+      expect(configuration.ordered_object_template_attributes(template).keys).to eq(%w[message sources excluded guidance_location custom])
+    end
   end
 
   describe "#nested_selected_label" do

--- a/spec/models/description_intercept_spec.rb
+++ b/spec/models/description_intercept_spec.rb
@@ -1,4 +1,4 @@
-# rubocop:disable RSpec/ExampleLength
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
 RSpec.describe DescriptionIntercept do
   subject(:intercept) { described_class.new(attributes) }
 
@@ -8,6 +8,7 @@ RSpec.describe DescriptionIntercept do
       term: "animal feed",
       excluded: false,
       message: "Show this guidance message to the trader.",
+      message_header: "Check the term",
       guidance_level: "warning",
       guidance_location: "results",
       escalate_to_webchat: true,
@@ -74,6 +75,7 @@ RSpec.describe DescriptionIntercept do
     it "defaults guidance metadata when a message is present" do
       attrs = {
         message: "Show this guidance message to the trader.",
+        message_header: "Check the term",
         guidance_level: "warning",
         guidance_location: "results",
         filter_prefixes: %w[1201],
@@ -91,6 +93,7 @@ RSpec.describe DescriptionIntercept do
     it "clears guidance metadata when the message is blank" do
       attrs = {
         message: "",
+        message_header: "Stale header",
         guidance_level: "warning",
         guidance_location: "results",
         filter_prefixes: %w[1201],
@@ -101,6 +104,7 @@ RSpec.describe DescriptionIntercept do
 
       expect(attrs).to include(
         message: nil,
+        message_header: nil,
         guidance_level: nil,
         guidance_location: nil,
       )
@@ -157,6 +161,39 @@ RSpec.describe DescriptionIntercept do
     end
   end
 
+  describe ".bulk_import" do
+    it "posts CSV content to the backend and returns import counts" do
+      stub_api_request("/description_intercepts/bulk_import", :post)
+        .with { |request|
+          Rack::Utils.parse_nested_query(request.body).dig("data", "attributes", "csv") == "term,aliases,template\ngift,\"present,gifts\",generic\n"
+        }
+        .and_return(
+          status: 201,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: { data: { type: "description_intercept_bulk_import", attributes: { created: 1, updated: 2, total: 3 } } }.to_json,
+        )
+
+      result = described_class.bulk_import("term,aliases,template\ngift,\"present,gifts\",generic\n")
+
+      expect(result).to be_success
+      expect(result.message).to eq("Imported 3 description intercepts: 1 created, 2 updated.")
+    end
+
+    it "returns grouped backend validation errors" do
+      stub_api_request("/description_intercepts/bulk_import", :post)
+        .and_return(
+          status: 422,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: { errors: [{ detail: "foo and baz are not valid templates" }] }.to_json,
+        )
+
+      result = described_class.bulk_import("term,aliases,template\ngift,\"present,gifts\",foo\n")
+
+      expect(result).not_to be_success
+      expect(result.errors).to eq([{ "detail" => "foo and baz are not valid templates" }])
+    end
+  end
+
   describe ".find" do
     before do
       stub_api_request("/description_intercepts/123")
@@ -194,4 +231,4 @@ RSpec.describe DescriptionIntercept do
   end
 end
 
-# rubocop:enable RSpec/ExampleLength
+# rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations

--- a/spec/models/govspeak_preview_spec.rb
+++ b/spec/models/govspeak_preview_spec.rb
@@ -28,6 +28,24 @@ RSpec.describe GovspeakPreview do
       expect(rendered).to match '<a href="/" target="_blank">link</a>'
     end
 
+    context "when content includes template placeholders" do
+      let(:content) { "Contact HMRC and quote reference {{request_id}}" }
+      let(:page) { Capybara.string(rendered) }
+
+      it "highlights placeholders" do
+        expect(page).to have_css(".placeholder", text: "{{request_id}}")
+      end
+    end
+
+    context "when link text includes template placeholders" do
+      let(:content) { "Email: [{{enquiries_email}}](mailto:{{enquiries_email}})" }
+      let(:page) { Capybara.string(rendered) }
+
+      it "highlights placeholders in link text" do
+        expect(page).to have_css("a .placeholder", text: "{{enquiries_email}}")
+      end
+    end
+
     context "when code reference linkification is enabled" do
       subject(:preview) { described_class.new content, linkify_code_references: true }
 

--- a/spec/requests/classification_configurations_controller_spec.rb
+++ b/spec/requests/classification_configurations_controller_spec.rb
@@ -109,6 +109,24 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
               "deleted" => false,
             },
           },
+          {
+            type: "admin_configuration",
+            id: "description_intercept_templates",
+            attributes: {
+              "name" => "description_intercept_templates",
+              "value" => {
+                "vague" => {
+                  "label" => "Vague term",
+                  "description" => "Use when the term is too broad to classify safely.",
+                  "attributes" => { "excluded" => true },
+                },
+              },
+              "config_type" => "object_template",
+              "area" => "classification",
+              "description" => "Named templates used by the description intercept bulk import",
+              "deleted" => false,
+            },
+          },
         ],
       }.to_json,
     }
@@ -133,6 +151,8 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
       expect(rendered_page.body).to include("Classification Configurations")
       expect(rendered_page.body).to include("Expansion Prompt")
       expect(rendered_page.body).to include("Qa Enabled")
+      expect(rendered_page.body).to include("Object template")
+      expect(rendered_page.body).to include("1 template")
     end
 
     it "does not display a new configuration button" do
@@ -270,6 +290,44 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
       it "displays the string value in a pre block" do
         expect(rendered_page.body).to include("<pre>sk-abc...xyz</pre>")
+      end
+    end
+
+    context "with an object template config" do
+      let(:config_name) { "description_intercept_templates" }
+      let(:config_attributes) do
+        {
+          "name" => "description_intercept_templates",
+          "value" => {
+            "vague" => {
+              "label" => "Vague term",
+              "description" => "Use when the term is too broad to classify safely.",
+              "attributes" => {
+                "escalate_to_webchat" => false,
+                "excluded" => true,
+                "sources" => %w[guided_search fpo_search],
+              },
+            },
+          },
+          "config_type" => "object_template",
+          "area" => "classification",
+          "description" => "Named templates used by the description intercept bulk import",
+          "deleted" => false,
+        }
+      end
+
+      it "displays templates as a structured table", :aggregate_failures do
+        expect(rendered_page.body).to include("Object templates")
+        expect(rendered_page.body).to include("vague")
+        expect(rendered_page.body).to include("Vague term")
+        expect(rendered_page.body).to include("Description")
+        expect(rendered_page.body).to include("Escalate to webchat")
+        expect(rendered_page.body).to include("Excluded")
+        expect(rendered_page.body).to include("Yes")
+        expect(rendered_page.body).to include("No")
+        expect(rendered_page.body).to include("guided_search")
+        expect(rendered_page.body).not_to include(">escalate_to_webchat<")
+        expect(rendered_page.body).not_to include("<pre>{&quot;vague&quot;")
       end
     end
 
@@ -474,6 +532,32 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
       it "renders a text area" do
         expect(rendered_page.body).to include("sk-abc...xyz")
+      end
+    end
+
+    context "with a description intercept templates config" do
+      let(:config_name) { "description_intercept_templates" }
+      let(:config_attributes) do
+        {
+          "name" => "description_intercept_templates",
+          "value" => {
+            "vague" => {
+              "label" => "Vague term",
+              "description" => "Use when the term is too broad to classify safely.",
+              "attributes" => { "excluded" => true },
+            },
+          },
+          "config_type" => "object_template",
+          "area" => "classification",
+          "description" => "Named templates used by the description intercept bulk import",
+          "deleted" => false,
+        }
+      end
+
+      it "renders the template registry as editable JSON" do
+        expect(rendered_page.body).to include("Template configuration")
+        expect(rendered_page.body).to include("&quot;vague&quot;")
+        expect(rendered_page.body).to include("&quot;label&quot;")
       end
     end
 

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -1,4 +1,5 @@
-# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+# rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/MultipleMemoizedHelpers
+require "zip"
 RSpec.describe DescriptionInterceptsController, type: :request do
   subject(:rendered_page) { make_request && response }
 
@@ -11,6 +12,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       "term" => "animal feed",
       "excluded" => false,
       "message" => "Ask the trader to pick a more specific feed type.",
+      "message_header" => "Check the feed type",
       "guidance_level" => "warning",
       "guidance_location" => "results",
       "escalate_to_webchat" => true,
@@ -35,8 +37,56 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     }
   end
 
+  let(:template_config_attributes) do
+    {
+      "name" => "description_intercept_templates",
+      "config_type" => "object_template",
+      "area" => "classification",
+      "description" => "Named templates used by the description intercept bulk import.",
+      "value" => {
+        "generic" => {
+          "label" => "Generic guidance",
+          "description" => "Use when more detail is needed before a commodity code can be suggested.",
+          "attributes" => {
+            "excluded" => true,
+            "escalate_to_webchat" => false,
+            "filter_prefixes" => [],
+            "guidance_level" => "info",
+            "guidance_location" => "interstitial",
+            "message_header" => "We can't suggest a tariff code yet",
+            "message" => "To find the relevant commodity code, we need more information about the product.",
+            "sources" => %w[guided_search fpo_search],
+          },
+        },
+        "escalation" => {
+          "label" => "Escalation guidance",
+          "description" => "Use when HMRC support is needed to classify the product.",
+          "attributes" => {
+            "excluded" => true,
+            "escalate_to_webchat" => true,
+            "filter_prefixes" => [],
+            "guidance_level" => "info",
+            "guidance_location" => "interstitial",
+            "message_header" => "Contact HMRC for help",
+            "message" => "Contact HMRC and quote reference {{request_id}}",
+            "sources" => %w[guided_search fpo_search],
+          },
+        },
+      },
+    }
+  end
+
+  let(:template_config_response) do
+    jsonapi_response("admin_configuration", template_config_attributes.merge("resource_id" => "description_intercept_templates"))
+  end
+
   describe "GET #index" do
     let(:make_request) { get description_intercepts_path }
+
+    before do
+      stub_api_request("/admin_configurations/description_intercept_templates")
+        .and_return(template_config_response)
+    end
 
     it { is_expected.to have_http_status :success }
 
@@ -50,6 +100,44 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       expect(rendered_page.body).to include("Excluded")
       expect(rendered_page.body).to include("Commodity Intercepts (coming soon)")
       expect(rendered_page.body).to include("New description intercept")
+      expect(rendered_page.body).to include("Import description intercepts from a file")
+      expect(rendered_page.body).to include("Bulk import description intercepts")
+      expect(rendered_page.body).to include("Available templates")
+      expect(rendered_page.body).to include("Prepare your file")
+      expect(rendered_page.body).to include("Download example CSV")
+      expect(rendered_page.body).to include("gift")
+      expect(rendered_page.body).to include("present")
+      expect(rendered_page.body).to include("generic")
+      expect(rendered_page.body).to include("escalation")
+    end
+
+    context "when no templates are configured" do
+      let(:template_config_response) do
+        jsonapi_response(
+          "admin_configuration",
+          template_config_attributes.merge("resource_id" => "description_intercept_templates", "value" => {}),
+        )
+      end
+
+      it "shows an actionable warning and disables upload" do
+        page = Capybara.string(rendered_page.body)
+
+        expect(page).to have_text("No templates are currently configured.")
+        expect(rendered_page.body).to include("Classification configurations")
+        expect(rendered_page.body).to include(classification_configuration_path("description_intercept_templates"))
+        expect(rendered_page.body).to include('disabled="disabled"')
+        expect(rendered_page.body).to include('value="Import description intercepts"')
+      end
+    end
+  end
+
+  describe "GET #example_import" do
+    let(:make_request) { get example_import_description_intercepts_path }
+
+    it "downloads an example CSV" do
+      expect(rendered_page).to have_http_status(:success)
+      expect(rendered_page.headers["Content-Type"]).to include("text/csv")
+      expect(rendered_page.body).to eq("term,aliases,template\ngift,\"present,gifts\",generic\n")
     end
   end
 
@@ -116,6 +204,67 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     end
   end
 
+  describe "POST #bulk_import" do
+    let(:csv_upload) do
+      Rack::Test::UploadedFile.new(StringIO.new("term,aliases,template\ngift,\"present,gifts\",generic\n"), "text/csv", original_filename: "intercepts.csv")
+    end
+
+    let(:make_request) do
+      post bulk_import_description_intercepts_path, params: { description_intercept_import: { file: csv_upload } }
+    end
+
+    before do
+      stub_api_request("/admin_configurations/description_intercept_templates")
+        .and_return(template_config_response)
+      stub_api_request("/description_intercepts/bulk_import", :post)
+        .with { |request|
+          Rack::Utils.parse_nested_query(request.body).dig("data", "attributes", "csv") == "term,aliases,template\ngift,\"present,gifts\",generic\n"
+        }
+        .and_return(
+          status: 201,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: { data: { type: "description_intercept_bulk_import", attributes: { created: 1, updated: 0, total: 1 } } }.to_json,
+        )
+    end
+
+    it { is_expected.to redirect_to(description_intercepts_path) }
+
+    it "shows the import counts" do
+      rendered_page
+      expect(session.dig("flash", "flashes", "notice")).to eq("Imported 1 description intercept: 1 created, 0 updated.")
+    end
+
+    context "when the backend rejects templates" do
+      before do
+        stub_api_request("/description_intercepts/bulk_import", :post)
+          .and_return(
+            status: 422,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: { errors: [{ detail: "foo and baz are not valid templates", meta: { code: "invalid_templates", values: %w[foo baz] } }] }.to_json,
+          )
+      end
+
+      it "renders the grouped errors" do
+        expect(rendered_page).to have_http_status(:unprocessable_content)
+        expect(rendered_page.body).to include("foo and baz are not valid templates")
+      end
+    end
+
+    context "with an XLSX upload" do
+      let(:csv_upload) do
+        Rack::Test::UploadedFile.new(StringIO.new(xlsx_content), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", original_filename: "intercepts.xlsx")
+      end
+
+      it "converts the single worksheet to CSV" do
+        rendered_page
+
+        expect(WebMock).to(have_requested(:post, /description_intercepts\/bulk_import/).with do |request|
+          Rack::Utils.parse_nested_query(request.body).dig("data", "attributes", "csv") == "term,aliases,template\ngift,\"present,gifts\",generic\n"
+        end)
+      end
+    end
+  end
+
   describe "GET #show" do
     before do
       stub_api_request("/description_intercepts/#{intercept_id}")
@@ -139,6 +288,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       expect(rendered_page.body).to include("Description intercept")
       expect(rendered_page.body).to include("animal feed")
       expect(rendered_page.body).to include("Ask the trader to pick a more specific feed type.")
+      expect(rendered_page.body).to include("Check the feed type")
       expect(rendered_page.body).to include("Edit")
     end
 
@@ -153,6 +303,20 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       expect(rendered_page.body).to include("Not excluded")
       expect(rendered_page.body).not_to include("Guidance level")
       expect(rendered_page.body).not_to include("Guidance location")
+    end
+
+    context "with markdown and placeholder guidance" do
+      let(:intercept_attributes) do
+        super().merge("message" => "{{search_term}} needs **more detail**.\n\nBrowse chapter 64.")
+      end
+
+      it "renders guidance using the markdown previewer" do
+        page = Capybara.string(rendered_page.body)
+
+        expect(page).to have_css(".hott-markdown-preview .placeholder", text: "{{search_term}}")
+        expect(page).to have_css(".hott-markdown-preview strong", text: "more detail")
+        expect(page).to have_no_text("{{search_term}} needs **more detail**")
+      end
     end
 
     context "when the intercept has no guidance" do
@@ -195,6 +359,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     it "shows the edit form" do
       expect(rendered_page.body).to include("Save changes")
       expect(rendered_page.body).to include("Allow HMRC support escalation")
+      expect(rendered_page.body).to include("Guidance message header")
       expect(rendered_page.body).to include("Guidance message")
       expect(rendered_page.body).to include("Add alias")
       expect(rendered_page.body).to include("pet food")
@@ -528,9 +693,11 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     end
 
     context "with invalid update" do
+      let(:description_intercept_error_response) { webmock_response(:error, { filter_prefixes: "cannot be combined with excluded" }) }
+
       before do
         stub_api_request("/description_intercepts/#{intercept_id}", :patch)
-          .and_return(webmock_response(:error, filter_prefixes: "cannot be combined with excluded"))
+          .and_return(description_intercept_error_response)
         stub_api_request("/versions")
           .with(query: hash_including("item_type" => "DescriptionIntercept", "item_id" => intercept_id))
           .and_return(status: 200, headers: { "content-type" => "application/json; charset=utf-8" }, body: { data: [] }.to_json)
@@ -542,6 +709,36 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       it "links the error summary to the filter prefixes input" do
         expect(rendered_page.body).to include('href="#description-intercept-filter-prefixes-field-error"')
         expect(rendered_page.body).to include('id="description-intercept-filter-prefixes-error"')
+      end
+    end
+
+    context "with an aliases uniqueness error on update" do
+      before do
+        stub_api_request("/description_intercepts/#{intercept_id}", :patch)
+          .and_return(
+            status: 422,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              errors: [
+                {
+                  status: 422,
+                  title: "include values already used by another description intercept (present, gift)",
+                  detail: "Aliases include values already used by another description intercept (present, gift)",
+                  source: { pointer: "/data/attributes/aliases" },
+                },
+              ],
+            }.to_json,
+          )
+        stub_api_request("/versions")
+          .with(query: hash_including("item_type" => "DescriptionIntercept", "item_id" => intercept_id))
+          .and_return(status: 200, headers: { "content-type" => "application/json; charset=utf-8" }, body: { data: [] }.to_json)
+      end
+
+      it "shows a grammatical aliases validation message" do
+        expect(rendered_page.body).to include("Aliases include values already used by another description intercept (present, gift)")
+        expect(rendered_page.body).to include('href="#description-intercept-aliases-field-error"')
+        expect(rendered_page.body).to include('id="description-intercept-aliases-field-error"')
+        expect(rendered_page.body).not_to include("Aliases Aliases include")
       end
     end
 
@@ -669,5 +866,38 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       end
     end
   end
+
+  def xlsx_content
+    buffer = Zip::OutputStream.write_buffer do |zip|
+      zip.put_next_entry("[Content_Types].xml")
+      zip.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+          <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+          <Default Extension="xml" ContentType="application/xml"/>
+          <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+          <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+        </Types>
+      XML
+      zip.put_next_entry("xl/workbook.xml")
+      zip.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <sheets><sheet name="Sheet1" sheetId="1" r:id="rId1"/></sheets>
+        </workbook>
+      XML
+      zip.put_next_entry("xl/worksheets/sheet1.xml")
+      zip.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <sheetData>
+            <row r="1"><c r="A1" t="inlineStr"><is><t>term</t></is></c><c r="B1" t="inlineStr"><is><t>aliases</t></is></c><c r="C1" t="inlineStr"><is><t>template</t></is></c></row>
+            <row r="2"><c r="A2" t="inlineStr"><is><t>gift</t></is></c><c r="B2" t="inlineStr"><is><t>present,gifts</t></is></c><c r="C2" t="inlineStr"><is><t>generic</t></is></c></row>
+          </sheetData>
+        </worksheet>
+      XML
+    end
+    buffer.string
+  end
 end
-# rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+# rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations, RSpec/MultipleMemoizedHelpers

--- a/spec/services/description_intercept_import_file_spec.rb
+++ b/spec/services/description_intercept_import_file_spec.rb
@@ -1,0 +1,84 @@
+# rubocop:disable RSpec/MultipleExpectations
+require "zip"
+
+RSpec.describe DescriptionInterceptImportFile do
+  describe "#call" do
+    it "passes CSV uploads through unchanged" do
+      upload = Rack::Test::UploadedFile.new(StringIO.new("term,aliases,template\ngift,\"present,gifts\",generic\n"), "text/csv", original_filename: "intercepts.csv")
+
+      result = described_class.new(upload).call
+
+      expect(result).to be_success
+      expect(result.csv_content).to eq("term,aliases,template\ngift,\"present,gifts\",generic\n")
+    end
+
+    it "converts a single-sheet XLSX upload to CSV" do
+      upload = Rack::Test::UploadedFile.new(StringIO.new(xlsx_content), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", original_filename: "intercepts.xlsx")
+
+      result = described_class.new(upload).call
+
+      expect(result).to be_success
+      expect(result.csv_content).to eq("term,aliases,template\ngift,\"present,gifts\",generic\n")
+    end
+
+    it "rejects unsupported file types" do
+      upload = Rack::Test::UploadedFile.new(StringIO.new("hello"), "text/plain", original_filename: "intercepts.txt")
+
+      result = described_class.new(upload).call
+
+      expect(result).not_to be_success
+      expect(result.errors).to eq([{ "detail" => "Upload a CSV or XLSX file." }])
+    end
+
+    it "rejects XLSX files with more than one worksheet" do
+      upload = Rack::Test::UploadedFile.new(StringIO.new(xlsx_content(sheet_count: 2)), "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", original_filename: "intercepts.xlsx")
+
+      result = described_class.new(upload).call
+
+      expect(result).not_to be_success
+      expect(result.errors).to eq([{ "detail" => "Upload an XLSX file with a single worksheet." }])
+    end
+  end
+
+  def xlsx_content(sheet_count: 1)
+    buffer = Zip::OutputStream.write_buffer do |zip|
+      zip.put_next_entry("xl/workbook.xml")
+      zip.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+          <sheets>
+            #{Array.new(sheet_count) { |index| %(<sheet name="Sheet#{index + 1}" sheetId="#{index + 1}" r:id="rId#{index + 1}"/>) }.join}
+          </sheets>
+        </workbook>
+      XML
+
+      zip.put_next_entry("xl/sharedStrings.xml")
+      zip.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <si><t>term</t></si>
+          <si><t>aliases</t></si>
+          <si><t>template</t></si>
+          <si><t>gift</t></si>
+          <si><t>present,gifts</t></si>
+          <si><t>generic</t></si>
+        </sst>
+      XML
+
+      zip.put_next_entry("xl/worksheets/sheet1.xml")
+      zip.write <<~XML
+        <?xml version="1.0" encoding="UTF-8"?>
+        <worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+          <sheetData>
+            <row r="1"><c r="A1" t="s"><v>0</v></c><c r="B1" t="s"><v>1</v></c><c r="C1" t="s"><v>2</v></c></row>
+            <row r="2"><c r="A2" t="s"><v>3</v></c><c r="B2" t="s"><v>4</v></c><c r="C2" t="s"><v>5</v></c></row>
+          </sheetData>
+        </worksheet>
+      XML
+    end
+
+    buffer.string
+  end
+end
+
+# rubocop:enable RSpec/MultipleExpectations


### PR DESCRIPTION
### Jira link

[AI-663](https://transformuk.atlassian.net/browse/AI-663)

<img width="1495" height="1225" alt="image" src="https://github.com/user-attachments/assets/a1a28ebf-0f3d-4a4b-b4ad-664abe005279" />
<img width="1495" height="1225" alt="image" src="https://github.com/user-attachments/assets/bb9f834b-ed1e-4d9e-82bc-60d5e1961fb1" />
<img width="1495" height="1225" alt="image" src="https://github.com/user-attachments/assets/441c9df8-88fd-490f-8d45-43b7279d42b9" />


### What?

- [x] Adds the description intercept bulk import form to the admin UI.
- [x] Shows admins the required `term,template` shape and available templates.
- [x] Converts single-sheet XLSX uploads to CSV before posting to the backend.
- [x] Displays grouped backend validation errors without partial success messaging.
- [x] Makes `description_intercept_templates` editable as JSON admin configuration.

### Why?

So admins can upload simple term/template imports and manage the template registry from the admin app.