### PR TITLE
AI-517: Implement Section Notes Review Approval Process

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,10 +1,11 @@
 ADMIN_HOST='http://localhost:3000'
 API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000/uk","xi":"http://localhost:3000/xi" }
 AUTH_STRATEGY=none
+BEARER_TOKEN=tariff-api-test-token
+ENABLE_SECTION_CHAPTER_NOTE_VERSIONING=false
 IDENTITY_BASE_URL=http://localhost:3005
 IDENTITY_CONSUMER=admin
 BASIC_PASSWORD=dev123
-BEARER_TOKEN=tariff-api-test-token
 PORT=3003
 SERVICE_DEFAULT=uk
 TARIFF_API_HOST=http://localhost:3000/

--- a/.env.development
+++ b/.env.development
@@ -2,7 +2,6 @@ ADMIN_HOST='http://localhost:3000'
 API_SERVICE_BACKEND_URL_OPTIONS={"uk":"http://localhost:3000/uk","xi":"http://localhost:3000/xi" }
 AUTH_STRATEGY=none
 BEARER_TOKEN=tariff-api-test-token
-ENABLE_SECTION_CHAPTER_NOTE_VERSIONING=false
 IDENTITY_BASE_URL=http://localhost:3005
 IDENTITY_CONSUMER=admin
 BASIC_PASSWORD=dev123

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
             db/
             data/
             docs/
+            spec/
             terraform/versions.tf
             *.md
             *.lock

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -25,7 +25,7 @@ class ApplicationController < ActionController::Base
   def default_landing_path
     return references_sections_path if current_user&.hmrc_admin?
     # dashboard is routed to pages#index however to replicate behaviour reroute to customs_tariff_updates_path for UK
-    return customs_tariff_updates_path if TradeTariffAdmin::ServiceChooser.uk?
+    return customs_tariff_updates_path if TradeTariffAdmin::ServiceChooser.uk? && TradeTariffAdmin.enable_section_chapter_note_versioning?
 
     dashboard_path
   end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -24,6 +24,8 @@ class ApplicationController < ActionController::Base
 
   def default_landing_path
     return references_sections_path if current_user&.hmrc_admin?
+    # dashboard is routed to pages#index however to replicate behaviour reroute to customs_tariff_updates_path for UK
+    return customs_tariff_updates_path if TradeTariffAdmin::ServiceChooser.uk?
 
     dashboard_path
   end

--- a/app/controllers/customs_tariff/updates/comparisons_controller.rb
+++ b/app/controllers/customs_tariff/updates/comparisons_controller.rb
@@ -1,0 +1,37 @@
+module CustomsTariff
+  module Updates
+    class ComparisonsController < AuthenticatedController
+      before_action :require_compare_version
+
+      def index
+        @update = CustomsTariff::Update.find(params[:version])
+        authorize @update, :show?
+        @compare_version = params[:compare_version]
+        @section_notes = CustomsTariff::SectionNote.all(
+          customs_tariff_update_version: params[:version],
+          compare_version: @compare_version,
+        )
+      end
+
+      def show
+        @update = CustomsTariff::Update.find(params[:update_version])
+        authorize @update, :show?
+        @compare_version = params[:compare_version]
+        @section_note = CustomsTariff::SectionNote.find(
+          params[:id],
+          customs_tariff_update_version: params[:update_version],
+          compare_version: @compare_version,
+        )
+      end
+
+    private
+
+      def require_compare_version
+        return if params[:compare_version].present?
+
+        redirect_to customs_tariff_update_path(params[:version] || params[:update_version]),
+                    alert: "Please select a version to compare against."
+      end
+    end
+  end
+end

--- a/app/controllers/customs_tariff/updates/section_notes_controller.rb
+++ b/app/controllers/customs_tariff/updates/section_notes_controller.rb
@@ -1,0 +1,44 @@
+module CustomsTariff
+  module Updates
+    class SectionNotesController < AuthenticatedController
+      def edit
+        @update = CustomsTariff::Update.find(params[:update_version])
+        @section_note = CustomsTariff::SectionNote.find(
+          params[:id],
+          customs_tariff_update_version: params[:update_version],
+        )
+        authorize @section_note, :edit?
+      end
+
+      def update
+        @update = CustomsTariff::Update.find(params[:update_version])
+        @section_note = CustomsTariff::SectionNote.find(
+          params[:id],
+          customs_tariff_update_version: params[:update_version],
+        )
+        authorize @section_note, :update?
+        @section_note.build(content: section_note_params[:content])
+
+        if @section_note.save && @section_note.errors.empty?
+          redirect_to customs_tariff_update_path(params[:update_version]),
+                      notice: "Section note updated."
+        else
+          render :edit
+        end
+      end
+
+      def preview
+        authorize CustomsTariff::SectionNote, :update?
+        content = params.fetch(:content, "")
+        formatted = TariffNoteFormatter.new(content).format
+        render json: { html: GovspeakPreview.new(formatted).render }
+      end
+
+    private
+
+      def section_note_params
+        params.require(:customs_tariff_section_note).permit(:content)
+      end
+    end
+  end
+end

--- a/app/controllers/customs_tariff/updates_controller.rb
+++ b/app/controllers/customs_tariff/updates_controller.rb
@@ -8,6 +8,7 @@ module CustomsTariff
     def show
       @update = CustomsTariff::Update.find(params[:version])
       authorize @update, :show?
+      @updates = CustomsTariff::Update.all
       @section_notes = CustomsTariff::SectionNote.all(customs_tariff_update_version: params[:version])
     end
 

--- a/app/controllers/customs_tariff/updates_controller.rb
+++ b/app/controllers/customs_tariff/updates_controller.rb
@@ -1,0 +1,30 @@
+module CustomsTariff
+  class UpdatesController < AuthenticatedController
+    def index
+      authorize CustomsTariff::Update, :index?
+      @updates = CustomsTariff::Update.all
+    end
+
+    def show
+      @update = CustomsTariff::Update.find(params[:version])
+      authorize @update, :show?
+      @section_notes = CustomsTariff::SectionNote.all(customs_tariff_update_version: params[:version])
+    end
+
+    def update_status
+      @update = CustomsTariff::Update.find(params[:version])
+      authorize @update, :update?
+
+      CustomsTariff::Update.api.patch(
+        "admin/customs_tariff_updates/#{params[:version]}/status",
+        { data: { attributes: { status: params.require(:status) } } },
+      )
+
+      redirect_to customs_tariff_update_path(params[:version]),
+                  notice: "Status updated to #{params[:status]}."
+    rescue Faraday::UnprocessableEntityError => e
+      redirect_to customs_tariff_update_path(params[:version]),
+                  alert: "Could not update status: #{e.response[:body].dig('errors', 0, 'detail')}"
+    end
+  end
+end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -31,7 +31,7 @@ private
     filter = { page: params[:page] || 1 }
     filter[:item_type] = params[:item_type] if params[:item_type].present?
     filter[:event] = event_filter if event_filter.present?
-    filter[:exclude_item_type] = %w[ChapterNote SectionNote] if params[:item_type].blank?
+    filter[:exclude_item_type] = %w[ChapterNote SectionNote CustomsTariffSectionNote] if params[:item_type].blank?
     filter
   end
 

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -3,6 +3,7 @@ module NavigationHelper
   NavigationItem = Data.define(:text, :href, :policy_class, :active_when, :service)
 
   def navigation_sections
