### PR TITLE
AI-517: Add TariffNoteFormatter to render section notes as Govspeak markdown

### DIFF
--- a/app/models/section_note.rb
+++ b/app/models/section_note.rb
@@ -13,6 +13,8 @@ class SectionNote
 
   def preview(field_name = :content, **options)
     content = public_send(field_name)
-    GovspeakPreview.new(content, **options).render if content.present?
+    return if content.blank?
+
+    GovspeakPreview.new(TariffNoteFormatter.new(content).format, **options).render
   end
 end

--- a/app/models/tariff_note_formatter.rb
+++ b/app/models/tariff_note_formatter.rb
@@ -1,0 +1,144 @@
+# Transforms raw tariff note content (as stored by the ETL pipeline) into valid
+# Govspeak markdown before it is passed to GovspeakPreview for rendering.
+#
+# The ETL output is plain text — it has no indentation, no bold markers, no heading
+# markup, and uses • bullets and — em-dash rows. Without this formatter those
+# elements either render as code blocks (4-space indent outside a list), literal
+# asterisks, or unstyled paragraphs.
+#
+# Rules applied (in priority order):
+#   Note spacing  "1.Text" → "1. Text" so Govspeak recognises the list marker.
+#   Rule 1        — em-dash pairs → a two-column Govspeak table (blank header).
+#   Rule 2        Known section headings ("Subheading notes", "Additional section
+#                 notes") → ### heading, which also resets the ordered list counter.
+#   Rule 3        Lettered sub-items (a., b., ij.) → 4-space indent; bolded when
+#                 the text looks like a definition title (starts uppercase, no
+#                 terminal period, does not trail with ' and'/' or').
+#   Rule 4        Capital-bracket sub-paragraphs (B)–(Z) → 4-space indent only.
+#                 Starts at B because (A) always appears inline with the note number
+#                 ("1. (A) ...") and is never a standalone line.
+#   Rule 5        Lowercase-bracket sub-items (a)–(z) → same bold heuristic as rule 3.
+#   Rule 6        Numbered-bracket sub-sub-items (1), (2) → 4-space indent only.
+#   Rule 7        • bullet → Govspeak sub-bullet "  - ".
+#   Rule 8        Plain prose lines belonging to a numbered note (no match from
+#                 rules 1–7) are indented 4 spaces. Govspeak renders 4-space content
+#                 after an "N." list marker as a <p> inside the <li>; without the
+#                 indent the prose becomes a detached top-level paragraph.
+#
+#                   ETL in:  "1. Note heading.\n\nContinuation prose."
+#                   Out:     "1. Note heading.\n\n    Continuation prose."
+#
+class TariffNoteFormatter
+  SECTION_HEADINGS = ["Subheading notes", "Additional section notes"].freeze
+
+  def initialize(content)
+    @content = content.to_s
+  end
+
+  def format
+    lines = normalize(@content).split("\n")
+    result = []
+    in_note = false
+    i = 0
+
+    while i < lines.length
+      line = lines[i]
+
+      # Normalise missing space after note number: "1.Text" → "1. Text"
+      line = line.sub(/\A(\d+)\.([^\s])/, '\1. \2')
+
+      # Rule 1: em-dash table (multi-line — must run before any line rule)
+      if line.start_with?("—")
+        rows, consumed = extract_emdash_rows(lines, i)
+        result.concat(render_emdash_table(rows))
+        i += consumed
+        next
+      end
+
+      if line.match?(/\A\d+\./)
+        in_note = true
+        result << line
+      elsif line.strip.empty?
+        result << line
+      elsif (transformed = transform_line(line))
+        result << transformed
+      elsif in_note
+        result << "    #{line}"
+      else
+        result << line
+      end
+
+      i += 1
+    end
+
+    result.join("\n")
+  end
+
+private
+
+  def normalize(content)
+    content.gsub("\r\n", "\n").gsub("\r", "\n")
+  end
+
+  def transform_line(line)
+    # Rule 2: known section headings — must be first so rule 8 cannot indent them
+    return "### #{line}" if SECTION_HEADINGS.include?(line)
+
+    # Rule 3: lettered sub-items (a., b., ..., ij.)
+    if (m = line.match(/\A([a-z]{1,2})\. (.+)/))
+      label = m[1]
+      rest = m[2]
+      return definition_title?(rest) ? "    **#{label}. #{rest}**" : "    #{label}. #{rest}"
+    end
+
+    # Rule 4: capital bracket sub-paragraphs (B)-(Z) — indent only, never bold
+    if (m = line.match(/\A\(([B-Z])\) (.+)/))
+      return "    (#{m[1]}) #{m[2]}"
+    end
+
+    # Rule 5: lowercase bracket sub-items (a)-(z)
+    if (m = line.match(/\A\(([a-z])\) (.+)/))
+      label = m[1]
+      rest = m[2]
+      return definition_title?(rest) ? "    **(#{label}) #{rest}**" : "    (#{label}) #{rest}"
+    end
+
+    # Rule 6: numbered bracket sub-sub-items
+    if (m = line.match(/\A\((\d+)\) (.+)/))
+      return "    (#{m[1]}) #{m[2]}"
+    end
+
+    # Rule 7: bullet character
+    if (m = line.match(/\A•\s*(.*)/))
+      return "  - #{m[1]}"
+    end
+
+    nil
+  end
+
+  def definition_title?(text)
+    text.match?(/\A[A-Z]/) && !text.end_with?(".") && !text.end_with?(" and") && !text.end_with?(" or")
+  end
+
+  def extract_emdash_rows(lines, start_i)
+    rows = []
+    i = start_i
+
+    while i < lines.length && (m = lines[i].match(/\A—\s*(.*)/))
+      description = "— #{m[1].strip}"
+      i += 1
+      break unless i < lines.length
+
+      rows << [description, lines[i].strip]
+      i += 1
+    end
+
+    [rows, i - start_i]
+  end
+
+  def render_emdash_table(rows)
+    output = ["|   |   |", "|---|---|"]
+    rows.each { |desc, val| output << "| #{desc} | #{val} |" }
+    output
+  end
+end

