### PR TITLE
HMRC-2248: add slack observability topic

### DIFF
--- a/terraform/README.md
+++ b/terraform/README.md
@@ -20,7 +20,7 @@ Terraform to deploy the service into AWS.
 | Name | Source | Version |
 | ---- | ------ | ------- |
 | <a name="module_admin-job"></a> [admin-job](#module\_admin-job) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
-| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.0.1 |
+| <a name="module_service"></a> [service](#module\_service) | git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service | aws/ecs-service-v3.1.0 |
 
 ## Resources
 
@@ -36,6 +36,7 @@ Terraform to deploy the service into AWS.
 | [aws_secretsmanager_secret_version.ecs_tls_certificate](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_secretsmanager_secret_version.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/secretsmanager_secret_version) | data source |
 | [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/security_group) | data source |
+| [aws_sns_topic.slack_observability_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_sns_topic.slack_topic](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/sns_topic) | data source |
 | [aws_subnets.private](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnets) | data source |
 | [aws_vpc.vpc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/vpc) | data source |
@@ -48,6 +49,7 @@ Terraform to deploy the service into AWS.
 | <a name="input_cpu"></a> [cpu](#input\_cpu) | CPU units to use. | `number` | n/a | yes |
 | <a name="input_docker_tag"></a> [docker\_tag](#input\_docker\_tag) | Image tag to use. | `string` | n/a | yes |
 | <a name="input_enable_alarms"></a> [enable\_alarms](#input\_enable\_alarms) | Whether to enable CPU alarms for the ECS service | `bool` | n/a | yes |
+| <a name="input_enable_observability_alerts"></a> [enable\_observability\_alerts](#input\_enable\_observability\_alerts) | n/a | `bool` | `false` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | Deployment environment. | `string` | n/a | yes |
 | <a name="input_max_capacity"></a> [max\_capacity](#input\_max\_capacity) | Largest number of tasks the service can scale-out to. | `number` | n/a | yes |
 | <a name="input_memory"></a> [memory](#input\_memory) | Memory to allocate in MB. Powers of 2 only. | `number` | n/a | yes |

--- a/terraform/config_production.tfvars
+++ b/terraform/config_production.tfvars
@@ -6,3 +6,5 @@ service_count = 3
 min_capacity  = 2
 max_capacity  = 5
 enable_alarms = true
+
+enable_observability_alerts = true

--- a/terraform/data.tf
+++ b/terraform/data.tf
@@ -48,3 +48,8 @@ data "aws_secretsmanager_secret_version" "ecs_tls_certificate" {
 data "aws_sns_topic" "slack_topic" {
   name = "slack-topic"
 }
+
+data "aws_sns_topic" "slack_observability_topic" {
+  count = var.enable_observability_alerts ? 1 : 0
+  name  = "slack-observability-topic"
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,5 +1,5 @@
 module "service" {
-  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.0.1"
+  source = "git@github.com:trade-tariff/trade-tariff-platform-terraform-modules.git//aws/ecs-service?ref=aws/ecs-service-v3.1.0"
 
   region = var.region
 
@@ -33,5 +33,6 @@ module "service" {
 
   service_environment_config = local.admin_service_env_vars
 
-  sns_topic_arns = [data.aws_sns_topic.slack_topic.arn]
+  sns_topic_arns               = [data.aws_sns_topic.slack_topic.arn]
+  observability_sns_topic_arns = var.enable_observability_alerts ? [data.aws_sns_topic.slack_observability_topic[0].arn] : null
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -60,3 +60,8 @@ variable "enable_alarms" {
   description = "Whether to enable CPU alarms for the ECS service"
   type        = bool
 }
+
+variable "enable_observability_alerts" {
+  type    = bool
+  default = false
+}


### PR DESCRIPTION
### Jira link

[HMRC-2248](https://transformuk.atlassian.net/browse/HMRC-2248)

### What?

I have added/removed/altered:

- Bumps ECS service module ref to pick up new `observability_sns_topic_arns` variable
- Adds `data.aws_sns_topic.slack_observability_topic` lookup
- Passes `observability_sns_topic_arns` to ECS service module callers. This routes `ecs_capacity_loss` and `ecs_high_cpu` to` #production-observability` and keeps service_count in `#production-alerts`.

### Why?

I am doing this because:

- Reduces noise in `#production-alerts `by moving `degraded-but-not-down` signals to the observability channel. On-call engineers see only alarms requiring immediate action in the main channel.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- Validated any auth changes don't break the apps integration with the backend