+    versioning = TradeTariffAdmin.enable_section_chapter_note_versioning?
     @navigation_sections ||= [
       NavigationSection.new(
         key: :ott_admin,
@@ -12,9 +13,9 @@ module NavigationHelper
         items: [
           NavigationItem.new(
             text: "Section & chapter notes",
-            href: customs_tariff_updates_path,
-            policy_class: CustomsTariff::Update,
-            active_when: /\/customs_tariff/,
+            href: versioning ? customs_tariff_updates_path : notes_sections_path,
+            policy_class: versioning ? CustomsTariff::Update : SectionNote,
+            active_when: versioning ? %r{/customs_tariff} : %r{/notes},
             service: :uk,
           ),
           NavigationItem.new(

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -12,10 +12,17 @@ module NavigationHelper
         items: [
           NavigationItem.new(
             text: "Section & chapter notes",
+            href: customs_tariff_updates_path,
+            policy_class: CustomsTariff::Update,
+            active_when: /\/customs_tariff/,
+            service: :uk,
+          ),
+          NavigationItem.new(
+            text: "Section & chapter notes",
             href: notes_sections_path,
             policy_class: SectionNote,
             active_when: /\/notes/,
-            service: nil,
+            service: :xi,
           ),
           NavigationItem.new(
             text: "News",

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -32,6 +32,14 @@ module VersionsHelper
     safe_join(version.changes.map { |field, change| render_field_change(field, change) })
   end
 
+  def side_by_side_diff_html(version, from_version:, to_version:)
+    return nil unless version.has_changeset?
+
+    safe_join(version.changes.map do |field, change|
+      render_side_by_side_field(field, change, from_version:, to_version:)
+    end)
+  end
+
 private
 
   def version_oid(version)
@@ -82,6 +90,43 @@ private
       content_tag(:del, change["old"].to_s, class: "diff-delete") +
         content_tag(:span, " -> ", class: "diff-unchanged") +
         content_tag(:ins, change["new"].to_s, class: "diff-insert")
+    end
+  end
+
+  def render_side_by_side_field(field, change, from_version:, to_version:)
+    # Text diffs use version labels as panel headings rather than the field name,
+    # since this helper is called in contexts where version identity is more meaningful.
+    if change["type"] == "text"
+      render_side_by_side_text(change, from_version:, to_version:)
+    else
+      render_field_change(field, change)
+    end
+  end
+
+  def render_side_by_side_text(change, from_version:, to_version:)
+    ops = Array(change["diff"])
+
+    old_content = safe_join(
+      ops.reject { |op| op["op"] == "insert" }.map do |op|
+        op["op"] == "delete" ? content_tag(:del, op["text"], class: "diff-delete") : op["text"]
+      end,
+    )
+
+    new_content = safe_join(
+      ops.reject { |op| op["op"] == "delete" }.map do |op|
+        op["op"] == "insert" ? content_tag(:ins, op["text"], class: "diff-insert") : op["text"]
+      end,
+    )
+
+    content_tag(:div, class: "diff-side-by-side") do
+      diff_panel(from_version, old_content) + diff_panel(to_version, new_content)
+    end
+  end
+
+  def diff_panel(label, content)
+    content_tag(:div, class: "diff-side-by-side__panel") do
+      content_tag(:strong, label, class: "diff-side-by-side__label") +
+        content_tag(:div, content, class: "diff-side-by-side__content")
     end
   end
 end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -4,6 +4,9 @@ module VersionsHelper
     opts = oid ? { oid: oid } : {}
 
     case version.item_type
+    when "CustomsTariffSectionNote"
+      update_version = version.object&.dig("customs_tariff_update_version")
+      customs_tariff_update_path(update_version) if update_version.present?
     when "GoodsNomenclatureLabel"
       item_id = version.object&.dig("goods_nomenclature_item_id")
       goods_nomenclature_label_path(item_id, **opts) if item_id.present?

--- a/app/models/customs_tariff/section_note.rb
+++ b/app/models/customs_tariff/section_note.rb
@@ -14,6 +14,16 @@ module CustomsTariff
       :changed
     end
 
+    def has_changeset?
+      file_diff_status == :changed
+    end
+
+    def changes
+      return {} unless file_diff.is_a?(Hash)
+
+      file_diff["changes"] || {}
+    end
+
     def preview
       return if content.blank?
 

--- a/app/models/customs_tariff/section_note.rb
+++ b/app/models/customs_tariff/section_note.rb
@@ -1,0 +1,27 @@
+module CustomsTariff
+  class SectionNote
+    include ApiEntity
+
+    attributes :section_id, :content, :customs_tariff_update_version, :file_diff, :versions
+
+    set_singular_path   "admin/customs_tariff_updates/:customs_tariff_update_version/section_notes/:id"
+    set_collection_path "admin/customs_tariff_updates/:customs_tariff_update_version/section_notes"
+
+    def file_diff_status
+      return :new       if file_diff.nil?
+      return :unchanged if file_diff.respond_to?(:empty?) && file_diff.empty?
+
+      :changed
+    end
+
+    def preview
+      return if content.blank?
+
+      GovspeakPreview.new(TariffNoteFormatter.new(content).format).render
+    end
+
+    def version_objects
+      @version_objects ||= (versions || []).map { |v| Version.new(v.merge("resource_id" => v["id"])) }
+    end
+  end
+end

--- a/app/models/customs_tariff/update.rb
+++ b/app/models/customs_tariff/update.rb
@@ -1,0 +1,19 @@
+module CustomsTariff
+  class Update
+    include ApiEntity
+
+    attributes :version, :status, :validity_start_date, :validity_end_date,
+               :source_url, :document_created_on, :created_at, :updated_at
+
+    set_collection_path "admin/customs_tariff_updates"
+    set_singular_path   "admin/customs_tariff_updates/:version"
+
+    def pending?  = status == "pending"
+    def approved? = status == "approved"
+    def rejected? = status == "rejected"
+
+    def status_tag_colour
+      { "pending" => "blue", "approved" => "green", "rejected" => "red" }.fetch(status, "grey")
+    end
+  end
+end

--- a/app/policies/customs_tariff/section_note_policy.rb
+++ b/app/policies/customs_tariff/section_note_policy.rb
@@ -1,0 +1,6 @@
+module CustomsTariff
+  class SectionNotePolicy < ApplicationPolicy
+    def edit?   = technical_operator?
+    def update? = technical_operator?
+  end
+end

--- a/app/policies/customs_tariff/update_policy.rb
+++ b/app/policies/customs_tariff/update_policy.rb
@@ -1,0 +1,7 @@
+module CustomsTariff
+  class UpdatePolicy < ApplicationPolicy
+    def index?  = technical_operator? || auditor?
+    def show?   = technical_operator? || auditor?
+    def update? = technical_operator?
+  end
+end

--- a/app/views/customs_tariff/updates/comparisons/index.html.erb
+++ b/app/views/customs_tariff/updates/comparisons/index.html.erb
@@ -1,6 +1,8 @@
-<h2>Comparing update <%= @update.version %> against <%= @compare_version %></h2>
+<p class="govuk-body">
+  <%= govuk_back_link(text: "Back to update #{@update.version}", href: customs_tariff_update_path(@update.version)) %>
+</p>
 
-<%= govuk_back_link(text: "Back to update", href: customs_tariff_update_path(@update.version)) %>
+<h2>Comparing update <%= @update.version %> against <%= @compare_version %></h2>
 
 <%= govuk_table do |table|
   table.with_head do |head|

--- a/app/views/customs_tariff/updates/comparisons/index.html.erb
+++ b/app/views/customs_tariff/updates/comparisons/index.html.erb
@@ -1,0 +1,36 @@
+<h2>Comparing update <%= @update.version %> against <%= @compare_version %></h2>
+
+<%= govuk_back_link(text: "Back to update", href: customs_tariff_update_path(@update.version)) %>
+
+<%= govuk_table do |table|
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(text: "Section")
+      row.with_cell(text: "Change")
+      row.with_cell(text: "Actions")
+    end
+  end
+
+  table.with_body do |body|
+    @section_notes.each do |note|
+      chip_colour = { new: "blue", changed: "orange", unchanged: "grey" }.fetch(note.file_diff_status, "grey")
+
+      body.with_row do |row|
+        row.with_cell(text: "Section #{note.section_id}")
+        row.with_cell do
+          tag.strong(note.file_diff_status.to_s.capitalize, class: "govuk-tag govuk-tag--#{chip_colour}")
+        end
+        row.with_cell do
+          unless note.file_diff_status == :new || note.file_diff_status == :unchanged
+            link_to "View diff",
+                    customs_tariff_update_comparison_section_note_path(
+                      @update.version, note.id,
+                      compare_version: @compare_version
+                    ),
+                    class: "govuk-link"
+          end
+        end
+      end
+    end
+  end
+end %>

--- a/app/views/customs_tariff/updates/comparisons/show.html.erb
+++ b/app/views/customs_tariff/updates/comparisons/show.html.erb
@@ -1,10 +1,11 @@
-<h2>Section <%= @section_note.section_id %> &mdash; <%= @update.version %> compared against <%= @compare_version %></h2>
-
-<%= govuk_back_link(
-  text: "Back to comparison",
+<p class="govuk-body">
+  <%= govuk_back_link(
+  text: "Back to comparison summary",
   href: customs_tariff_update_comparison_path(@update.version, compare_version: @compare_version)
 ) %>
+<p>
 
+<h2>Section <%= @section_note.section_id %> &mdash; <%= @update.version %> compared against <%= @compare_version %></h2>
 <% if @section_note.has_changeset? %>
   <%= side_by_side_diff_html(@section_note, from_version: @compare_version, to_version: @update.version) %>
 <% else %>

--- a/app/views/customs_tariff/updates/comparisons/show.html.erb
+++ b/app/views/customs_tariff/updates/comparisons/show.html.erb
@@ -1,0 +1,22 @@
+<h2>Section <%= @section_note.section_id %> &mdash; <%= @update.version %> compared against <%= @compare_version %></h2>
+
+<%= govuk_back_link(
+  text: "Back to comparison",
+  href: customs_tariff_update_comparison_path(@update.version, compare_version: @compare_version)
+) %>
+
+<% if @section_note.has_changeset? %>
+  <%= side_by_side_diff_html(@section_note, from_version: @compare_version, to_version: @update.version) %>
+<% else %>
+  <%= govuk_inset_text do %>
+    No changes in this section between <%= @update.version %> and <%= @compare_version %>.
+  <% end %>
+<% end %>
+
+<% if !@update.rejected? && policy(@section_note).edit? %>
+  <p class="govuk-body">
+    <%= link_to "Edit this note",
+          edit_customs_tariff_update_section_note_path(@update.version, @section_note.id),
+          class: "govuk-link" %>
+  </p>
+<% end %>

--- a/app/views/customs_tariff/updates/index.html.erb
+++ b/app/views/customs_tariff/updates/index.html.erb
@@ -1,0 +1,29 @@
+<h2>Customs Tariff Updates</h2>
+
+<%= govuk_table do |table|
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(text: 'Version')
+      row.with_cell(text: 'Valid from')
+      row.with_cell(text: 'Valid to')
+      row.with_cell(text: 'Status')
+      row.with_cell(text: 'Actions')
+    end
+  end
+
+  table.with_body do |body|
+    @updates.each do |update|
+      body.with_row do |row|
+        row.with_cell(text: update.version)
+        row.with_cell(text: update.validity_start_date)
+        row.with_cell(text: update.validity_end_date || '—')
+        row.with_cell do
+          tag.strong(update.status.capitalize, class: "govuk-tag govuk-tag--#{update.status_tag_colour}")
+        end
+        row.with_cell do
+          link_to 'Review', customs_tariff_update_path(update.version), class: 'govuk-link'
+        end
+      end
+    end
+  end
+end %>

--- a/app/views/customs_tariff/updates/section_notes/edit.html.erb
+++ b/app/views/customs_tariff/updates/section_notes/edit.html.erb
@@ -1,0 +1,43 @@
+<h2> Edit Section <%= @section_note.section_id %> Note </h2>
+
+<p class="govuk-body">
+  Update version: <%= @update.version %>
+  &nbsp;
+  <%= link_to 'Back to update', customs_tariff_update_path(@update.version), class: 'govuk-link' %>
+</p>
+
+<div class="govuk-grid-row"
+     data-controller="tariff-note-preview"
+     data-tariff-note-preview-url-value="<%= customs_tariff_section_note_preview_path %>">
+  <div class="govuk-grid-column-one-half">
+    <%= form_with model: @section_note,
+                  url: customs_tariff_update_section_note_path(@update.version, @section_note.id),
+                  method: :patch do |f| %>
+      <div class="govuk-form-group">
+        <%= f.label :content, 'Content', class: 'govuk-label govuk-label--m' %>
+        <%= f.text_area :content, rows: 20, class: 'govuk-textarea',
+                        data: { tariff_note_preview_target: 'content',
+                                action: 'input->tariff-note-preview#update' } %>
+      </div>
+      <div class="govuk-button-group">
+        <%= f.submit 'Save', class: 'govuk-button' %>
+        <%= link_to 'Cancel', customs_tariff_update_path(@update.version), class: 'govuk-link' %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">Preview</h2>
+    <div class="govuk-body" data-tariff-note-preview-target="preview">
+      <%= @section_note.preview&.html_safe %>
+    </div>
+  </div>
+</div>
+
+<% if @section_note.version_objects.any? %>
+  <%= render 'versions/history_section',
+        versions: @section_note.version_objects,
+        can_restore: policy(@section_note).update?,
+        view_path_helper: nil,
+        restore_path_helper: ->(v) { restore_version_path(v.resource_id) } %>
+<% end %>

--- a/app/views/customs_tariff/updates/section_notes/edit.html.erb
+++ b/app/views/customs_tariff/updates/section_notes/edit.html.erb
@@ -29,7 +29,7 @@
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-m">Preview</h2>
     <div class="govuk-body" data-tariff-note-preview-target="preview">
-      <%= @section_note.preview&.html_safe %>
+      <%= @section_note.preview %>
     </div>
   </div>
 </div>

--- a/app/views/customs_tariff/updates/show.html.erb
+++ b/app/views/customs_tariff/updates/show.html.erb
@@ -38,6 +38,17 @@
   <% end %>
 <% end %>
 
+<h2 class="govuk-heading-m">Compare with another version</h2>
+
+<%= form_with url: customs_tariff_update_comparison_path(@update.version), method: :get do |f| %>
+  <%= f.select :compare_version,
+        @updates.reject { |u| u.version == @update.version }
+                .map { |u| ["#{u.version} (#{u.status})", u.version] },
+        { include_blank: "Select a version..." },
+        { class: "govuk-select" } %>
+  <%= f.submit "Compare", class: "govuk-button govuk-button--secondary" %>
+<% end %>
+
 <h2 class="govuk-heading-m">Section Notes</h2>
 
 <%= govuk_table do |table|

--- a/app/views/customs_tariff/updates/show.html.erb
+++ b/app/views/customs_tariff/updates/show.html.erb
@@ -1,0 +1,77 @@
+<h2>Customs Tariff Update <%= @update.version %></h2>
+
+<p class="govuk-body">
+  Status:
+  <strong class="govuk-tag govuk-tag--<%= @update.status_tag_colour %>">
+    <%= @update.status.capitalize %>
+  </strong>
+</p>
+
+<% if policy(@update).update? %>
+  <div class="govuk-button-group">
+    <% if @update.pending? %>
+      <%= button_to 'Approve', update_status_customs_tariff_update_path(@update.version),
+            params: { status: 'approved' }, method: :patch, class: 'govuk-button' %>
+      <%= button_to 'Reject', update_status_customs_tariff_update_path(@update.version),
+            params: { status: 'rejected' }, method: :patch,
+            class: 'govuk-button govuk-button--warning',
+            data: { confirm: 'Are you sure you want to reject this update?' } %>
+    <% elsif @update.approved? %>
+      <%= button_to 'Set to Pending', update_status_customs_tariff_update_path(@update.version),
+            params: { status: 'pending' }, method: :patch, class: 'govuk-button govuk-button--secondary' %>
+      <%= button_to 'Reject', update_status_customs_tariff_update_path(@update.version),
+            params: { status: 'rejected' }, method: :patch,
+            class: 'govuk-button govuk-button--warning',
+            data: { confirm: 'This will take the current live section notes offline. Are you sure?' } %>
+    <% elsif @update.rejected? %>
+      <%= button_to 'Approve', update_status_customs_tariff_update_path(@update.version),
+            params: { status: 'approved' }, method: :patch, class: 'govuk-button' %>
+      <%= button_to 'Set to Pending', update_status_customs_tariff_update_path(@update.version),
+            params: { status: 'pending' }, method: :patch, class: 'govuk-button govuk-button--secondary' %>
+    <% end %>
+  </div>
+<% end %>
+
+<% if @update.rejected? %>
+  <%= govuk_inset_text do %>
+    This file has been rejected. To edit individual notes, set it back to pending.
+  <% end %>
+<% end %>
+
+<h2 class="govuk-heading-m">Section Notes</h2>
+
+<%= govuk_table do |table|
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(text: 'Section')
+      row.with_cell(text: 'Change')
+      row.with_cell(text: 'Actions')
+    end
+  end
+
+  table.with_body do |body|
+    @section_notes.each do |note|
+      chip_colour = { new: 'blue', changed: 'orange', unchanged: 'grey' }.fetch(note.file_diff_status, 'grey')
+
+      body.with_row do |row|
+        row.with_cell(text: "Section #{note.section_id}")
+        row.with_cell do
+          tag.strong(note.file_diff_status.to_s.capitalize, class: "govuk-tag govuk-tag--#{chip_colour}")
+        end
+        row.with_cell do
+          if !@update.rejected? && policy(note).edit?
+            link_to 'Edit',
+                    edit_customs_tariff_update_section_note_path(@update.version, note.id),
+                    class: 'govuk-link'
+          end
+        end
+      end
+
+      if note.file_diff_status == :changed
+        body.with_row do |row|
+          row.with_cell(colspan: 3) { changeset_detail_html(note) }
+        end
+      end
+    end
+  end
+end %>

--- a/app/views/customs_tariff/updates/show.html.erb
+++ b/app/views/customs_tariff/updates/show.html.erb
@@ -1,3 +1,10 @@
+<p class="govuk-body">
+  <%= govuk_back_link(
+  text: "Back to all updates",
+  href: customs_tariff_updates_path
+) %>
+</p>
+
 <h2>Customs Tariff Update <%= @update.version %></h2>
 
 <p class="govuk-body">

--- a/app/webpacker/controllers/tariff_note_preview_controller.js
+++ b/app/webpacker/controllers/tariff_note_preview_controller.js
@@ -1,0 +1,27 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  static get targets() {
+    return ['content', 'preview'];
+  }
+
+  static get values() {
+    return { url: String };
+  }
+
+  update() {
+    const csrfMeta = document.querySelector('meta[name="csrf-token"]');
+    const csrfToken = csrfMeta ? csrfMeta.getAttribute('content') : null;
+    fetch(this.urlValue, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-CSRF-Token': csrfToken,
+      },
+      body: JSON.stringify({ content: this.contentTarget.value }),
+    })
+      .then((response) => response.json())
+      .then((data) => { this.previewTarget.innerHTML = data.html || ''; }) // server-sanitised HTML
+      .catch((error) => console.error('Preview error:', error));
+  }
+}

--- a/app/webpacker/packs/application.js
+++ b/app/webpacker/packs/application.js
@@ -24,6 +24,7 @@ import ConfigTableController from '../controllers/config_table_controller';
 import ConfigFormController from '../controllers/config_form_controller';
 import DescriptionInterceptTableController from '../controllers/description_intercept_table_controller';
 import DescriptionInterceptFormController from '../controllers/description_intercept_form_controller';
+import TariffNotePreviewController from '../controllers/tariff_note_preview_controller';
 
 import '../javascripts/markdown-preview';
 
@@ -37,3 +38,4 @@ application.register('config-table', ConfigTableController);
 application.register('config-form', ConfigFormController);
 application.register('description-intercept-table', DescriptionInterceptTableController);
 application.register('description-intercept-form', DescriptionInterceptFormController);
+application.register('tariff-note-preview', TariffNotePreviewController);

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -347,6 +347,36 @@ $govuk-image-url-function: frontend-image-url;
   }
 }
 
+.diff-side-by-side {
+  display: flex;
+  gap: govuk-spacing(3);
+  margin-bottom: govuk-spacing(2);
+
+  @include govuk-media-query($until: tablet) {
+    flex-direction: column;
+  }
+
+  &__panel {
+    flex: 1;
+    background-color: govuk-colour("light-grey");
+    padding: govuk-spacing(2) govuk-spacing(3);
+    border-radius: 2px;
+    min-width: 0;
+  }
+
+  &__label {
+    display: block;
+    margin-bottom: govuk-spacing(1);
+    @include govuk-font($size: 16, $weight: bold);
+  }
+
+  &__content {
+    @include govuk-font($size: 16);
+    word-break: break-word;
+    white-space: pre-wrap;
+  }
+}
+
 
 
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -163,6 +163,22 @@ Rails.application.routes.draw do
     resources :measure_type_mappings, only: %i[index new create destroy]
   end
 
+  scope path: "customs_tariff", module: "customs_tariff" do
+    get  "updates", to: "updates#index", as: :customs_tariff_updates
+    post "updates/section_notes/preview", to: "updates/section_notes#preview", as: :customs_tariff_section_note_preview
+
+    constraints(version: /[^\/]+/) do
+      get   "updates/:version",               to: "updates#show",          as: :customs_tariff_update
+      patch "updates/:version/update_status", to: "updates#update_status", as: :update_status_customs_tariff_update
+    end
+
+    constraints(update_version: /[^\/]+/) do
+      get   "updates/:update_version/section_notes/:id/edit", to: "updates/section_notes#edit",   as: :edit_customs_tariff_update_section_note
+      patch "updates/:update_version/section_notes/:id",      to: "updates/section_notes#update", as: :customs_tariff_update_section_note
+      put   "updates/:update_version/section_notes/:id",      to: "updates/section_notes#update"
+    end
+  end
+
   resources :tariff_updates, only: %i[index show] do
     collection do
       post "/download", to: "tariff_updates#download"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -170,12 +170,14 @@ Rails.application.routes.draw do
     constraints(version: /[^\/]+/) do
       get   "updates/:version",               to: "updates#show",          as: :customs_tariff_update
       patch "updates/:version/update_status", to: "updates#update_status", as: :update_status_customs_tariff_update
+      get   "updates/:version/compare",       to: "updates/comparisons#index", as: :customs_tariff_update_comparison
     end
 
     constraints(update_version: /[^\/]+/) do
       get   "updates/:update_version/section_notes/:id/edit", to: "updates/section_notes#edit",   as: :edit_customs_tariff_update_section_note
       patch "updates/:update_version/section_notes/:id",      to: "updates/section_notes#update", as: :customs_tariff_update_section_note
       put   "updates/:update_version/section_notes/:id",      to: "updates/section_notes#update"
+      get   "updates/:update_version/compare/section_notes/:id", to: "updates/comparisons#show", as: :customs_tariff_update_comparison_section_note
     end
   end
 

--- a/lib/trade_tariff_admin.rb
+++ b/lib/trade_tariff_admin.rb
@@ -134,7 +134,9 @@ module TradeTariffAdmin
     end
 
     def environment
-      ENV.fetch("ENVIRONMENT", "production")
+      env = ENV.fetch("ENVIRONMENT", "production")
+
+      ActiveSupport::StringInquirer.new(env)
     end
 
     def frontend_host
@@ -178,7 +180,10 @@ module TradeTariffAdmin
     end
 
     def enable_section_chapter_note_versioning?
-      ENV.fetch("ENABLE_SECTION_CHAPTER_NOTE_VERSIONING", "false") == "true"
+      return false if environment.production?
+      return false if TradeTariffAdmin::ServiceChooser.xi?
+
+      true
     end
   end
 end

--- a/lib/trade_tariff_admin.rb
+++ b/lib/trade_tariff_admin.rb
@@ -176,5 +176,9 @@ module TradeTariffAdmin
         "#{environment}_#{base_name}"
       end.to_sym
     end
+
+    def enable_section_chapter_note_versioning?
+      ENV.fetch("ENABLE_SECTION_CHAPTER_NOTE_VERSIONING", "false") == "true"
+    end
   end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe ApplicationController do
         allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it "returns dashboard_path" do
-        expect(controller.default_landing_path).to eq(dashboard_path)
+      it "returns customs_tariff_updates_path" do
+        expect(controller.default_landing_path).to eq(customs_tariff_updates_path)
       end
     end
 
@@ -37,8 +37,8 @@ RSpec.describe ApplicationController do
         allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it "returns dashboard_path" do
-        expect(controller.default_landing_path).to eq(dashboard_path)
+      it "returns customs_tariff_updates_path" do
+        expect(controller.default_landing_path).to eq(customs_tariff_updates_path)
       end
     end
 
@@ -49,8 +49,8 @@ RSpec.describe ApplicationController do
         allow(controller).to receive(:current_user).and_return(user)
       end
 
-      it "returns dashboard_path" do
-        expect(controller.default_landing_path).to eq(dashboard_path)
+      it "returns customs_tariff_updates_path" do
+        expect(controller.default_landing_path).to eq(customs_tariff_updates_path)
       end
     end
 
@@ -59,8 +59,8 @@ RSpec.describe ApplicationController do
         allow(controller).to receive(:current_user).and_return(nil)
       end
 
-      it "returns dashboard_path" do
-        expect(controller.default_landing_path).to eq(dashboard_path)
+      it "returns customs_tariff_updates_path" do
+        expect(controller.default_landing_path).to eq(customs_tariff_updates_path)
       end
     end
   end

--- a/spec/controllers/sessions_controller_spec.rb
+++ b/spec/controllers/sessions_controller_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SessionsController do
 
       it "redirects to the default landing page" do
         get :login
-        expect(response).to redirect_to(dashboard_path)
+        expect(response).to redirect_to(customs_tariff_updates_path)
       end
     end
   end
@@ -75,7 +75,7 @@ RSpec.describe SessionsController do
 
       it "creates a session and signs the user in", :aggregate_failures do
         expect { get :handle_redirect }.to change(Session, :count)
-        expect(response).to redirect_to(dashboard_path)
+        expect(response).to redirect_to(customs_tariff_updates_path)
         expect(Session.last.user.email).to eq("user@example.com")
         expect(Session.last.raw_info).to eq(token_payload)
         expect(Session.last.expires_at.to_i).to eq(Time.zone.at(token_payload["exp"]).to_i)

--- a/spec/features/section_notes_spec.rb
+++ b/spec/features/section_notes_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Section Note management" do
 
       fill_in "Content", with: section_note.content
       click_button "Create Section note"
-      verify current_path == dashboard_path
+      verify current_path == customs_tariff_updates_path
     end
   end
 
@@ -50,7 +50,7 @@ RSpec.describe "Section Note management" do
 
       fill_in "Content", with: "new content"
       click_button "Update Section note"
-      verify current_path == dashboard_path
+      verify current_path == customs_tariff_updates_path
     end
   end
 
@@ -71,7 +71,7 @@ RSpec.describe "Section Note management" do
     it "can be removed" do
       ensure_on edit_notes_section_section_note_path(section)
       click_link "Remove"
-      verify current_path == dashboard_path
+      verify current_path == customs_tariff_updates_path
     end
   end
 end

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -17,10 +17,10 @@ RSpec.describe NavigationHelper, type: :helper do
       expect(helper.navigation_sections.map(&:key)).to eq(%i[ott_admin classification spimm manage_users])
     end
 
-    it "defines OTT Admin with 6 items" do
+    it "defines OTT Admin with 8 items" do
       section = helper.navigation_sections.find { |s| s.key == :ott_admin }
       expect(section.items.map(&:text)).to eq(
-        ["Section & chapter notes", "News", "Live Issues", "Quotas", "Updates", "Reports", "Rollbacks"],
+        ["Section & chapter notes", "Section & chapter notes", "News", "Live Issues", "Quotas", "Updates", "Reports", "Rollbacks"],
       )
     end
 
@@ -184,8 +184,8 @@ RSpec.describe NavigationHelper, type: :helper do
 
     let(:user) { build(:user, :technical_operator) }
 
-    context "when on the notes page" do
-      let(:request_path) { "/notes/1" }
+    context "when on the customs tariff page" do
+      let(:request_path) { "/customs_tariff/updates" }
 
       it "returns OTT Admin section" do
         expect(helper.current_navigation_section.key).to eq(:ott_admin)
@@ -251,7 +251,7 @@ RSpec.describe NavigationHelper, type: :helper do
     include_context "with UK service"
 
     let(:user) { build(:user, :technical_operator) }
-    let(:request_path) { "/notes/1" }
+    let(:request_path) { "/customs_tariff/updates" }
 
     it "returns true for OTT Admin when path matches" do
       section = helper.visible_navigation_sections.find { |s| s.key == :ott_admin }
@@ -271,7 +271,7 @@ RSpec.describe NavigationHelper, type: :helper do
 
     it "returns first item href for sections with items" do
       section = helper.visible_navigation_sections.find { |s| s.key == :ott_admin }
-      expect(helper.section_href(section)).to eq(helper.notes_sections_path)
+      expect(helper.section_href(section)).to eq(helper.customs_tariff_updates_path)
     end
 
     it "returns standalone href for Manage Users" do

--- a/spec/helpers/versions_helper_spec.rb
+++ b/spec/helpers/versions_helper_spec.rb
@@ -75,4 +75,88 @@ RSpec.describe VersionsHelper, type: :helper do
       end
     end
   end
+
+  describe "#side_by_side_diff_html" do
+    def build_note_with_text_diff(ops)
+      build_version(
+        event: "update",
+        changeset: {
+          "changed_fields" => %w[content],
+          "changes" => { "content" => { "type" => "text", "diff" => ops } },
+        },
+      )
+    end
+
+    let(:ops) do
+      [
+        { "op" => "equal",  "text" => "Common text. " },
+        { "op" => "delete", "text" => "old word" },
+        { "op" => "insert", "text" => "new word" },
+      ]
+    end
+
+    let(:html) { helper.side_by_side_diff_html(build_note_with_text_diff(ops), from_version: "1.31", to_version: "1.32") }
+
+    it "returns nil when there is no changeset" do
+      note = build_version(event: "update")
+      expect(helper.side_by_side_diff_html(note, from_version: "1.31", to_version: "1.32")).to be_nil
+    end
+
+    it "wraps output in a diff-side-by-side container" do
+      expect(html).to include('class="diff-side-by-side"')
+    end
+
+    it "renders the from_version label" do
+      expect(html).to include("1.31")
+    end
+
+    it "renders the to_version label" do
+      expect(html).to include("1.32")
+    end
+
+    it "renders deleted text wrapped in del" do
+      expect(html).to include('<del class="diff-delete">old word</del>')
+    end
+
+    it "renders inserted text wrapped in ins" do
+      expect(html).to include('<ins class="diff-insert">new word</ins>')
+    end
+
+    it "deleted text appears only once (left panel only)" do
+      expect(html.scan("old word").count).to eq(1)
+    end
+
+    it "inserted text appears only once (right panel only)" do
+      expect(html.scan("new word").count).to eq(1)
+    end
+
+    it "equal text appears in both panels" do
+      expect(html.scan("Common text.").count).to eq(2)
+    end
+
+    context "with a non-text (array) change type" do
+      let(:array_change) do
+        { "type" => "array", "added" => %w[banana], "removed" => %w[apple], "unchanged" => [] }
+      end
+
+      let(:array_html) do
+        note = build_version(
+          event: "update",
+          changeset: {
+            "changed_fields" => %w[tags],
+            "changes" => { "tags" => array_change },
+          },
+        )
+        helper.side_by_side_diff_html(note, from_version: "1.31", to_version: "1.32")
+      end
+
+      it "falls back to inline rendering with added pills" do
+        expect(array_html).to include("diff-pill--added")
+      end
+
+      it "falls back to inline rendering with removed pills" do
+        expect(array_html).to include("diff-pill--removed")
+      end
+    end
+  end
 end

--- a/spec/models/customs_tariff/section_note_spec.rb
+++ b/spec/models/customs_tariff/section_note_spec.rb
@@ -57,4 +57,34 @@ RSpec.describe CustomsTariff::SectionNote do
       expect(version.resource_id).to eq(42)
     end
   end
+
+  describe "#has_changeset?" do
+    it "returns false when file_diff is nil" do
+      expect(section_note.has_changeset?).to be false
+    end
+
+    it "returns false when file_diff is empty" do
+      section_note.file_diff = []
+      expect(section_note.has_changeset?).to be false
+    end
+
+    it "returns true when file_diff has changed_fields" do
+      section_note.file_diff = { "changed_fields" => %w[content], "changes" => {} }
+      expect(section_note.has_changeset?).to be true
+    end
+  end
+
+  describe "#changes" do
+    it "returns empty hash when file_diff is nil" do
+      expect(section_note.changes).to eq({})
+    end
+
+    it "returns the changes hash from file_diff" do
+      section_note.file_diff = {
+        "changed_fields" => %w[content],
+        "changes" => { "content" => { "type" => "simple", "old" => "a", "new" => "b" } },
+      }
+      expect(section_note.changes).to eq("content" => { "type" => "simple", "old" => "a", "new" => "b" })
+    end
+  end
 end

--- a/spec/models/customs_tariff/section_note_spec.rb
+++ b/spec/models/customs_tariff/section_note_spec.rb
@@ -1,0 +1,60 @@
+RSpec.describe CustomsTariff::SectionNote do
+  subject(:section_note) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      section_id: 1,
+      content: "Note content",
+      customs_tariff_update_version: "1.31",
+      file_diff: nil,
+      versions: [],
+    }
+  end
+
+  describe "#file_diff_status" do
+    it "returns :new when file_diff is nil" do
+      expect(section_note.file_diff_status).to eq(:new)
+    end
+
+    it "returns :unchanged when file_diff is empty" do
+      section_note.file_diff = []
+      expect(section_note.file_diff_status).to eq(:unchanged)
+    end
+
+    it "returns :changed when file_diff has entries" do
+      section_note.file_diff = [{ "type" => "change", "value" => "updated text" }]
+      expect(section_note.file_diff_status).to eq(:changed)
+    end
+  end
+
+  describe "#preview" do
+    it "returns nil when content is blank" do
+      section_note.content = ""
+      expect(section_note.preview).to be_nil
+    end
+
+    it "passes content through TariffNoteFormatter then GovspeakPreview" do
+      formatter = instance_double(TariffNoteFormatter, format: "formatted content")
+      renderer = instance_double(GovspeakPreview, render: "<p>formatted content</p>")
+      allow(TariffNoteFormatter).to receive(:new).with("Note content").and_return(formatter)
+      allow(GovspeakPreview).to receive(:new).with("formatted content").and_return(renderer)
+
+      expect(section_note.preview).to eq("<p>formatted content</p>")
+    end
+  end
+
+  describe "#version_objects" do
+    it "returns an empty array when versions is nil" do
+      section_note.versions = nil
+      expect(section_note.version_objects).to eq([])
+    end
+
+    it "maps each version hash to a Version with resource_id from the id key", :aggregate_failures do
+      section_note.versions = [{ "id" => 42, "event" => "update", "object" => {} }]
+      version = section_note.version_objects.first
+
+      expect(version).to be_a(Version)
+      expect(version.resource_id).to eq(42)
+    end
+  end
+end

--- a/spec/models/customs_tariff/update_spec.rb
+++ b/spec/models/customs_tariff/update_spec.rb
@@ -1,0 +1,68 @@
+RSpec.describe CustomsTariff::Update do
+  subject(:update) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      version: "1.31",
+      status: "pending",
+      validity_start_date: "2026-01-01",
+      validity_end_date: nil,
+      source_url: "https://example.com/document.pdf",
+      document_created_on: "2026-01-01",
+      created_at: "2026-01-01T00:00:00Z",
+      updated_at: "2026-01-01T00:00:00Z",
+    }
+  end
+
+  describe "#pending?" do
+    it { is_expected.to be_pending }
+
+    it "is false when status is approved" do
+      update.status = "approved"
+      expect(update).not_to be_pending
+    end
+  end
+
+  describe "#approved?" do
+    it "is false when status is pending" do
+      expect(update).not_to be_approved
+    end
+
+    it "is true when status is approved" do
+      update.status = "approved"
+      expect(update).to be_approved
+    end
+  end
+
+  describe "#rejected?" do
+    it "is false when status is pending" do
+      expect(update).not_to be_rejected
+    end
+
+    it "is true when status is rejected" do
+      update.status = "rejected"
+      expect(update).to be_rejected
+    end
+  end
+
+  describe "#status_tag_colour" do
+    it "returns 'blue' for pending" do
+      expect(update.status_tag_colour).to eq("blue")
+    end
+
+    it "returns 'green' for approved" do
+      update.status = "approved"
+      expect(update.status_tag_colour).to eq("green")
+    end
+
+    it "returns 'red' for rejected" do
+      update.status = "rejected"
+      expect(update.status_tag_colour).to eq("red")
+    end
+
+    it "returns 'grey' for an unknown status" do
+      update.status = "unknown_value"
+      expect(update.status_tag_colour).to eq("grey")
+    end
+  end
+end

