### PR TITLE
BAU: Add description intercept delete UI

### DIFF
--- a/app/controllers/description_intercepts_controller.rb
+++ b/app/controllers/description_intercepts_controller.rb
@@ -1,5 +1,7 @@
 class DescriptionInterceptsController < AuthenticatedController
-  before_action :load_description_intercept, only: %i[show edit update]
+  rescue_from Faraday::ResourceNotFound, with: :redirect_description_intercept_not_found
+
+  before_action :load_description_intercept, only: %i[show edit update destroy]
 
   def index
     authorize DescriptionIntercept, :index?
@@ -65,6 +67,15 @@ class DescriptionInterceptsController < AuthenticatedController
     redirect_to description_intercepts_path, alert: "Description intercept not found."
   end
 
+  def destroy
+    authorize @description_intercept, :destroy?
+
+    @description_intercept.destroy
+    redirect_to description_intercepts_path, notice: "Description intercept deleted successfully."
+  rescue Faraday::ResourceNotFound
+    redirect_to description_intercepts_path, alert: "Description intercept not found."
+  end
+
   def bulk_import
     authorize DescriptionIntercept, :update?
 
@@ -94,6 +105,10 @@ private
 
   def load_description_intercept
     @description_intercept = DescriptionIntercept.find(params[:id], params[:oid].present? ? { oid: params[:oid] } : {})
+  end
+
+  def redirect_description_intercept_not_found
+    redirect_to description_intercepts_path, alert: "Description intercept not found."
   end
 
   def fetch_versions

--- a/app/controllers/description_intercepts_controller.rb
+++ b/app/controllers/description_intercepts_controller.rb
@@ -1,7 +1,7 @@
 class DescriptionInterceptsController < AuthenticatedController
   rescue_from Faraday::ResourceNotFound, with: :redirect_description_intercept_not_found
 
-  before_action :load_description_intercept, only: %i[show edit update destroy]
+  before_action :load_description_intercept, only: %i[show edit update confirm_destroy destroy]
 
   def index
     authorize DescriptionIntercept, :index?
@@ -65,6 +65,10 @@ class DescriptionInterceptsController < AuthenticatedController
     end
   rescue Faraday::ResourceNotFound
     redirect_to description_intercepts_path, alert: "Description intercept not found."
+  end
+
+  def confirm_destroy
+    authorize @description_intercept, :destroy?
   end
 
   def destroy

--- a/app/policies/description_intercept_policy.rb
+++ b/app/policies/description_intercept_policy.rb
@@ -10,4 +10,8 @@ class DescriptionInterceptPolicy < ApplicationPolicy
   def update?
     technical_operator?
   end
+
+  def destroy?
+    technical_operator?
+  end
 end

--- a/app/views/description_intercepts/confirm_destroy.html.erb
+++ b/app/views/description_intercepts/confirm_destroy.html.erb
@@ -1,0 +1,23 @@
+<%= govuk_breadcrumbs 'Intercepts': description_intercepts_path,
+                      @description_intercept.term => description_intercept_path(@description_intercept) %>
+
+<span class="govuk-caption-l">Description intercept</span>
+<h1 class="govuk-heading-l">Are you sure you want to delete this description intercept?</h1>
+
+<%= govuk_warning_text(text: "This will delete the current description intercept. Previous versions will remain available in version history.") %>
+
+<%= govuk_summary_list(rows: [
+  { key: { text: "Term" }, value: { text: @description_intercept.term } },
+  { key: { text: "Search behaviour" }, value: { text: @description_intercept.behaviour_summary } },
+  { key: { text: "Relevant Products" }, value: { text: @description_intercept.sources_label } },
+]) %>
+
+<div class="govuk-button-group description-intercept-actions">
+  <%= govuk_button_to 'Delete description intercept',
+                      description_intercept_path(@description_intercept),
+                      method: :delete,
+                      warning: true,
+                      prevent_double_click: true,
+                      form_class: 'description-intercept-actions__delete-form' %>
+  <%= govuk_link_to 'Cancel', description_intercept_path(@description_intercept) %>
+</div>

