### PR TITLE
BAU: Add worktree isolation hook to flake (short Postgres + Bundler + automatic DB setup)

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -205,14 +205,20 @@
                 echo "    Installing gems + initializing databases + assets..."
                 echo ""
 
+                # Start Postgres as a proper daemon on the short socket if not already running
+                if ! pg_isready -h "$PGHOST" -p "${PGPORT:-5432}" >/dev/null 2>&1; then
+                  echo "    Starting Postgres as daemon on short socket..."
+                  pg_ctl start -D "$PGDATA" -l "/tmp/pg-$WT_ID.log" \
+                    -o "-k $PGHOST -c listen_addresses=''" -w -t 30 || true
+                fi
+
                 rm -rf .bundle
                 bundle install --jobs=4 --retry=3 2>&1 | tail -8 || true
-                bundle exec rails db:create 2>&1 | tail -3 || true
-                bundle exec rails db:structure:load 2>&1 | tail -5 || true
+                bundle exec rails db:prepare 2>&1 | tail -8 || true
 
                 echo ""
                 echo "    Preparing test database..."
-                RAILS_ENV=test bundle exec rails db:test:prepare 2>&1 | tail -5 || true
+                RAILS_ENV=test bundle exec rails db:prepare 2>&1 | tail -5 || true
 
                 echo ""
                 echo "    Installing JS dependencies and compiling webpack packs..."

--- a/flake.nix
+++ b/flake.nix
@@ -169,6 +169,9 @@
               WT_ID=$(${worktree.id})
               export GEM_HOME="$HOME/.local/share/gem/worktrees/$WT_ID"
               export BUNDLE_PATH=".bundle"
+              export BUNDLE_APP_CONFIG=".bundle"
+              export BUNDLE_IGNORE_CONFIG=1
+              export BUNDLE_FORCE_RUBY_PLATFORM=1
               mkdir -p "$GEM_HOME" ".bundle"
               echo "Worktree Bundler isolation enabled (ID: $WT_ID)"
             else

--- a/flake.nix
+++ b/flake.nix
@@ -89,12 +89,12 @@
         postgresql-start = pkgs.writeShellScriptBin "pg-start" ''
           ${pg-environment-variables}
 
-          if [ ! -d $PGDATA ]; then
-            mkdir -p $PGDATA
-            ${postgresql}/bin/initdb $PGDATA --auth=trust
+          if [ ! -f "$PGDATA/PG_VERSION" ]; then
+            mkdir -p "$PGDATA"
+            ${postgresql}/bin/initdb "$PGDATA" --auth=trust
           fi
 
-          ${postgresql}/bin/postgres -k $PGHOST -c listen_addresses=''' -c unix_socket_directories=$PGHOST
+          ${postgresql}/bin/postgres -k "$PGHOST" -c listen_addresses=''' -c unix_socket_directories="$PGHOST"
         '';
 
         worktree-info = pkgs.writeShellScriptBin "worktree-info" ''
@@ -119,13 +119,20 @@
           WT_ID=$(${worktree.id})
           echo "Cleaning worktree $WT_ID..."
 
-          if command -v dropdb >/dev/null 2>&1; then
-            dropdb --if-exists "tariff_admin_development" || true
-            dropdb --if-exists "tariff_admin_test" || true
+          PGDATA="$HOME/.local/share/postgres/worktrees/$WT_ID"
+          PGHOST="/tmp/pg-$WT_ID"
+          PIDFILE="/tmp/pg-$WT_ID.pid"
+
+          # Stop the daemonised Postgres for this worktree before removing its data.
+          if [ -f "$PGDATA/postmaster.pid" ] || [ -f "$PIDFILE" ]; then
+            echo "    Stopping Postgres..."
+            ${postgresql}/bin/pg_ctl stop -D "$PGDATA" -s -m fast || true
           fi
 
-          rm -rf "/tmp/pg-$WT_ID"
-          rm -rf "$HOME/.local/share/postgres/worktrees/$WT_ID"
+          rm -f "$PIDFILE"
+
+          rm -rf "$PGHOST"
+          rm -rf "$PGDATA"
           rm -rf ".bundle"
           rm -rf "$HOME/.local/share/gem/worktrees/$WT_ID" 2>/dev/null || true
           rm -rf "$HOME/.cache/bundle/worktrees/$WT_ID" 2>/dev/null || true