--- a/spec/policies/customs_tariff/section_note_policy_spec.rb
+++ b/spec/policies/customs_tariff/section_note_policy_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe CustomsTariff::SectionNotePolicy do
+  subject(:policy) { described_class }
+
+  let(:section_note) { CustomsTariff::SectionNote.new(section_id: 1) }
+
+  permissions :edit?, :update? do
+    it "grants access to technical operator" do
+      expect(policy).to permit(create(:user, :technical_operator), section_note)
+    end
+
+    it "denies access to auditor" do
+      expect(policy).not_to permit(create(:user, :auditor), section_note)
+    end
+
+    it "denies access to hmrc admin" do
+      expect(policy).not_to permit(create(:user, :hmrc_admin), section_note)
+    end
+
+    it "denies access to guest" do
+      expect(policy).not_to permit(create(:user, :guest), section_note)
+    end
+  end
+end

--- a/spec/policies/customs_tariff/update_policy_spec.rb
+++ b/spec/policies/customs_tariff/update_policy_spec.rb
@@ -1,0 +1,43 @@
+# rubocop:disable RSpec/RepeatedExample
+RSpec.describe CustomsTariff::UpdatePolicy do
+  subject(:policy) { described_class }
+
+  let(:update) { CustomsTariff::Update.new(version: "1.31", status: "pending") }
+
+  permissions :index?, :show? do
+    it "grants index and show access to technical operator" do
+      expect(policy).to permit(create(:user, :technical_operator), update)
+    end
+
+    it "grants index and show access to auditor" do
+      expect(policy).to permit(create(:user, :auditor), update)
+    end
+
+    it "denies index and show access to hmrc admin" do
+      expect(policy).not_to permit(create(:user, :hmrc_admin), update)
+    end
+
+    it "denies index and show access to guest" do
+      expect(policy).not_to permit(create(:user, :guest), update)
+    end
+  end
+
+  permissions :update? do
+    it "grants update access to technical operator" do
+      expect(policy).to permit(create(:user, :technical_operator), update)
+    end
+
+    it "denies update access to auditor" do
+      expect(policy).not_to permit(create(:user, :auditor), update)
+    end
+
+    it "denies update access to hmrc admin" do
+      expect(policy).not_to permit(create(:user, :hmrc_admin), update)
+    end
+
+    it "denies update access to guest" do
+      expect(policy).not_to permit(create(:user, :guest), update)
+    end
+  end
+end
+# rubocop:enable RSpec/RepeatedExample

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -45,6 +45,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:deletion)
   end
 