--- a/spec/models/tariff_note_formatter_spec.rb
+++ b/spec/models/tariff_note_formatter_spec.rb
@@ -1,0 +1,202 @@
+require "rails_helper"
+
+RSpec.describe TariffNoteFormatter do
+  subject(:result) { described_class.new(content).format }
+
+  describe "note number spacing normalisation" do
+    context "when the note number is immediately followed by text with no space" do
+      let(:content) { "8.In this section, the following expressions have the meanings hereby assigned to them:" }
+
+      it "adds a space after the period so Govspeak treats it as a list marker" do
+        expect(result).to eq "8. In this section, the following expressions have the meanings hereby assigned to them:"
+      end
+    end
+
+    context "when the note number already has a space" do
+      let(:content) { "1. This section does not cover:" }
+
+      it "is unchanged" do
+        expect(result).to eq "1. This section does not cover:"
+      end
+    end
+  end
+
+  describe "passthrough — no ETL patterns" do
+    let(:content) { "Some plain text with no special patterns." }
+
+    it "returns the content unchanged" do
+      expect(result).to eq content
+    end
+  end
+
+  describe "rule 3: lettered sub-items" do
+    context "when text starts with lowercase" do
+      let(:content) { "a. having regard to the manner in which they are put up;" }
+
+      it "adds four-space indent, no bold" do
+        expect(result).to eq "    a. having regard to the manner in which they are put up;"
+      end
+    end
+
+    context "when text starts with uppercase but ends with a period" do
+      let(:content) { "a. An alloy of base metals is to be classified as an alloy of the metal which predominates by weight over each of the other metals." }
+
+      it "does not bold — period at end indicates a complete sentence, not a title" do
+        expect(result).to eq "    a. An alloy of base metals is to be classified as an alloy of the metal which predominates by weight over each of the other metals."
+      end
+    end
+
+    context "when text starts with uppercase but ends with ' and'" do
+      let(:content) { "a. Chapters 50 to 55 and 60 and, except where the context otherwise requires, Chapters 56 to 59 do not apply to goods made up within the meaning of note 7 above; and" }
+
+      it "does not bold — trailing ' and' marks a continuing list item, not a title" do
+        expect(result).to eq "    a. Chapters 50 to 55 and 60 and, except where the context otherwise requires, Chapters 56 to 59 do not apply to goods made up within the meaning of note 7 above; and"
+      end
+    end
+
+    context "when text starts with uppercase — definition title" do
+      let(:content) { "a. Waste and scrap" }
+
+      it "adds four-space indent and bold markers" do
+        expect(result).to eq "    **a. Waste and scrap**"
+      end
+    end
+
+    context "with the EU ij. digraph" do
+      let(:content) { "ij. woven, knitted or crocheted fabrics, of Chapter 40;" }
+
+      it "handles two-letter label correctly" do
+        expect(result).to eq "    ij. woven, knitted or crocheted fabrics, of Chapter 40;"
+      end
+    end
+  end
+
+  describe "rule 4: capital bracket sub-paragraphs (B)-(Z)" do
+    context "with a full sentence and terminal punctuation" do
+      let(:content) { "(B) Subject to paragraph (A) above, goods answering to a description in heading 2843;" }
+
+      it "adds four-space indent, no bold" do
+        expect(result).to eq "    (B) Subject to paragraph (A) above, goods answering to a description in heading 2843;"
+      end
+    end
+
+    context "with a colon introducing sub-items" do
+      let(:content) { "(B) For the purposes of the above rule:" }
+
+      it "adds four-space indent, no bold" do
+        expect(result).to eq "    (B) For the purposes of the above rule:"
+      end
+    end
+  end
+
+  describe "rule 5: lowercase bracket sub-items (a)-(z)" do
+    context "when text starts with uppercase — definition title" do
+      let(:content) { "(a) Bars and rods" }
+
+      it "adds four-space indent and bold markers" do
+        expect(result).to eq "    **(a) Bars and rods**"
+      end
+    end
+
+    context "when text starts with lowercase" do
+      let(:content) { "(a) where appropriate, only the part which determines the classification;" }
+
+      it "adds four-space indent, no bold" do
+        expect(result).to eq "    (a) where appropriate, only the part which determines the classification;"
+      end
+    end
+  end
+
+  describe "rule 6: numbered bracket sub-sub-items" do
+    let(:content) { "(1) polished or glazed, measuring 1.429 decitex or more; or" }
+
+    it "adds four-space indent" do
+      expect(result).to eq "    (1) polished or glazed, measuring 1.429 decitex or more; or"
+    end
+  end
+
+  describe "rule 7: bullet character (•)" do
+    let(:content) { "•of rectangular (including square) shape with a thickness not exceeding one-tenth of the width;" }
+
+    it "converts to a Govspeak sub-bullet" do
+      expect(result).to eq "  - of rectangular (including square) shape with a thickness not exceeding one-tenth of the width;"
+    end
+  end
+
+  describe "rule 2: known section headings" do
+    context "when content is 'Subheading notes'" do
+      let(:content) { "Subheading notes" }
+
+      it "promotes to h3" do
+        expect(result).to eq "### Subheading notes"
+      end
+    end
+
+    context "when content is 'Additional section notes'" do
+      let(:content) { "Additional section notes" }
+
+      it "promotes to h3" do
+        expect(result).to eq "### Additional section notes"
+      end
+    end
+  end
+
+  describe "rule 8: continuation paragraph indentation" do
+    context "when plain prose immediately follows a numbered note" do
+      let(:content) do
+        "2. (A) Goods classifiable in Chapters 50 to 55.\n\n" \
+        "When no one textile material predominates by weight, the goods are to be classified accordingly."
+      end
+
+      it "indents the continuation paragraph with four spaces" do
+        expect(result).to eq(
+          "2. (A) Goods classifiable in Chapters 50 to 55.\n\n" \
+          "    When no one textile material predominates by weight, the goods are to be classified accordingly.",
+        )
+      end
+    end
+
+    context "when plain prose appears before any numbered note" do
+      let(:content) { "Some introductory text.\n\nMore introductory text." }
+
+      it "does not indent — no numbered note has been seen yet" do
+        expect(result).to eq "Some introductory text.\n\nMore introductory text."
+      end
+    end
+
+    context "when a known section heading appears after a numbered note" do
+      let(:content) { "15. Some note.\n\nSubheading notes\n\n1. Another note." }
+
+      it "promotes the heading to h3 and does not indent it" do
+        expect(result).to eq "15. Some note.\n\n### Subheading notes\n\n1. Another note."
+      end
+    end
+  end
+
+  describe "rule 1: em-dash table" do
+    let(:content) do
+      <<~TEXT.chomp
+        — single yarn of nylon or other polyamides, or of polyesters:
+        60 cN/tex,
+        — multiple (folded) or cabled yarn of nylon or other polyamides, or of polyesters:
+        53 cN/tex,
+        — single, multiple (folded) or cabled yarn of viscose rayon:
+        27 cN/tex.
+      TEXT
+    end
+
+    let(:expected_table) do
+      <<~TABLE.chomp
+        |   |   |
+        |---|---|
+        | — single yarn of nylon or other polyamides, or of polyesters: | 60 cN/tex, |
+        | — multiple (folded) or cabled yarn of nylon or other polyamides, or of polyesters: | 53 cN/tex, |
+        | — single, multiple (folded) or cabled yarn of viscose rayon: | 27 cN/tex. |
+      TABLE
+    end
+
+    it "converts em-dash pairs to a blank-header Govspeak table" do
+      expect(result).to eq expected_table
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-517](https://transformuk.atlassian.net/browse/AI-517)

### What?

I have added/removed/altered:

- Added a new `TariffNoteFormatter` class that converts raw section note text (as stored by the ETL pipeline) into properly structured Govspeak markdown before it is rendered
- Wired `TariffNoteFormatter` into `SectionNote#preview` so formatting is applied automatically at render time
- Added an RSpec unit test suite covering all formatting rules

### Why?

I am doing this because:

- The ETL pipeline stores section note content as plain text with no indentation, bold markers, or heading markup
- Without formatting, sub-items render as code blocks, bold definition headings appear as literal asterisks, and section headings are indented as plain paragraphs
- Transforming the content at render time (rather than at ETL time) keeps the stored data clean and lets us adjust formatting rules without re-running the pipeline

### Screenshot

<!-- Add screenshot here -->

### Have you? (optional)

- [x] Reviewed view changes with stake holders
- [x] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- No auth changes. The formatter only affects how existing section note content is displayed — it does not write to the database or change any stored data.