### PR TITLE
OTTIMP-629 Use Data objects

### DIFF
--- a/app/services/verify_token.rb
+++ b/app/services/verify_token.rb
@@ -1,5 +1,5 @@
 class VerifyToken
-  Result = Struct.new(:valid, :payload, :reason, keyword_init: true) do
+  Result = Data.define(:valid, :payload, :reason) do
     def valid?
       valid
     end

--- a/app/views/classification_configurations/_form.html.erb
+++ b/app/views/classification_configurations/_form.html.erb
@@ -9,11 +9,7 @@
   <% when "markdown" %>
     <%= govuk_markdown_area f, :value, rows: 10, label: { text: "Value" } %>
   <% when "boolean" %>
-    <%= f.govuk_collection_radio_buttons :value,
-                                         [OpenStruct.new(id: "true", name: "Yes"), OpenStruct.new(id: "false", name: "No")],
-                                         :id,
-                                         :name,
-                                         legend: { text: "Value" } %>
+    <%= f.govuk_collection_radio_buttons :value, { "true" => "Yes", "false" => "No" }, :first, :last, legend: { text: "Value" } %>
   <% when "integer" %>
     <%= f.govuk_number_field :value, label: { text: "Value" } %>
   <% when "date" %>

--- a/app/views/green_lanes/category_assessments/index.html.erb
+++ b/app/views/green_lanes/category_assessments/index.html.erb
@@ -23,7 +23,11 @@
           <%= form.label :regulation_role, "Regulation Role", class: "govuk-label" %>
           <%= form.text_field :regulation_role, value: params[:regulation_role], class: "govuk-input", id: "search-term"%>
           <%= form.label :theme_id, "Theme", class: "govuk-label" %>
-          <%= form.collection_select :theme_id, [OpenStruct.new(id: nil, label: "Select a Theme")] + @themes, :id, :label, {selected: params[:theme_id]}, {class: "govuk-select govuk-!-width-one-third"}%>
+          <% theme_options = [["Select a Theme", nil]] + @themes.map { |theme| [theme.label, theme.id] } %>
+          <%= form.select :theme_id,
+                          options_for_select(theme_options, params[:theme_id]),
+                          {},
+                          class: "govuk-select govuk-!-width-one-third" %>
         </div>
 
         <div class="govuk-form-group">


### PR DESCRIPTION
### Jira link

[OTTIMP-629](https://transformuk.atlassian.net/browse/OTTIMP-629)

### What?

Replaces usage of Struct and OpenStruct with [Data](https://docs.ruby-lang.org/en/3.2/Data.html)

### Why?

Data objects are immutable and offer better performance than OpenStruct.
