### PR TITLE
Prevent CSP violation noise

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -2,8 +2,19 @@ class CspReportsController < ApplicationController
   skip_forgery_protection only: %i[create]
 
   def create
-    Rails.logger.warn "CSP Violation: #{request.body.read}"
-    # Potentially, send an error message to new relic
+    violation_body = request.body.read
+    Rails.logger.warn "CSP Violation: #{violation_body}"
+
+    unless gtm_csp_violation?(violation_body)
+      NewRelic::Agent.notice_error("CSP Violation: #{violation_body}")
+    end
+
     head :ok
+  end
+
+private
+
+  def gtm_csp_violation?(violation_body)
+    violation_body.include?("Content Security Policy") && violation_body.include?("googletagmanager")
   end
 end


### PR DESCRIPTION
### Jira link

[HMRC-2183](https://transformuk.atlassian.net/browse/HMRC-2183)

### What?

Prevent Browser CSP violations from appearing in New Relic Browser Errors

### Why?

We are receiving repeated Content Security Policy (CSP) violation reports caused by Google Tag Manager attempting to use eval. These are expected and non-actionable.