@@ -187,7 +194,7 @@
 
             export BUNDLE_BUILD__PG="${builtins.concatStringsSep " " postgresqlBuildFlags}"
             export GEM_PATH=$GEM_HOME
-            export PATH=$GEM_HOME/bin:$PATH
+            export PATH=${ruby}/bin:$GEM_HOME/bin:$PATH
 
             export BUNDLE_BUILD__PSYCH="${builtins.concatStringsSep " " psychBuildFlags}"
             export BUNDLE_BUILD__ZLIB="${builtins.concatStringsSep " " zlibBuildFlags}"
@@ -198,46 +205,91 @@
             if [ "$(${worktree.isWorktree})" = "true" ]; then
               WT_ID=$(${worktree.id})
               MARKER="$PGDATA/.worktree-initialized"
+              PIDFILE="/tmp/pg-$WT_ID.pid"
 
               if [ ! -f "$MARKER" ]; then
                 echo ""
-                echo "==> First time in this worktree (ID: $WT_ID)"
-                echo "    Installing gems + initializing databases + assets..."
+                echo "==> First time in this worktree ($WT_ID) - running full setup..."
                 echo ""
 
+                fail_worktree_setup() {
+                  echo ""
+                  echo "==> Worktree setup failed. Fix the error above, then re-enter the shell."
+                  if [ -f "$PGDATA/postmaster.pid" ]; then
+                    ${postgresql}/bin/pg_ctl stop -D "$PGDATA" -s -m fast || true
+                  fi
+                  exit 1
+                }
+
+                run_setup_step() {
+                  label="$1"
+                  shift
+                  log_file="/tmp/worktree-$WT_ID-$(echo "$label" | tr '[:upper:] /:' '[:lower:]---').log"
+
+                  echo "    $label..."
+                  if "$@" >"$log_file" 2>&1; then
+                    echo "      ok (log: $log_file)"
+                  else
+                    status=$?
+                    echo "      failed with exit $status (log: $log_file)"
+                    echo "      last 80 log lines:"
+                    tail -80 "$log_file" | sed 's/^/        /'
+                    return "$status"
+                  fi
+                }
+
                 # Start Postgres as a proper daemon on the short socket if not already running
-                if ! pg_isready -h "$PGHOST" -p "${PGPORT:-5432}" >/dev/null 2>&1; then
+                if ! ${postgresql}/bin/pg_isready -h "$PGHOST" -p "''${PGPORT:-5432}" >/dev/null 2>&1; then
                   echo "    Starting Postgres as daemon on short socket..."
-                  pg_ctl start -D "$PGDATA" -l "/tmp/pg-$WT_ID.log" \
-                    -o "-k $PGHOST -c listen_addresses=''" -w -t 30 || true
+                  if [ ! -f "$PGDATA/PG_VERSION" ]; then
+                    mkdir -p "$PGDATA"
+                    run_setup_step "Initialising Postgres data directory" ${postgresql}/bin/initdb "$PGDATA" --auth=trust || fail_worktree_setup
+                  fi
+                  rm -f "$PIDFILE"
+                  if ! ${postgresql}/bin/pg_ctl start -D "$PGDATA" -l "/tmp/pg-$WT_ID.log" -o "-k $PGHOST -c listen_addresses= -c external_pid_file=$PIDFILE" -w -t 60; then
+                    echo "      failed to start Postgres (log: /tmp/pg-$WT_ID.log)"
+                    echo "      last 80 log lines:"
+                    tail -80 "/tmp/pg-$WT_ID.log" | sed 's/^/        /' || true
+                    fail_worktree_setup
+                  fi
+                  for i in {1..60}; do
+                    if ${postgresql}/bin/pg_isready -h "$PGHOST" -p "''${PGPORT:-5432}" >/dev/null 2>&1; then
+                      break
+                    fi
+                    sleep 1
+                  done
+                  if ! ${postgresql}/bin/pg_isready -h "$PGHOST" -p "''${PGPORT:-5432}" >/tmp/pg-$WT_ID-ready.log 2>&1; then
+                    echo "      Postgres did not become ready on $PGHOST"
+                    cat /tmp/pg-$WT_ID-ready.log | sed 's/^/        /' || true
+                    fail_worktree_setup
+                  fi
                 fi
 
                 rm -rf .bundle
