### PR TITLE
Parallelise admin RSpec suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ permissions:
 env:
   TERRAFORM_VERSION: 1.13.5
   PYTHON_VERSION: 3
+  PARALLEL_TEST_PROCESSORS: "5"
 
 jobs:
   check-pr-lines:
@@ -82,9 +83,21 @@ jobs:
         with:
           cache: yarn
       - run: yarn install --frozen-lockfile
+      - name: Prepare test databases
+        env:
+          PGHOST: localhost
+          DB_USER: postgres
+          PGPASSWORD: postgres
+        run: bundle exec rails db:test:prepare_parallel
+
       - name: Run tests
         env:
           PGHOST: localhost
           DB_USER: postgres
           PGPASSWORD: postgres
-        run: bundle exec rspec
+        run: |
+          bundle exec parallel_test spec \
+            -n "$PARALLEL_TEST_PROCESSORS" \
+            --type rspec \
+            --serialize-stdout \
+            --exec-args "sh -c 'PARALLEL_RSPEC_CHILD=true bundle exec rspec \"\$@\"' sh"

--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
+--require ./spec/parallel_rspec
 --require rails_helper
 --color

--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,7 @@ group :test do
   gem "capybara"
   gem "database_cleaner"
   gem "factory_bot_rails"
+  gem "parallel_tests"
   gem "rails-controller-testing"
   gem "rspec_junit_formatter"
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -274,6 +274,8 @@ GEM
     ostruct (0.6.3)
     pagy (9.4.0)
     parallel (1.28.0)
+    parallel_tests (5.7.0)
+      parallel
     parser (3.3.11.1)
       ast (~> 2.4.1)
       racc
@@ -521,6 +523,7 @@ DEPENDENCIES
   lograge
   logstash-event
   nokogiri
+  parallel_tests
   pg
   pry-rails
   puma

--- a/config/database.yml
+++ b/config/database.yml
@@ -15,7 +15,7 @@ test:
   host: <%= ENV.fetch("PGHOST", "localhost") %>
   user: <%= ENV.fetch("DB_USER", "postgres") %>
   password: <%= ENV["PGPASSWORD"] %>
-  database: tariff_admin_test
+  database: <%= "tariff_admin_test#{ENV["TEST_ENV_NUMBER"]}" %>
 
 production:
   <<: *default

--- a/lib/tasks/test_database.rake
+++ b/lib/tasks/test_database.rake
@@ -1,0 +1,39 @@
+require "open3"
+
+namespace :db do
+  namespace :test do
+    desc "Prepare parallel test databases"
+    task prepare_parallel: :environment do
+      workers = Integer(ENV.fetch("PARALLEL_TEST_PROCESSORS", 5))
+
+      raise "PARALLEL_TEST_PROCESSORS must be at least 1" if workers < 1
+
+      puts "Preparing test databases..."
+
+      1.upto(workers) do |worker|
+        test_env_number = worker == 1 ? "" : worker.to_s
+        database_name = "tariff_admin_test#{test_env_number}"
+        env = {
+          "RAILS_ENV" => "test",
+          "TEST_ENV_NUMBER" => test_env_number,
+        }
+        command = %w[bundle exec rails db:drop db:create db:schema:load]
+
+        stdout, stderr, status = Open3.capture3(env, *command)
+
+        if ENV["PARALLEL_TEST_PREPARE_VERBOSE"] == "true"
+          puts stdout
+          warn stderr
+        end
+
+        unless status.success?
+          puts stdout
+          warn stderr
+          abort "Failed to prepare #{database_name}"
+        end
+
+        puts "Prepared #{database_name}"
+      end
+    end
+  end
+end

--- a/spec/config/database_yml_spec.rb
+++ b/spec/config/database_yml_spec.rb
@@ -1,0 +1,34 @@
+# rubocop:disable RSpec/DescribeClass
+RSpec.describe "Database configuration" do
+  subject(:database_config) do
+    YAML.safe_load(
+      ERB.new(Rails.root.join("config/database.yml").read).result,
+      aliases: true,
+    )
+  end
+
+  around do |example|
+    original_test_env_number = ENV["TEST_ENV_NUMBER"]
+
+    example.run
+  ensure
+    ENV["TEST_ENV_NUMBER"] = original_test_env_number
+  end
+
+  context "when TEST_ENV_NUMBER is not set" do
+    before { ENV.delete("TEST_ENV_NUMBER") }
+
+    it "uses the original test database name" do
+      expect(database_config.fetch("test").fetch("database")).to eq("tariff_admin_test")
+    end
+  end
+
+  context "when TEST_ENV_NUMBER is set" do
+    before { ENV["TEST_ENV_NUMBER"] = "2" }
+
+    it "uses the matching parallel test database name" do
+      expect(database_config.fetch("test").fetch("database")).to eq("tariff_admin_test2")
+    end
+  end
+end
+# rubocop:enable RSpec/DescribeClass

--- a/spec/parallel_rspec.rb
+++ b/spec/parallel_rspec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require "English"
+
+if ENV["PARALLEL_RSPEC_CHILD"] != "true" && !ENV.key?("TEST_ENV_NUMBER")
+  if ARGV.any?
+    ENV["PARALLEL_RSPEC_CHILD"] = "true"
+  else
+    workers = Integer(ENV.fetch("PARALLEL_TEST_PROCESSORS", 5))
+
+    unless ENV["SKIP_PARALLEL_TEST_PREPARE"] == "true"
+      system({ "PARALLEL_TEST_PROCESSORS" => workers.to_s }, "bundle", "exec", "rails", "db:test:prepare_parallel")
+      exit($CHILD_STATUS.exitstatus || 1) unless $CHILD_STATUS.success?
+    end
+
+    exec(
+      { "PARALLEL_RSPEC_CHILD" => "true" },
+      "bundle",
+      "exec",
+      "parallel_test",
+      "-n",
+      workers.to_s,
+      "--type",
+      "rspec",
+      "--serialize-stdout",
+      "spec",
+    )
+  end
+end


### PR DESCRIPTION
### Jira link

[HMRC-2291](https://transformuk.atlassian.net/browse/HMRC-2291)

### What?

Added parallel worker RSpec support to `trade-tariff-admin`

### Why?

This reduces the feedback time for the admin test suite by spreading the specs across multiple workers