+  config.before do
+    allow(TradeTariffAdmin).to receive(:enable_section_chapter_note_versioning?).and_return(true)
+  end
+
   config.around do |example|
     DatabaseCleaner.cleaning do
       example.run

--- a/spec/requests/basic_sessions_controller_spec.rb
+++ b/spec/requests/basic_sessions_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe "BasicSessionsController", type: :request do
 
     it "sets return_url to default_landing_path when not provided" do
       get "/basic_sessions/new"
-      expect(assigns(:basic_session).return_url).to eq("/dashboard")
+      expect(assigns(:basic_session).return_url).to eq("/customs_tariff/updates")
     end
   end
 

--- a/spec/requests/customs_tariff/updates/comparisons_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates/comparisons_controller_spec.rb
@@ -1,0 +1,139 @@
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+RSpec.describe CustomsTariff::Updates::ComparisonsController, type: :request do
+  subject(:rendered_page) { make_request && response }
+
+  before { TradeTariffAdmin::ServiceChooser.service_choice = "uk" }
+
+  let(:update_version)  { "1.32" }
+  let(:compare_version) { "1.31" }
+  let(:section_note_id) { "42" }
+
+  let(:update_attributes) do
+    {
+      "version" => update_version,
+      "status" => "pending",
+      "validity_start_date" => "2026-01-01",
+      "validity_end_date" => nil,
+      "source_url" => "https://example.com/document.pdf",
+      "document_created_on" => "2026-01-01",
+      "created_at" => "2026-01-01T00:00:00Z",
+      "updated_at" => "2026-01-01T00:00:00Z",
+    }
+  end
+
+  let(:update_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: {
+          type: "customs_tariff_update",
+          id: update_version,
+          attributes: update_attributes,
+        },
+      }.to_json,
+    }
+  end
+
+  let(:section_note_attributes) do
+    {
+      "id" => section_note_id,
+      "section_id" => 5,
+      "content" => "## Section 5\n\nSome content here.",
+      "customs_tariff_update_version" => update_version,
+      "file_diff" => { "changed_fields" => %w[content], "changes" => {} },
+      "versions" => [],
+    }
+  end
+
+  let(:section_notes_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: [
+          {
+            type: "customs_tariff_section_note",
+            id: section_note_id,
+            attributes: section_note_attributes,
+          },
+        ],
+      }.to_json,
+    }
+  end
+
+  describe "GET #show" do
+    let(:make_request) do
+      get customs_tariff_update_comparison_section_note_path(update_version, section_note_id),
+          params: { compare_version: }
+    end
+
+    let(:single_note_response) do
+      {
+        status: 200,
+        headers: { "content-type" => "application/json; charset=utf-8" },
+        body: {
+          data: {
+            type: "customs_tariff_section_note",
+            id: section_note_id,
+            attributes: section_note_attributes,
+          },
+        }.to_json,
+      }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/section_notes/#{section_note_id}")
+        .with(query: hash_including(
+          "customs_tariff_update_version" => update_version,
+          "compare_version" => compare_version,
+        ))
+        .and_return(single_note_response)
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:show) }
+
+    context "when compare_version param is missing" do
+      let(:make_request) do
+        get customs_tariff_update_comparison_section_note_path(update_version, section_note_id)
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+    end
+  end
+
+  describe "GET #index" do
+    let(:make_request) do
+      get customs_tariff_update_comparison_path(update_version),
+          params: { compare_version: }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/section_notes")
+        .with(query: hash_including("compare_version" => compare_version))
+        .and_return(section_notes_response)
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:index) }
+
+    context "when compare_version param is missing" do
+      let(:make_request) do
+        get customs_tariff_update_comparison_path(update_version)
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+
+      it "sets an alert flash" do
+        make_request
+        expect(session.dig("flash", "flashes", "alert")).to eq("Please select a version to compare against.")
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/requests/customs_tariff/updates/section_notes_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates/section_notes_controller_spec.rb
@@ -1,0 +1,148 @@
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+RSpec.describe CustomsTariff::Updates::SectionNotesController, type: :request do
+  subject(:rendered_page) { make_request && response }
+
+  before { TradeTariffAdmin::ServiceChooser.service_choice = "uk" }
+
+  let(:update_version) { "1.31" }
+  let(:section_note_id) { "127" }
+
+  let(:update_attributes) do
+    {
+      "version" => update_version,
+      "status" => "pending",
+      "validity_start_date" => "2026-01-01",
+      "validity_end_date" => nil,
+      "source_url" => "https://example.com/document.pdf",
+      "document_created_on" => "2026-01-01",
+      "created_at" => "2026-01-01T00:00:00Z",
+      "updated_at" => "2026-01-01T00:00:00Z",
+    }
+  end
+
+  let(:update_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: {
+          type: "customs_tariff_update",
+          id: update_version,
+          attributes: update_attributes,
+        },
+      }.to_json,
+    }
+  end
+
+  let(:section_note_attributes) do
+    {
+      "id" => section_note_id,
+      "section_id" => 5,
+      "content" => '## Section 5\n\nOriginal content.',
+      "customs_tariff_update_version" => update_version,
+      "file_diff" => nil,
+      "versions" => [],
+    }
+  end
+
+  let(:section_note_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: {
+          type: "customs_tariff_section_note",
+          id: section_note_id,
+          attributes: section_note_attributes,
+        },
+      }.to_json,
+    }
+  end
+
+  describe "GET #edit" do
+    let(:make_request) do
+      get edit_customs_tariff_update_section_note_path(update_version, section_note_id)
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/section_notes/#{section_note_id}")
+        .with(query: hash_including("customs_tariff_update_version" => update_version))
+        .and_return(section_note_response)
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:edit) }
+  end
+
+  describe "PATCH #update" do
+    let(:make_request) do
+      patch customs_tariff_update_section_note_path(update_version, section_note_id),
+            params: { customs_tariff_section_note: { content: "Updated content." } }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/section_notes/#{section_note_id}")
+        .with(query: hash_including("customs_tariff_update_version" => update_version))
+        .and_return(section_note_response)
+    end
+
+    context "when the backend accepts the update" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/section_notes/#{section_note_id}", :patch)
+          .and_return(
+            status: 200,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              data: {
+                type: "customs_tariff_section_note",
+                id: section_note_id,
+                attributes: section_note_attributes.merge("content" => "Updated content."),
+              },
+            }.to_json,
+          )
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+
+      it "sets a success flash notice" do
+        make_request
+        expect(session.dig("flash", "flashes", "notice")).to eq("Section note updated.")
+      end
+    end
+
+    context "when the backend rejects the update with a 422" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/section_notes/#{section_note_id}", :patch)
+          .and_return(
+            status: 422,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              errors: [
+                { source: { pointer: "/data/attributes/content" }, detail: "is invalid" },
+              ],
+            }.to_json,
+          )
+      end
+
+      it { is_expected.to render_template(:edit) }
+    end
+  end
+
+  describe "POST #preview" do
+    let(:make_request) do
+      post customs_tariff_section_note_preview_path, params: { content: "some markdown" }
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+
+    it "returns JSON with an html key" do
+      json = JSON.parse(rendered_page.body)
+      expect(json).to have_key("html")
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/requests/customs_tariff/updates_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates_controller_spec.rb
@@ -1,0 +1,120 @@
+RSpec.describe CustomsTariff::UpdatesController, type: :request do
+  subject(:rendered_page) { make_request && response }
+
+  before { TradeTariffAdmin::ServiceChooser.service_choice = "uk" }
+
+  let(:update_version) { "1.31" }
+
+  let(:update_attributes) do
+    {
+      "version" => update_version,
+      "status" => "pending",
+      "validity_start_date" => "2026-01-01",
+      "validity_end_date" => nil,
+      "source_url" => "https://example.com/document.pdf",
+      "document_created_on" => "2026-01-01",
+      "created_at" => "2026-01-01T00:00:00Z",
+      "updated_at" => "2026-01-01T00:00:00Z",
+    }
+  end
+
+  let(:update_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: {
+          type: "customs_tariff_update",
+          id: update_version,
+          attributes: update_attributes,
+        },
+      }.to_json,
+    }
+  end
+
+  describe "GET #index" do
+    let(:make_request) { get customs_tariff_updates_path }
+
+    before do
+      stub_api_request("/customs_tariff_updates")
+        .and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: {
+            data: [{ type: "customs_tariff_update", id: update_version, attributes: update_attributes }],
+          }.to_json,
+        )
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:index) }
+  end
+
+  describe "GET #show" do
+    let(:make_request) { get customs_tariff_update_path(update_version) }
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/section_notes")
+        .and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: { data: [] }.to_json,
+        )
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:show) }
+  end
+
+  describe "PATCH #update_status" do
+    context "when the backend accepts the status change" do
+      let(:make_request) do
+        patch update_status_customs_tariff_update_path(update_version), params: { status: "approved" }
+      end
+
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}")
+          .and_return(update_response)
+        stub_api_request("/customs_tariff_updates/#{update_version}/status", :patch)
+          .and_return(
+            status: 200,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {}.to_json,
+          )
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+
+      it "sets a success flash notice" do
+        make_request
+        expect(session.dig("flash", "flashes", "notice")).to eq("Status updated to approved.")
+      end
+    end
+
+    context "when the backend rejects the status change" do
+      let(:make_request) do
+        patch update_status_customs_tariff_update_path(update_version), params: { status: "approved" }
+      end
+
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}")
+          .and_return(update_response)
+        stub_api_request("/customs_tariff_updates/#{update_version}/status", :patch)
+          .and_return(
+            status: 422,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: { errors: [{ detail: "Version is already approved" }] }.to_json,
+          )
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+
+      it "sets a flash alert containing the backend error detail" do
+        make_request
+        expect(session.dig("flash", "flashes", "alert")).to eq("Could not update status: Version is already approved")
+      end
+    end
+  end
+end

