### PR TITLE
BAU: upgrade Ruby 4.0.3 → 4.0.5

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1778036283,
-        "narHash": "sha256-62EWg6lI0qyzm7oAx5cAnGkLutvJsRBe0KkEW2JDZCE=",
+        "lastModified": 1779877693,
+        "narHash": "sha256-NOF9NAREhxr50bbBfVcVOq+ArCMSoe8dP79Pk2uyARk=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "ed67bc86e84e51d4a88e73c7fd36006dc876476f",
+        "rev": "4100e830e085863741bc69b156ec4ccd53ab5be0",
         "type": "github"
       },
       "original": {
@@ -61,11 +61,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1777794641,
-        "narHash": "sha256-YynFFJm7k67pVgIuU4FJZu+qCL1+92g4lnRDHBFGsjw=",
+        "lastModified": 1779267859,
+        "narHash": "sha256-0WVw5bxFhrqIerTuVnXC5weXEWLda2eehb+ArZFRRJY=",
         "owner": "bobvanderlinden",
         "repo": "nixpkgs-ruby",
-        "rev": "21250b7913a4d439c77d3e7091bf246cb55544b5",
+        "rev": "f6e23dc8dd65bfbd384009c4fb364e88306f6ebb",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## What?

Upgrade Ruby from 4.0.3 to 4.0.5 and update nixpkgs/flake.lock

## Why?

Routine Ruby version maintenance for BAU.

## How?

- Updated Dockerfile ARG RUBY_VERSION from 4.0.3 to 4.0.5
- Updated nixpkgs-ruby and nixpkgs flake inputs via 
- flake.lock updated with latest nixpkgs and ruby overlays

## How to test?

1. Verify Docker build succeeds with new Ruby version
2. Run bundle install and ensure gems install correctly
3. Run test suite to confirm no regressions