--- a/app/views/description_intercepts/show.html.erb
+++ b/app/views/description_intercepts/show.html.erb
@@ -81,20 +81,20 @@
 </dl>
 
 <% if @description_intercept.current? && (policy(@description_intercept).update? || policy(@description_intercept).destroy?) %>
-  <div class="govuk-button-group">
+  <div class="govuk-button-group description-intercept-actions">
     <% if policy(@description_intercept).update? %>
-      <%= link_to 'Edit', edit_description_intercept_path(@description_intercept), class: 'govuk-button' %>
+      <%= govuk_button_link_to 'Edit', edit_description_intercept_path(@description_intercept) %>
     <% end %>
     <% if policy(@description_intercept).destroy? %>
-      <%= button_to 'Delete description intercept',
-                    description_intercept_path(@description_intercept),
-                    method: :delete,
-                    class: 'govuk-button govuk-button--warning',
-                    form_class: 'govuk-!-display-inline-block',
-                    data: {
-                      confirm: "Are you sure you want to delete the description intercept for #{@description_intercept.term}?",
-                      disable: 'Working ...',
-                    } %>
+      <%= govuk_button_to 'Delete description intercept',
+                          description_intercept_path(@description_intercept),
+                          method: :delete,
+                          warning: true,
+                          form_class: 'description-intercept-actions__delete-form',
+                          data: {
+                            confirm: "Are you sure you want to delete the description intercept for #{@description_intercept.term}?",
+                            disable: 'Working ...',
+                          } %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/description_intercepts/show.html.erb
+++ b/app/views/description_intercepts/show.html.erb
@@ -86,15 +86,9 @@
       <%= govuk_button_link_to 'Edit', edit_description_intercept_path(@description_intercept) %>
     <% end %>
     <% if policy(@description_intercept).destroy? %>
-      <%= govuk_button_to 'Delete description intercept',
-                          description_intercept_path(@description_intercept),
-                          method: :delete,
-                          warning: true,
-                          form_class: 'description-intercept-actions__delete-form',
-                          data: {
-                            confirm: "Are you sure you want to delete the description intercept for #{@description_intercept.term}?",
-                            disable: 'Working ...',
-                          } %>
+      <%= govuk_button_link_to 'Delete description intercept',
+                               delete_description_intercept_path(@description_intercept),
+                               warning: true %>
     <% end %>
   </div>
 <% end %>

--- a/app/views/description_intercepts/show.html.erb
+++ b/app/views/description_intercepts/show.html.erb
@@ -80,9 +80,22 @@
   </div>
 </dl>
 
-<% if @description_intercept.current? && policy(@description_intercept).update? %>
+<% if @description_intercept.current? && (policy(@description_intercept).update? || policy(@description_intercept).destroy?) %>
   <div class="govuk-button-group">
-    <%= link_to 'Edit', edit_description_intercept_path(@description_intercept), class: 'govuk-button' %>
+    <% if policy(@description_intercept).update? %>
+      <%= link_to 'Edit', edit_description_intercept_path(@description_intercept), class: 'govuk-button' %>
+    <% end %>
+    <% if policy(@description_intercept).destroy? %>
+      <%= button_to 'Delete description intercept',
+                    description_intercept_path(@description_intercept),
+                    method: :delete,
+                    class: 'govuk-button govuk-button--warning',
+                    form_class: 'govuk-!-display-inline-block',
+                    data: {
+                      confirm: "Are you sure you want to delete the description intercept for #{@description_intercept.term}?",
+                      disable: 'Working ...',
+                    } %>
+    <% end %>
   </div>
 <% end %>
 

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -371,6 +371,14 @@ $govuk-image-url-function: frontend-image-url;
   gap: govuk-spacing(2);
 }
 