-                bundle install --jobs=4 --retry=3 2>&1 | tail -8 || true
-                bundle exec rails db:prepare 2>&1 | tail -8 || true
-
-                echo ""
-                echo "    Preparing test database..."
-                RAILS_ENV=test bundle exec rails db:prepare 2>&1 | tail -5 || true
-
-                echo ""
-                echo "    Installing JS dependencies and compiling webpack packs..."
-                yarn install --frozen-lockfile 2>&1 | tail -5 || true
-                bundle exec bin/webpack 2>&1 | tail -8 || true
+                export BUNDLE_PATH=".bundle"
+                export BUNDLE_APP_CONFIG=".bundle"
+                export BUNDLE_IGNORE_CONFIG=1
+                export BUNDLE_FORCE_RUBY_PLATFORM=1
+                run_setup_step "Installing gems" bundle install --jobs=4 --retry=3 || fail_worktree_setup
+                run_setup_step "Preparing development database" bundle exec rails db:prepare || fail_worktree_setup
+                run_setup_step "Preparing test database" env RAILS_ENV=test bundle exec rails db:prepare || fail_worktree_setup
+                run_setup_step "Installing JS dependencies" yarn install --frozen-lockfile || fail_worktree_setup
+                run_setup_step "Compiling webpack packs" bundle exec bin/webpack || fail_worktree_setup
+                run_setup_step "Installing pre-commit hooks" pre-commit install --install-hooks || fail_worktree_setup
 
                 touch "$MARKER"
                 echo ""
-                echo "==> Worktree databases + assets ready."
+                echo "==> Worktree first-time setup complete."
                 echo ""
+              else
+                export BUNDLE_PATH=".bundle"
+                export BUNDLE_APP_CONFIG=".bundle"
+                export BUNDLE_IGNORE_CONFIG=1
+                export BUNDLE_FORCE_RUBY_PLATFORM=1
               fi
             fi
 
             ${worktree-info}/bin/worktree-info
-
-            # Ensure pre-commit hooks are installed (so they actually run on commit)
-            if command -v pre-commit >/dev/null 2>&1; then
-              pre-commit install --install-hooks 2>/dev/null || true
-            fi
           '';
 
           buildInputs = [

--- a/flake.nix
+++ b/flake.nix
@@ -199,9 +199,11 @@
               if [ ! -f "$MARKER" ]; then
                 echo ""
                 echo "==> First time in this worktree (ID: $WT_ID)"
-                echo "    Initializing databases (db:create + db:structure:load + db:test:prepare)..."
+                echo "    Installing gems + initializing databases + assets..."
                 echo ""
 
+                rm -rf .bundle
+                bundle install --jobs=4 --retry=3 2>&1 | tail -8 || true
                 bundle exec rails db:create 2>&1 | tail -3 || true
                 bundle exec rails db:structure:load 2>&1 | tail -5 || true
 
@@ -212,7 +214,7 @@
                 echo ""
                 echo "    Installing JS dependencies and compiling webpack packs..."
                 yarn install --frozen-lockfile 2>&1 | tail -5 || true
-                bin/webpack 2>&1 | tail -8 || true
+                bundle exec bin/webpack 2>&1 | tail -8 || true
 
                 touch "$MARKER"
                 echo ""

--- a/flake.nix
+++ b/flake.nix
@@ -48,25 +48,95 @@
           "--with-zlib-lib=${zlib.out}/lib"
         ];
         postgresql = pkgs.postgresql_18;
+
+        # Worktree isolation hook (same pattern as backend)
+        worktree = rec {
+          isWorktree = ''
+            if git rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+              if [ "$(git rev-parse --git-dir 2>/dev/null)" != "$(git rev-parse --git-common-dir 2>/dev/null)" ]; then
+                echo "true"
+              else
+                echo "false"
+              fi
+            else
+              echo "false"
+            fi
+          '';
+
+          id = ''
+            if [ "$(${isWorktree})" = "true" ]; then
+              git rev-parse --show-toplevel | md5sum | cut -c1-8
+            else
+              echo "main"
+            fi
+          '';
+        };
+
         pg-environment-variables = ''
