### PR TITLE
Follow up Ruby 4.0.3 maintenance

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1777946660,
-        "narHash": "sha256-iw3XDIG6xxk+AZTcawCLHf6i9i4tXRzLZEoV9xhRToQ=",
+        "lastModified": 1778036283,
+        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "bc57abace07689cfd34203aa5fb4027514895987",
+        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What
- Refresh `flake.lock` after rerunning `nix flake update`

## Why
- complete the Ruby 4.0.3 maintenance follow-up after merged PR #1239

## Verification
- checked current Ruby target files on the default branch
- reran `nix flake update`
- confirmed the resulting diff is limited to: flake.lock