+.description-intercept-actions {
+  align-items: flex-start;
+
+  &__delete-form {
+    margin: 0;
+  }
+}
+
 .description-intercept-short-code-pill {
   display: inline-flex;
   align-items: flex-start;

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -135,6 +135,10 @@ Rails.application.routes.draw do
   resources :classification_configurations, param: :name, only: %i[index show edit update]
 
   resources :description_intercepts, only: %i[index new create show edit update destroy] do
+    member do
+      get :delete, action: :confirm_destroy
+    end
+
     collection do
       get :example_import
       post :bulk_import

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -134,7 +134,7 @@ Rails.application.routes.draw do
 
   resources :classification_configurations, param: :name, only: %i[index show edit update]
 
-  resources :description_intercepts, only: %i[index new create show edit update] do
+  resources :description_intercepts, only: %i[index new create show edit update destroy] do
     collection do
       get :example_import
       post :bulk_import

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -297,9 +297,8 @@ RSpec.describe DescriptionInterceptsController, type: :request do
 
       expect(page).to have_link("Edit", class: "govuk-button")
       expect(page).to have_css(".govuk-button-group.description-intercept-actions")
-      expect(page).to have_button("Delete description intercept", class: "govuk-button--warning")
-      expect(page).to have_css("form.description-intercept-actions__delete-form[action='#{description_intercept_path(intercept_id)}'][method='post']")
-      expect(page).to have_css("input[name='_method'][value='delete']", visible: :hidden)
+      expect(page).to have_link("Delete description intercept", href: delete_description_intercept_path(intercept_id), class: "govuk-button--warning")
+      expect(page).to have_no_css("[data-confirm]")
     end
 
     it "shows the full intercept summary" do
@@ -677,6 +676,51 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       it "sends empty filter prefixes in the payload" do
         expect(rendered_page).to redirect_to(description_intercept_path("999"))
       end
+    end
+  end
+
+  describe "GET #confirm_destroy" do
+    before do
+      stub_api_request("/description_intercepts/#{intercept_id}")
+        .and_return(intercept_response)
+    end
+
+    let(:make_request) { get delete_description_intercept_path(intercept_id) }
+
+    it { is_expected.to have_http_status :success }
+
+    it "asks for delete confirmation" do
+      page = Capybara.string(rendered_page.body)
+
+      expect(page).to have_css("h1", text: "Are you sure you want to delete this description intercept?")
+      expect(page).to have_text("animal feed")
+      expect(page).to have_text("Filters to selected short codes")
+      expect(page).to have_button("Delete description intercept", class: "govuk-button--warning")
+      expect(page).to have_css("form[action='#{description_intercept_path(intercept_id)}'][method='post']")
+      expect(page).to have_css("input[name='_method'][value='delete']", visible: :hidden)
+      expect(page).to have_link("Cancel", href: description_intercept_path(intercept_id))
+      expect(page).to have_no_css("[data-confirm]")
+    end
+
+    context "when the intercept does not exist" do
+      before do
+        stub_api_request("/description_intercepts/#{intercept_id}")
+          .and_return(status: 404, headers: { "content-type" => "application/json; charset=utf-8" }, body: "{}")
+      end
+
+      it { is_expected.to redirect_to(description_intercepts_path) }
+
+      it "shows a not found message" do
+        rendered_page
+
+        expect(session.dig("flash", "flashes", "alert")).to eq("Description intercept not found.")
+      end
+    end
+
+    context "when the user cannot delete intercepts" do
+      let(:current_user) { create(:user, :hmrc_admin) }
+
+      it { is_expected.to have_http_status :forbidden }
     end
   end
 

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -292,6 +292,14 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       expect(rendered_page.body).to include("Edit")
     end
 
+    it "shows the delete action after the intercept details" do
+      page = Capybara.string(rendered_page.body)
+
+      expect(page).to have_button("Delete description intercept", class: "govuk-button--warning")
+      expect(page).to have_css("form[action='#{description_intercept_path(intercept_id)}'][method='post']")
+      expect(page).to have_css("input[name='_method'][value='delete']", visible: :hidden)
+    end
+
     it "shows the full intercept summary" do
       expect(rendered_page.body).to include("Filters to selected short codes")
       expect(rendered_page.body).to include("Relevant Products")
@@ -336,6 +344,33 @@ RSpec.describe DescriptionInterceptsController, type: :request do
         expect(rendered_page.body).to include("None")
         expect(rendered_page.body).not_to include("Guidance level")
         expect(rendered_page.body).not_to include("Guidance location")
+      end
+    end
+
+    context "when viewing a previous version" do
+      let(:intercept_response) do
+        super().deep_merge(
+          body: {
+            data: {
+              type: "description_intercept",
+              id: intercept_id,
+              attributes: intercept_attributes,
+            },
+            meta: {
+              version: {
+                current: false,
+                oid: "2",
+                previous_oid: "1",
+                has_previous_version: true,
+                latest_event: "update",
+              },
+            },
+          }.to_json,
+        )
+      end
+
+      it "does not show destructive actions" do
+        expect(Capybara.string(rendered_page.body)).to have_no_button("Delete description intercept")
       end
     end
   end
@@ -640,6 +675,52 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       it "sends empty filter prefixes in the payload" do
         expect(rendered_page).to redirect_to(description_intercept_path("999"))
       end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    before do
+      stub_api_request("/description_intercepts/#{intercept_id}")
+        .and_return(intercept_response)
+      stub_api_request("/description_intercepts/#{intercept_id}", :delete)
+        .and_return(webmock_response(:no_content))
+    end
+
+    let(:make_request) { delete description_intercept_path(intercept_id) }
+
+    it { is_expected.to redirect_to(description_intercepts_path) }
+
+    it "deletes the intercept through the backend API" do
+      rendered_page
+
+      expect(WebMock).to have_requested(:delete, /description_intercepts\/#{intercept_id}/)
+    end
+
+    it "shows a success message" do
+      rendered_page
+
+      expect(session.dig("flash", "flashes", "notice")).to eq("Description intercept deleted successfully.")
+    end
+
+    context "when the intercept does not exist" do
+      before do
+        stub_api_request("/description_intercepts/#{intercept_id}")
+          .and_return(status: 404, headers: { "content-type" => "application/json; charset=utf-8" }, body: "{}")
+      end
+
+      it { is_expected.to redirect_to(description_intercepts_path) }
+
+      it "shows a not found message" do
+        rendered_page
+
+        expect(session.dig("flash", "flashes", "alert")).to eq("Description intercept not found.")
+      end
+    end
+
+    context "when the user cannot delete intercepts" do
+      let(:current_user) { create(:user, :hmrc_admin) }
+
+      it { is_expected.to have_http_status :forbidden }
     end
   end
 

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -295,8 +295,10 @@ RSpec.describe DescriptionInterceptsController, type: :request do
     it "shows the delete action after the intercept details" do
       page = Capybara.string(rendered_page.body)
 
+      expect(page).to have_link("Edit", class: "govuk-button")
+      expect(page).to have_css(".govuk-button-group.description-intercept-actions")
       expect(page).to have_button("Delete description intercept", class: "govuk-button--warning")
-      expect(page).to have_css("form[action='#{description_intercept_path(intercept_id)}'][method='post']")
+      expect(page).to have_css("form.description-intercept-actions__delete-form[action='#{description_intercept_path(intercept_id)}'][method='post']")
       expect(page).to have_css("input[name='_method'][value='delete']", visible: :hidden)
     end
 


### PR DESCRIPTION
### Jira link

BAU

<img width="886" height="1257" alt="image" src="https://github.com/user-attachments/assets/b0ab736c-0448-4841-881a-a241c6610c8e" />
<img width="850" height="382" alt="image" src="https://github.com/user-attachments/assets/79a88e4b-a056-424e-8610-a6ec1957b6f3" />


### What?

I have added/removed/altered:

- [x] Added a description intercept delete route and controller action
- [x] Added a GOV.UK warning button on the current intercept show page
- [x] Added request coverage for delete, authorization, not-found handling, and historical-version display

### Why?

Admins need to be able to remove description intercepts after reviewing the full intercept details. This depends on the backend delete endpoint in https://github.com/trade-tariff/trade-tariff-backend/pull/3157.

### Deployment risks (optional)

- Medium risk: this enables a destructive admin action, limited to technical operators and backed by confirmation plus request coverage.