-          export PGDATA=$PWD/.nix/postgres/data
-          export PGHOST=$PWD/.nix/postgres
-          export PGPORT=5432
+          if [ "$(${worktree.isWorktree})" = "true" ]; then
+            WT_ID=$(${worktree.id})
+            export PGHOST="/tmp/pg-$WT_ID"
+            export PGDATA="$HOME/.local/share/postgres/worktrees/$WT_ID"
+            mkdir -p "$PGHOST" "$PGDATA"
+          else
+            export PGDATA=$PWD/.nix/postgres/data
+            export PGHOST=$PWD/.nix/postgres
+            export PGPORT=5432
+          fi
           export DB_USER=""
         '';
 
         postgresql-start = pkgs.writeShellScriptBin "pg-start" ''
           ${pg-environment-variables}
 
-          mkdir -p $PGHOST
-
           if [ ! -d $PGDATA ]; then
             mkdir -p $PGDATA
-
             ${postgresql}/bin/initdb $PGDATA --auth=trust
           fi
 
           ${postgresql}/bin/postgres -k $PGHOST -c listen_addresses=''' -c unix_socket_directories=$PGHOST
+        '';
+
+        worktree-info = pkgs.writeShellScriptBin "worktree-info" ''
+          if [ "$(${worktree.isWorktree})" = "true" ]; then
+            WT_ID=$(${worktree.id})
+            echo "Worktree mode enabled"
+            echo "  ID:          $WT_ID"
+            echo "  PGHOST:      /tmp/pg-$WT_ID"
+            echo "  PGDATA:      $HOME/.local/share/postgres/worktrees/$WT_ID"
+          else
+            echo "Normal checkout (not a worktree)"
+          fi
+        '';
+
+        worktree-clean = pkgs.writeShellScriptBin "worktree-clean" ''
+          set -euo pipefail
+          if [ "$(${worktree.isWorktree})" != "true" ]; then
+            echo "Not inside a worktree. Nothing to clean."
+            exit 0
+          fi
+
+          WT_ID=$(${worktree.id})
+          echo "Cleaning worktree $WT_ID..."
+
+          if command -v dropdb >/dev/null 2>&1; then
+            dropdb --if-exists "tariff_admin_development" || true
+            dropdb --if-exists "tariff_admin_test" || true
+          fi
+
+          rm -rf "/tmp/pg-$WT_ID"
+          rm -rf "$HOME/.local/share/postgres/worktrees/$WT_ID"
+          rm -rf ".bundle"
+          rm -rf "$HOME/.local/share/gem/worktrees/$WT_ID" 2>/dev/null || true
+          rm -rf "$HOME/.cache/bundle/worktrees/$WT_ID" 2>/dev/null || true
+
+          # Per-worktree Yarn cache + generated webpack packs (for bin/webpack)
+          rm -rf "$HOME/.local/share/yarn/worktrees/$WT_ID"
+          rm -rf public/packs public/packs-test 2>/dev/null || true
+
+          rm -f "$HOME/.local/share/postgres/worktrees/$WT_ID/.worktree-initialized" 2>/dev/null || true
+
+          echo "Worktree $WT_ID cleaned (Postgres + bundle + yarn + packs)."
         '';
 
         lint = pkgs.writeShellScriptBin "lint" ''
@@ -94,8 +164,23 @@
             export CPATH="${pkgs.zlib.dev}/include:$CPATH"
             export LIBRARY_PATH="${pkgs.zlib.out}/lib:$LIBRARY_PATH"
 
-            export GEM_HOME=$PWD/.nix/ruby/$(${ruby}/bin/ruby -e "puts RUBY_VERSION")
-            mkdir -p $GEM_HOME
+            # Worktree-aware Bundler/Ruby isolation
+            if [ "$(${worktree.isWorktree})" = "true" ]; then
+              WT_ID=$(${worktree.id})
+              export GEM_HOME="$HOME/.local/share/gem/worktrees/$WT_ID"
+              export BUNDLE_PATH=".bundle"
+              mkdir -p "$GEM_HOME" ".bundle"
+              echo "Worktree Bundler isolation enabled (ID: $WT_ID)"
+            else
+              export GEM_HOME=$PWD/.nix/ruby/$(${ruby}/bin/ruby -e "puts RUBY_VERSION")
+              mkdir -p $GEM_HOME
+            fi
+
+            # Per-worktree Yarn cache (for bin/webpack after yarn)
+            if [ "$(${worktree.isWorktree})" = "true" ]; then
+              export YARN_CACHE_FOLDER="$HOME/.local/share/yarn/worktrees/$WT_ID"
+              mkdir -p "$YARN_CACHE_FOLDER"
+            fi
 
             export BUNDLE_BUILD__PG="${builtins.concatStringsSep " " postgresqlBuildFlags}"
             export GEM_PATH=$GEM_HOME
@@ -105,6 +190,43 @@
             export BUNDLE_BUILD__ZLIB="${builtins.concatStringsSep " " zlibBuildFlags}"
 
             ${pg-environment-variables}
+
+            # === Automatic per-worktree database initialization ===
+            if [ "$(${worktree.isWorktree})" = "true" ]; then
+              WT_ID=$(${worktree.id})
+              MARKER="$PGDATA/.worktree-initialized"
+
+              if [ ! -f "$MARKER" ]; then
+                echo ""
+                echo "==> First time in this worktree (ID: $WT_ID)"
+                echo "    Initializing databases (db:create + db:structure:load + db:test:prepare)..."
+                echo ""
+
+                bundle exec rails db:create 2>&1 | tail -3 || true
+                bundle exec rails db:structure:load 2>&1 | tail -5 || true
+
+                echo ""
+                echo "    Preparing test database..."
+                RAILS_ENV=test bundle exec rails db:test:prepare 2>&1 | tail -5 || true
+
+                echo ""
+                echo "    Installing JS dependencies and compiling webpack packs..."
+                yarn install --frozen-lockfile 2>&1 | tail -5 || true
+                bin/webpack 2>&1 | tail -8 || true
+
+                touch "$MARKER"
+                echo ""
+                echo "==> Worktree databases + assets ready."
+                echo ""
+              fi
+            fi
+
+            ${worktree-info}/bin/worktree-info
+
+            # Ensure pre-commit hooks are installed (so they actually run on commit)
+            if command -v pre-commit >/dev/null 2>&1; then
+              pre-commit install --install-hooks 2>/dev/null || true
+            fi
           '';
 
           buildInputs = [
@@ -112,6 +234,7 @@
             init
             lint
             lint-all
+            pkgs.pre-commit
             pkgs.circleci-cli
             pkgs.python3
             pkgs.rufo
@@ -123,6 +246,8 @@
             postgresql-start
             ruby
             update-providers
+            worktree-info
+            worktree-clean
           ];
         };
       }


### PR DESCRIPTION
## What

Add worktree isolation support to the `trade-tariff-admin` flake.

- When running inside a git worktree, automatically switch Postgres to a short socket path (`/tmp/pg-<short-id>`) and Bundler/Ruby to short `GEM_HOME` + `BUNDLE_PATH=.bundle` (with `BUNDLE_FORCE_RUBY_PLATFORM=1`).
- Isolate Yarn cache for long paths.
- On first entry to a new worktree, automatically:
  - Start Postgres as a proper daemon using `pg_ctl start -w` (with wait) on the short socket.
  - Run `bundle install` (with defensive `rm -rf .bundle` and explicit flags).
  - Run `rails db:prepare`.
  - Run `yarn install` + `bundle exec bin/webpack`.
  - Run `pre-commit install --install-hooks`.
- Expose `worktree-info` and `worktree-clean` (removes per-worktree Postgres data, bundle, yarn cache, and generated packs).

## Why

Long worktree paths (the superpowers pattern) break Unix socket paths for Postgres (~108 char limit), Bundler gem paths, and Yarn caches. Developers had to manually run multiple setup commands every time they created a fresh worktree.

Key lessons from implementation:
- Services like Postgres must be started with proper daemonisation (`pg_ctl start -w`) rather than simple `nohup ... &`.
- The first `bundle install` in a worktree must be explicit and defensive (clean `.bundle`, `BUNDLE_FORCE_RUBY_PLATFORM=1`) to avoid gem platform conflicts between system Ruby and Nix Ruby.
- Using `bundle exec` for tools like `bin/webpack` is more reliable than direct invocation in the Nix environment.

## Verification

- Hook tested in multiple brand-new clean long-path git worktrees created from the feature branch.
- `nix develop` in a fresh worktree now correctly:
  - Enables all short-path isolation.
  - Starts Postgres as a daemon with wait.
  - Completes full first-time setup (bundle + DB + yarn + webpack + pre-commit).
- `worktree-clean` removes all per-worktree state.
- Real diff with single `BAU:` commit on the feature branch.

## Risk

🟢 Low — developer experience / Nix flake change only. All logic is guarded by the `isWorktree` check and falls back on normal checkouts. No production impact. The pattern has been applied consistently across the platform.