### PR TITLE
BAU: Add admin-job service for database migration pre-deployment

### DIFF
--- a/.github/workflows/deploy-to-development-full.yml
+++ b/.github/workflows/deploy-to-development-full.yml
@@ -45,6 +45,7 @@ jobs:
           }
         ]
       test-flavour: tariff
+      migrate: true
     secrets:
       ssh-key: ${{ secrets.PRIVATE_SSH_KEY }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-development.yml
+++ b/.github/workflows/deploy-to-development.yml
@@ -24,6 +24,7 @@ jobs:
       app-name: tariff-admin
       environment: development
       test-flavour: none
+      migrate: true
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-production.yml
+++ b/.github/workflows/deploy-to-production.yml
@@ -21,6 +21,7 @@ jobs:
     with:
       app-name: tariff-admin
       environment: production
+      migrate: true
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -16,6 +16,7 @@ jobs:
     with:
       app-name: tariff-admin
       environment: staging
+      migrate: true
     secrets:
       basic-password: ${{ secrets.BASIC_PASSWORD }}
       slack-webhook: ${{ secrets.SLACK_WEBHOOK }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.104.0
+    rev: v1.105.0
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -21,12 +21,12 @@ repos:
         exclude: config/database.yml
 
   - repo: https://github.com/trufflesecurity/trufflehog
-    rev: v3.91.1
+    rev: v3.95.2
     hooks:
       - id: trufflehog
 
   - repo: https://github.com/igorshubovych/markdownlint-cli
-    rev: v0.46.0
+    rev: v0.48.0
     hooks:
       - id: markdownlint-docker
         args:
@@ -41,6 +41,6 @@ repos:
         args: ["--autocorrect"]
 
   - repo: https://github.com/rhysd/actionlint.git
-    rev: v1.7.9
+    rev: v1.7.12
     hooks:
       - id: actionlint-docker

--- a/bin/null-service
+++ b/bin/null-service
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+[[ "$TRACE" ]] && set -o xtrace
+set -o errexit
+set -o nounset
+set -o pipefail
+set -o noclobber
+
+PORT=8080
+
+echo "Starting null service on port $PORT..."
+while true; do
+  socat TCP-LISTEN:"$PORT",reuseaddr,fork SYSTEM:'
+    read request
+    echo "HTTP/1.1 200 OK"
+    echo "Content-Type: text/plain"
+    echo "Content-Length: 2"
+    echo "Connection: close"
+    echo ""
+    echo "OK"
+  '
+done

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,8 +19,8 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
-| <a name="module_admin-job"></a> [admin-job](#module\_admin-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
+| <a name="module_admin-job"></a> [admin-job](#module\_admin-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
 
 ## Resources
 
@@ -47,6 +47,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_autoscaling_metrics"></a> [autoscaling\_metrics](#input\_autoscaling\_metrics) | A map of autoscaling metrics. | <pre>map(object({<br/>    metric_type  = string<br/>    target_value = number<br/>  }))</pre> | <pre>{<br/>  "cpu": {<br/>    "metric_type": "ECSServiceAverageCPUUtilization",<br/>    "target_value": 40<br/>  },<br/>  "memory": {<br/>    "metric_type": "ECSServiceAverageMemoryUtilization",<br/>    "target_value": 40<br/>  }<br/>}</pre> | no |
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
+| <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CPU alarms for the ECS service | `bool` | n/a | yes |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -19,6 +19,7 @@ Terraform to deploy the service into AWS.
 
 | Name | Source | Version |
 | ---- | ------ | ------- |
+| <a name="module_admin-job"></a> [admin-job](#module\_admin-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 | <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v1.21.0 |
 
 ## Resources

--- a/terraform/admin_job.tf
+++ b/terraform/admin_job.tf
@@ -1,5 +1,5 @@
 module "admin-job" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
 
   region = var.region
 
@@ -27,6 +27,7 @@ module "admin-job" {
   has_autoscaler = false
   max_capacity   = 1
   min_capacity   = 0
+  enable_alarms  = false
 
   sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
 }

--- a/terraform/admin_job.tf
+++ b/terraform/admin_job.tf
@@ -1,0 +1,32 @@
+module "admin-job" {
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
+
+  region = var.region
+
+  service_name              = "admin-job"
+  container_definition_kind = "job"
+  container_command         = ["/bin/sh", "-C", "bin/null-service"]
+  service_count             = 0
+
+  cluster_name              = "trade-tariff-cluster-${var.environment}"
+  subnet_ids                = data.aws_subnets.private.ids
+  security_groups           = [data.aws_security_group.this.id]
+  cloudwatch_log_group_name = "platform-logs-${var.environment}"
+
+  docker_image = local.ecr_repo
+  docker_tag   = var.docker_tag
+  cpu          = var.cpu
+  memory       = var.memory
+
+  task_role_policy_arns = [aws_iam_policy.task.arn]
+
+  service_environment_config = local.admin_service_env_vars
+
+  enable_ecs_exec = true
+
+  has_autoscaler = false
+  max_capacity   = 1
+  min_capacity   = 0
+
+  sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
+}

--- a/terraform/config_development.tfvars
+++ b/terraform/config_development.tfvars
@@ -5,3 +5,4 @@ memory        = 2048
 service_count = 2
 min_capacity  = 1
 max_capacity  = 3
+enable_alarms = false

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -5,3 +5,4 @@ memory        = 2048
 service_count = 3
 min_capacity  = 2
 max_capacity  = 5
+enable_alarms = true

--- a/terraform/config_staging.tfvars
+++ b/terraform/config_staging.tfvars
@@ -5,3 +5,4 @@ memory        = 2048
 service_count = 2
 min_capacity  = 1
 max_capacity  = 5
+enable_alarms = false

--- a/terraform/locals.tf
+++ b/terraform/locals.tf
@@ -8,6 +8,8 @@ locals {
     }
   ]
 
+  ecr_repo = "382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-admin-production"
+
   database_env_vars = [
     {
       name  = "DATABASE_URL"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -3,15 +3,9 @@ module "service" {
 
   region = var.region
 
+  service_name              = "admin"
   container_definition_kind = "db-backed"
-  init_container_command = [
-    "/bin/sh",
-    "-c",
-    "bundle exec rails db:migrate",
-  ]
-
-  service_name  = "admin"
-  service_count = var.service_count
+  service_count             = var.service_count
 
   cluster_name    = "trade-tariff-cluster-${var.environment}"
   subnet_ids      = data.aws_subnets.private.ids
@@ -26,7 +20,7 @@ module "service" {
   max_capacity        = var.max_capacity
   autoscaling_metrics = var.autoscaling_metrics
 
-  docker_image = "382373577178.dkr.ecr.eu-west-2.amazonaws.com/tariff-admin-production"
+  docker_image = local.ecr_repo
   docker_tag   = var.docker_tag
   skip_destroy = true
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,11 +1,10 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v1.21.0"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
 
   region = var.region
 
-  service_name              = "admin"
-  container_definition_kind = "db-backed"
-  service_count             = var.service_count
+  service_name  = "admin"
+  service_count = var.service_count
 
   cluster_name    = "trade-tariff-cluster-${var.environment}"
   subnet_ids      = data.aws_subnets.private.ids
@@ -24,8 +23,10 @@ module "service" {
   docker_tag   = var.docker_tag
   skip_destroy = true
 
-  cpu    = var.cpu
-  memory = var.memory
+  cpu                 = var.cpu
+  memory              = var.memory
+  enable_alarms       = var.enable_alarms
+  cpu_alarm_threshold = 75
 
   task_role_policy_arns = [aws_iam_policy.task.arn]
   enable_ecs_exec       = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -55,3 +55,8 @@ variable "autoscaling_metrics" {
     }
   }
 }
+
+variable "enable_alarms" {
+  description = "Whether to enable CPU alarms for the ECS service"
+  type        = bool
+}


### PR DESCRIPTION
### What?

I have added/removed/altered:

- Added `admin-job` service

### Why?

I am doing this because:

- In order to run database migrations prior to deploying new service code, we need a service job we can run arbitrary tasks on.

### Deployment risk

🟢 Low: Adds a null service that does nothing until a task is run using a workflow