--- a/spec/requests/customs_tariff/updates_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates_controller_spec.rb
@@ -32,6 +32,22 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
     }
   end
 
+  let(:updates_list_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: [
+          {
+            type: "customs_tariff_update",
+            id: update_version,
+            attributes: update_attributes,
+          },
+        ],
+      }.to_json,
+    }
+  end
+
   describe "GET #index" do
     let(:make_request) { get customs_tariff_updates_path }
 
@@ -62,10 +78,16 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
           headers: { "content-type" => "application/json; charset=utf-8" },
           body: { data: [] }.to_json,
         )
+      stub_api_request("/customs_tariff_updates").and_return(updates_list_response)
     end
 
     it { is_expected.to have_http_status(:ok) }
     it { is_expected.to render_template(:show) }
+
+    it "renders the compare form" do
+      make_request
+      expect(response.body).to include(customs_tariff_update_comparison_path(update_version))
+    end
   end
 
   describe "PATCH #update_status" do

--- a/spec/requests/pages_controller_spec.rb
+++ b/spec/requests/pages_controller_spec.rb
@@ -9,20 +9,20 @@ RSpec.describe PagesController do
 
   describe "GET #index" do
     context "when authorised" do
-      it "returns success" do
+      it "redirects to customs tariff updates" do
         get dashboard_path
 
-        expect(response).to have_http_status :ok
+        expect(response).to redirect_to(customs_tariff_updates_path)
       end
     end
 
     context "when user is an auditor" do
       let(:current_user) { create(:user, :auditor) }
 
-      it "returns success" do
+      it "redirects to customs tariff updates" do
         get dashboard_path
 
-        expect(response).to have_http_status :ok
+        expect(response).to redirect_to(customs_tariff_updates_path)
       end
     end
 
@@ -39,10 +39,10 @@ RSpec.describe PagesController do
     context "when user is a guest" do
       let(:current_user) { create(:user, :guest) }
 
-      it "is forbidden" do
+      it "redirects to customs tariff updates" do
         get dashboard_path
 
-        expect(response).to have_http_status :forbidden
+        expect(response).to redirect_to(customs_tariff_updates_path)
       end
     end
   end


### PR DESCRIPTION
## What:

This PR adds the admin UI for the Customs Tariff section notes review and approval pipeline. Operators can view incoming updates, approve or reject them, and edit individual section notes — with version history and cross-update comparison built in.

Here's what's been added all feature flagged with `ENABLE_SECTION_CHAPTER_NOTE_VERSIONING=true`:

- **`UpdatesController`** — lists all customs tariff updates with their current status and exposes approve/reject/reset actions
- **`SectionNotesController`** (updates namespace) — allows editing of individual section notes; blocked when the parent update is rejected
- **`ComparisonsController`** — handles cross-version comparisons; a list view shows which sections changed and a detail view shows a side-by-side diff of the content
- **`CustomsTariff::Update`** and **`CustomsTariff::SectionNote`** models — ApiEntity models that consume the backend admin API
- **`UpdatePolicy`** and **`SectionNotePolicy`** — Pundit policies; status changes restricted to technical operators, read access available to auditors
- **`side_by_side_diff_html`** helper — renders a two-column diff with the old note on the left and the new note on the right, colour-coded inserts and deletes; falls back to the existing inline diff for non-text field types
- Navigation updated so customs tariff updates appear in the side nav for users with access
- Stimulus `tariff-note-preview-controller` — live markdown preview on the section note edit page

## Why:

Operators need a user interface to review changes in incoming Customs Tariff updates before they go live. This PR wires the admin frontend up to the API built in the backend [PR](https://github.com/trade-tariff/trade-tariff-backend/pull/3201) for this ticket.

The comparison UI is designed to guide the user one step at a time — select a version to compare against from a dropdown on the update show page, then drill into individual sections. The side-by-side diff is isolated to the comparison pages and doesn't affect the existing inline diff rendering used elsewhere in the app. Rejected updates are read-only in the UI and that's also enforced at the API level.

## Ticket:

[AI-517](https://transformuk.atlassian.net/browse/AI-517)

## Risk:
**Risk level:** 🟢

**Reason for rating:** New UI pages and controllers only. No changes to existing functionality, no database migrations, and no modifications to the backend API contract.

## Demo:

https://github.com/user-attachments/assets/fdf96fa9-2dd3-4114-b3fe-0b7f0bbe0dc7
