### PR TITLE
AI-589: Add search diagnostics admin screen

### DIFF
--- a/app/controllers/search_diagnostics_controller.rb
+++ b/app/controllers/search_diagnostics_controller.rb
@@ -1,0 +1,29 @@
+class SearchDiagnosticsController < AuthenticatedController
+  def index
+    authorize SearchDiagnostic, :index?
+
+    redirect_to search_diagnostic_path(request_id) if request_id.present?
+  end
+
+  def show
+    authorize SearchDiagnostic, :show?
+
+    @request_id = request_id
+    @search_diagnostic = SearchDiagnostic.find(@request_id, search_params)
+  rescue Faraday::ResourceNotFound
+    redirect_to search_diagnostics_path, alert: "Search diagnostics were not found for that request ID."
+  rescue Faraday::Error => e
+    Rails.logger.error("Failed to fetch search diagnostics for #{request_id}: #{e.class} #{e.message}")
+    redirect_to search_diagnostics_path, alert: "Search diagnostics could not be loaded."
+  end
+
+private
+
+  def request_id
+    params[:request_id].to_s.strip
+  end
+
+  def search_params
+    params.permit(:lookback_hours, :limit).to_h.compact_blank
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -104,6 +104,13 @@ module NavigationHelper
             service: :uk,
           ),
           NavigationItem.new(
+            text: "Diagnostics",
+            href: search_diagnostics_path,
+            policy_class: SearchDiagnostic,
+            active_when: /\/search_diagnostics/,
+            service: nil,
+          ),
+          NavigationItem.new(
             text: "Recent changes",
             href: versions_path,
             policy_class: Version,

--- a/app/helpers/search_diagnostics_helper.rb
+++ b/app/helpers/search_diagnostics_helper.rb
@@ -1,0 +1,250 @@
+module SearchDiagnosticsHelper
+  def search_diagnostic_event_summary(event)
+    fields = search_diagnostic_fields(event)
+
+    case event[:event].to_s
+    when "exact_match_selected"
+      code = target_label(fields)
+      source = fields[:match_source].to_s.humanize.downcase.presence || "source"
+      ["Exact match", source, fields[:matched_value], code].compact_blank.join(" - ")
+    when "fuzzy_results_returned"
+      "Fuzzy results returned - #{pluralize(fields[:result_count].to_i, 'result')}"
+    when "interactive_configuration_used"
+      "Interactive configuration used"
+    when "retrieval_results_returned"
+      [
+        fields[:retrieval_method].to_s.humanize.presence,
+        fields[:stage].to_s.humanize.presence,
+        fields[:leg].to_s.humanize.presence,
+        pluralize(fields[:result_count].to_i, "result"),
+      ].compact_blank.join(" - ")
+    when "question_returned"
+      "Questions returned - #{pluralize(fields[:question_count].to_i, 'question')}"
+    when "answer_returned"
+      "Answers returned - #{pluralize(fields[:answer_count].to_i, 'answer')}"
+    when "search_completed"
+      "Search completed - #{fields[:results_type].presence || fields[:final_result_type].presence || pluralize(fields[:result_count].to_i, 'result')}"
+    else
+      event[:event].presence || "Event"
+    end
+  end
+
+  def search_diagnostic_event_details(event)
+    fields = search_diagnostic_fields(event)
+
+    content = case event[:event].to_s
+              when "exact_match_selected"
+                exact_match_details(fields)
+              when "fuzzy_results_returned"
+                fuzzy_results_details(fields)
+              when "interactive_configuration_used"
+                key_value_list(search_diagnostic_details(fields))
+              when "retrieval_results_returned"
+                retrieval_results_details(fields)
+              when "question_returned"
+                questions_details(fields)
+              when "answer_returned"
+                answers_details(fields)
+              end
+
+    safe_join([
+      content.presence,
+      raw_event_details(event),
+    ].compact)
+  end
+
+  def search_diagnostic_fields(event)
+    normalise_search_diagnostic_hash(event[:fields] || {})
+  end
+
+private
+
+  def exact_match_details(fields)
+    rows = {
+      "Source" => fields[:match_source],
+      "Matched value" => fields[:matched_value],
+      "Target" => goods_nomenclature_link(fields),
+      "SID" => fields[:goods_nomenclature_sid],
+      "Self-text" => self_text_link(fields),
+      "Labels" => label_link(fields),
+    }
+
+    key_value_list(rows)
+  end
+
+  def fuzzy_results_details(fields)
+    details = search_diagnostic_details(fields)
+    sections = %i[goods_nomenclature_match reference_match].filter_map do |match_type|
+      groups = normalise_search_diagnostic_hash(details[match_type])
+      next if groups.blank?
+
+      content_tag(:div, class: "govuk-!-margin-bottom-3") do
+        safe_join([
+          content_tag(:h4, match_type.to_s.humanize, class: "govuk-heading-s govuk-!-margin-bottom-2"),
+          safe_join(groups.map { |level, results| result_group(level, results) }),
+        ])
+      end
+    end
+
+    safe_join(sections.presence || [content_tag(:p, "No grouped results were logged.", class: "govuk-body-s")])
+  end
+
+  def retrieval_results_details(fields)
+    details = search_diagnostic_details(fields)
+    results = Array(details[:results])
+
+    safe_join([
+      key_value_list(
+        "Retrieval method" => fields[:retrieval_method],
+        "Stage" => fields[:stage],
+        "Leg" => fields[:leg],
+        "Iteration" => fields[:iteration],
+        "Result count" => fields[:result_count],
+      ),
+      result_table(results),
+    ])
+  end
+
+  def questions_details(fields)
+    questions = Array(search_diagnostic_details(fields)[:questions])
+    return content_tag(:p, "No question details were logged.", class: "govuk-body-s") if questions.blank?
+
+    ordered_list(questions.map { |question| question[:question] || question[:text] || question.to_s })
+  end
+
+  def answers_details(fields)
+    answers = Array(search_diagnostic_details(fields)[:answers])
+    return content_tag(:p, "No answer details were logged.", class: "govuk-body-s") if answers.blank?
+
+    result_table(answers)
+  end
+
+  def result_group(level, results)
+    safe_join([
+      content_tag(:h5, level.to_s.humanize, class: "govuk-heading-s govuk-!-margin-bottom-1"),
+      result_table(Array(results)),
+    ])
+  end
+
+  def result_table(results)
+    return content_tag(:p, "No results were logged.", class: "govuk-body-s") if results.blank?
+
+    content_tag(:table, class: "govuk-table govuk-!-margin-bottom-4") do
+      safe_join([
+        content_tag(:thead, class: "govuk-table__head") do
+          content_tag(:tr, class: "govuk-table__row") do
+            safe_join(%w[Code Type Score Self-text Labels].map { |heading| content_tag(:th, heading, class: "govuk-table__header", scope: "col") })
+          end
+        end,
+        content_tag(:tbody, class: "govuk-table__body") do
+          safe_join(results.map { |result| result_row(normalise_search_diagnostic_hash(result)) })
+        end,
+      ])
+    end
+  end
+
+  def result_row(result)
+    content_tag(:tr, class: "govuk-table__row") do
+      safe_join([
+        content_tag(:td, goods_nomenclature_link(result), class: "govuk-table__cell"),
+        content_tag(:td, result[:goods_nomenclature_class].presence || "-", class: "govuk-table__cell"),
+        content_tag(:td, result[:score].presence || result[:confidence].presence || "-", class: "govuk-table__cell"),
+        content_tag(:td, self_text_link(result), class: "govuk-table__cell"),
+        content_tag(:td, label_link(result), class: "govuk-table__cell"),
+      ])
+    end
+  end
+
+  def key_value_list(rows)
+    rows = rows.filter_map do |key, value|
+      next if value.blank?
+
+      content_tag(:div, class: "govuk-summary-list__row") do
+        safe_join([
+          content_tag(:dt, key.to_s.humanize, class: "govuk-summary-list__key"),
+          content_tag(:dd, diagnostic_value(value), class: "govuk-summary-list__value"),
+        ])
+      end
+    end
+
+    return content_tag(:p, "No details were logged.", class: "govuk-body-s") if rows.blank?
+
+    content_tag(:dl, safe_join(rows), class: "govuk-summary-list govuk-summary-list--no-border govuk-!-margin-bottom-4")
+  end
+
+  def ordered_list(items)
+    content_tag(:ol, class: "govuk-list govuk-list--number") do
+      safe_join(items.map { |item| content_tag(:li, item) })
+    end
+  end
+
+  def diagnostic_value(value)
+    return value if value.is_a?(ActiveSupport::SafeBuffer)
+    return value.join(", ") if value.is_a?(Array)
+    return JSON.pretty_generate(value) if value.is_a?(Hash)
+
+    value
+  end
+
+  def raw_event_details(event)
+    tag.details(class: "govuk-details govuk-!-margin-bottom-0") do
+      safe_join([
+        content_tag(:summary, class: "govuk-details__summary") do
+          content_tag(:span, "View raw fields", class: "govuk-details__summary-text")
+        end,
+        content_tag(:div, class: "govuk-details__text") do
+          content_tag(:pre, JSON.pretty_generate(search_diagnostic_fields(event)), class: "govuk-body-s")
+        end,
+      ])
+    end
+  end
+
+  def goods_nomenclature_link(result)
+    endpoint = result[:target_endpoint].presence || endpoint_for_class(result[:goods_nomenclature_class])
+    id = result[:target_id].presence || result[:goods_nomenclature_item_id]
+    return "-" if endpoint.blank? || id.blank?
+
+    link_to(target_label(result), "#{TradeTariffAdmin.frontend_host}/#{endpoint}/#{id}", class: "govuk-link", target: "_blank", rel: "noopener noreferrer")
+  end
+
+  def self_text_link(result)
+    id = result[:self_text_id] || result[:goods_nomenclature_sid]
+    return "-" if id.blank?
+
+    link_to("View self-text", goods_nomenclature_self_text_path(id), class: "govuk-link")
+  end
+
+  def label_link(result)
+    id = result[:goods_nomenclature_item_id] || result[:target_id]
+    return "-" if id.blank?
+
+    link_to("View labels", goods_nomenclature_label_path(id), class: "govuk-link")
+  end
+
+  def search_diagnostic_details(fields)
+    normalise_search_diagnostic_hash(fields[:details] || {})
+  end
+
+  def endpoint_for_class(goods_nomenclature_class)
+    goods_nomenclature_class.to_s.underscore.pluralize.presence
+  end
+
+  def target_label(result)
+    endpoint = result[:target_endpoint].presence || endpoint_for_class(result[:goods_nomenclature_class])
+    id = result[:target_id].presence || result[:goods_nomenclature_item_id]
+
+    [endpoint, id].compact_blank.join("/")
+  end
+
+  def normalise_search_diagnostic_hash(value)
+    return nil if value.nil?
+
+    value = JSON.parse(value) if value.is_a?(String) && value.strip.start_with?("{", "[")
+    return value.map { |item| normalise_search_diagnostic_hash(item) } if value.is_a?(Array)
+    return value unless value.respond_to?(:to_h)
+
+    value.to_h.with_indifferent_access.transform_values { |item| normalise_search_diagnostic_hash(item) }
+  rescue JSON::ParserError
+    value
+  end
+end

--- a/app/models/search_diagnostic.rb
+++ b/app/models/search_diagnostic.rb
@@ -1,0 +1,19 @@
+class SearchDiagnostic
+  include ApiEntity
+
+  attributes :request_id, :log_group_name, :start_time, :end_time, :events
+
+  set_singular_path "admin/search_diagnostics/:request_id"
+
+  def to_param
+    request_id.presence || resource_id
+  end
+
+  def events
+    Array(attributes[:events]).map(&:with_indifferent_access)
+  end
+
+  def events?
+    events.any?
+  end
+end

--- a/app/policies/search_diagnostic_policy.rb
+++ b/app/policies/search_diagnostic_policy.rb
@@ -1,0 +1,9 @@
+class SearchDiagnosticPolicy < ApplicationPolicy
+  def index?
+    technical_operator? || hmrc_admin? || auditor?
+  end
+
+  def show?
+    index?
+  end
+end

--- a/app/views/search_diagnostics/index.html.erb
+++ b/app/views/search_diagnostics/index.html.erb
@@ -1,0 +1,23 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <h1 class="govuk-heading-l">Search diagnostics</h1>
+
+    <%= form_with url: search_diagnostics_path, method: :get do |form| %>
+      <div class="govuk-form-group">
+        <%= form.label :request_id, "Request ID", class: "govuk-label" %>
+        <div id="request-id-hint" class="govuk-hint">
+          Enter the request ID from the trader search journey.
+        </div>
+        <%= form.text_field :request_id,
+              value: params[:request_id],
+              class: "govuk-input",
+              "aria-describedby": "request-id-hint",
+              autocomplete: "off" %>
+      </div>
+
+      <div class="govuk-button-group">
+        <%= form.submit "Find diagnostics", class: "govuk-button" %>
+      </div>
+    <% end %>
+  </div>
+</div>

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -29,7 +29,8 @@
             <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Time</th>
             <th scope="col" class="govuk-table__header">Event</th>
             <th scope="col" class="govuk-table__header">Search type</th>
-            <th scope="col" class="govuk-table__header">Details</th>
+            <th scope="col" class="govuk-table__header">Summary</th>
+            <th scope="col" class="govuk-table__header">Diagnostics</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
@@ -38,13 +39,14 @@
               <td class="govuk-table__cell"><%= event[:timestamp].presence || "-" %></td>
               <td class="govuk-table__cell"><%= event[:event].presence || "-" %></td>
               <td class="govuk-table__cell"><%= event[:search_type].presence || "-" %></td>
+              <td class="govuk-table__cell"><%= search_diagnostic_event_summary(event) %></td>
               <td class="govuk-table__cell">
                 <details class="govuk-details">
                   <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">View fields</span>
+                    <span class="govuk-details__summary-text">View diagnostics</span>
                   </summary>
                   <div class="govuk-details__text">
-                    <pre class="govuk-body-s"><%= JSON.pretty_generate(event[:fields] || {}) %></pre>
+                    <%= search_diagnostic_event_details(event) %>
                   </div>
                 </details>
               </td>

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -1,0 +1,59 @@
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <%= link_to "Back to search diagnostics", search_diagnostics_path, class: "govuk-back-link" %>
+
+    <h1 class="govuk-heading-l">Search diagnostics</h1>
+
+    <dl class="govuk-summary-list">
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Request ID</dt>
+        <dd class="govuk-summary-list__value"><%= @search_diagnostic.request_id %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Log group</dt>
+        <dd class="govuk-summary-list__value"><%= @search_diagnostic.log_group_name %></dd>
+      </div>
+      <div class="govuk-summary-list__row">
+        <dt class="govuk-summary-list__key">Time range</dt>
+        <dd class="govuk-summary-list__value">
+          <%= @search_diagnostic.start_time %> to <%= @search_diagnostic.end_time %>
+        </dd>
+      </div>
+    </dl>
+
+    <% if @search_diagnostic.events? %>
+      <table class="govuk-table">
+        <caption class="govuk-table__caption govuk-table__caption--m">Search journey events</caption>
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Time</th>
+            <th scope="col" class="govuk-table__header">Event</th>
+            <th scope="col" class="govuk-table__header">Search type</th>
+            <th scope="col" class="govuk-table__header">Details</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @search_diagnostic.events.each do |event| %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell"><%= event[:timestamp].presence || "-" %></td>
+              <td class="govuk-table__cell"><%= event[:event].presence || "-" %></td>
+              <td class="govuk-table__cell"><%= event[:search_type].presence || "-" %></td>
+              <td class="govuk-table__cell">
+                <details class="govuk-details">
+                  <summary class="govuk-details__summary">
+                    <span class="govuk-details__summary-text">View fields</span>
+                  </summary>
+                  <div class="govuk-details__text">
+                    <pre class="govuk-body-s"><%= JSON.pretty_generate(event[:fields] || {}) %></pre>
+                  </div>
+                </details>
+              </td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    <% else %>
+      <p class="govuk-body">No search journey events were found for this request ID.</p>
+    <% end %>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
       post :bulk_import
     end
   end
+  resources :search_diagnostics, only: %i[index show], param: :request_id, constraints: { request_id: /[^\/.]+/ }
   resources :goods_nomenclature_autocomplete_results, only: %i[index]
 
   namespace :green_lanes, path: "green_lanes" do

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe NavigationHelper, type: :helper do
       )
     end
 
-    it "defines Classification with 4 items" do
+    it "defines Classification with 6 items" do
       section = helper.navigation_sections.find { |s| s.key == :classification }
-      expect(section.items.map(&:text)).to eq(["Search References", "Descriptions", "Configuration", "Intercepts", "Recent changes"])
+      expect(section.items.map(&:text)).to eq(["Search References", "Descriptions", "Configuration", "Intercepts", "Diagnostics", "Recent changes"])
     end
 
     it "defines SPIMM with xi service restriction" do
@@ -81,7 +81,7 @@ RSpec.describe NavigationHelper, type: :helper do
                          "Reports",
                          "Rollbacks",
                        ],
-                       classification: ["Search References", "Descriptions", "Configuration", "Intercepts", "Recent changes"],
+                       classification: ["Search References", "Descriptions", "Configuration", "Intercepts", "Diagnostics", "Recent changes"],
                        manage_users: nil
     end
 
@@ -92,7 +92,7 @@ RSpec.describe NavigationHelper, type: :helper do
 
       include_examples "visible sections and items",
                        ott_admin: ["News", "Live Issues"],
-                       classification: ["Search References"]
+                       classification: ["Search References", "Diagnostics"]
     end
 
     context "with UK service and auditor role" do
@@ -109,7 +109,7 @@ RSpec.describe NavigationHelper, type: :helper do
                          "Updates",
                          "Rollbacks",
                        ],
-                       classification: ["Search References", "Configuration"]
+                       classification: ["Search References", "Configuration", "Diagnostics"]
     end
 
     context "with UK service and guest role" do
@@ -129,7 +129,7 @@ RSpec.describe NavigationHelper, type: :helper do
 
       include_examples "visible sections and items",
                        ott_admin: ["Section & chapter notes", "Updates", "Reports", "Rollbacks"],
-                       classification: ["Search References", "Descriptions", "Recent changes"],
+                       classification: ["Search References", "Descriptions", "Diagnostics", "Recent changes"],
                        spimm: [
                          "Category Assessments",
                          "Exemptions",
@@ -147,7 +147,7 @@ RSpec.describe NavigationHelper, type: :helper do
       let(:user) { build(:user, :hmrc_admin) }
 
       include_examples "visible sections and items",
-                       classification: ["Search References"]
+                       classification: ["Search References", "Diagnostics"]
     end
 
     context "with XI service and auditor role" do
@@ -157,7 +157,7 @@ RSpec.describe NavigationHelper, type: :helper do
 
       include_examples "visible sections and items",
                        ott_admin: ["Section & chapter notes", "Updates", "Rollbacks"],
-                       classification: ["Search References"],
+                       classification: ["Search References", "Diagnostics"],
                        spimm: [
                          "Category Assessments",
                          "Exemptions",

--- a/spec/models/search_diagnostic_spec.rb
+++ b/spec/models/search_diagnostic_spec.rb
@@ -1,0 +1,50 @@
+RSpec.describe SearchDiagnostic do
+  describe ".find" do
+    before do
+      stub_api_request("/search_diagnostics/request-123")
+        .with(query: { lookback_hours: "24", limit: "50" })
+        .to_return jsonapi_response(
+          :search_diagnostic,
+          {
+            resource_id: "request-123",
+            request_id: "request-123",
+            log_group_name: "platform-logs-test",
+            start_time: "2026-06-02T10:00:00Z",
+            end_time: "2026-06-05T10:00:00Z",
+            events: [
+              {
+                timestamp: "2026-06-05 09:59:00.000",
+                event: "search_completed",
+                search_type: "classic",
+                fields: {
+                  request_id: "request-123",
+                  query: "horse",
+                },
+              },
+            ],
+          },
+        )
+    end
+
+    it "fetches diagnostics from the backend by request id" do
+      diagnostic = described_class.find("request-123", lookback_hours: "24", limit: "50")
+      event = diagnostic.events.first
+
+      expect([diagnostic.request_id, diagnostic.log_group_name, event[:event], event.dig(:fields, :query)]).to eq(%w[request-123 platform-logs-test search_completed horse])
+    end
+  end
+
+  describe "#events?" do
+    it "is true when events are present" do
+      diagnostic = described_class.new(events: [{ event: "search_started" }])
+
+      expect(diagnostic).to be_events
+    end
+
+    it "is false when events are absent" do
+      diagnostic = described_class.new(events: [])
+
+      expect(diagnostic).not_to be_events
+    end
+  end
+end

--- a/spec/policies/search_diagnostic_policy_spec.rb
+++ b/spec/policies/search_diagnostic_policy_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe SearchDiagnosticPolicy do
+  subject(:policy) { described_class }
+
+  let(:diagnostic) { SearchDiagnostic.new(request_id: "request-123") }
+
+  permissions :index?, :show? do
+    it "grants access to technical operator" do
+      expect(policy).to permit(create(:user, :technical_operator), diagnostic)
+    end
+
+    it "grants access to hmrc admin" do
+      expect(policy).to permit(create(:user, :hmrc_admin), diagnostic)
+    end
+
+    it "grants access to auditor" do
+      expect(policy).to permit(create(:user, :auditor), diagnostic)
+    end
+
+    it "denies access to guest user" do
+      expect(policy).not_to permit(create(:user, :guest), diagnostic)
+    end
+  end
+end

--- a/spec/requests/search_diagnostics_controller_spec.rb
+++ b/spec/requests/search_diagnostics_controller_spec.rb
@@ -48,6 +48,105 @@ RSpec.describe SearchDiagnosticsController do
                   query: "horse",
                 },
               },
+              {
+                timestamp: "2026-06-05 09:59:01.000",
+                event: "exact_match_selected",
+                search_type: "classic",
+                fields: {
+                  request_id: "request-123",
+                  search_type: "classic",
+                  query: "horse",
+                  match_source: "search_reference",
+                  matched_value: "horse",
+                  target_id: "0101210000",
+                  goods_nomenclature_item_id: "0101210000",
+                  goods_nomenclature_sid: 123,
+                  goods_nomenclature_class: "Commodity",
+                  details: {
+                    goods_nomenclature_item_id: "0101210000",
+                    goods_nomenclature_sid: 123,
+                    goods_nomenclature_class: "Commodity",
+                    self_text_id: 123,
+                  },
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:02.000",
+                event: "fuzzy_results_returned",
+                search_type: "classic",
+                fields: {
+                  request_id: "request-123",
+                  search_type: "classic",
+                  query: "shoe",
+                  result_count: 1,
+                  details: {
+                    goods_nomenclature_match: {
+                      commodities: [
+                        {
+                          goods_nomenclature_item_id: "6403990000",
+                          goods_nomenclature_sid: 456,
+                          goods_nomenclature_class: "Commodity",
+                          score: 14.2,
+                        },
+                      ],
+                    },
+                  },
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:03.000",
+                event: "interactive_configuration_used",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  search_type: "interactive",
+                  query: "red leather shoes",
+                  details: {
+                    retrieval_method: "hybrid",
+                    rrf_k: 60,
+                    filter_prefixes: %w[64],
+                  },
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:04.000",
+                event: "question_returned",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  question_count: 1,
+                  details: {
+                    questions: [
+                      { question: "What material are the shoes made from?" },
+                    ],
+                  },
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:05.000",
+                event: "retrieval_results_returned",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  search_type: "interactive",
+                  query: "red leather shoes",
+                  retrieval_method: "hybrid",
+                  stage: "after_rrf",
+                  leg: nil,
+                  result_count: 1,
+                  details: {
+                    results: [
+                      {
+                        goods_nomenclature_item_id: "6403990000",
+                        goods_nomenclature_sid: 456,
+                        goods_nomenclature_class: "Commodity",
+                        score: 12.7,
+                        self_text_id: 456,
+                      },
+                    ],
+                  },
+                },
+              },
             ],
           },
         )
@@ -57,10 +156,22 @@ RSpec.describe SearchDiagnosticsController do
 
     it { is_expected.to have_http_status :success }
 
-    it "renders the diagnostics journey" do
+    it "renders the diagnostics journey shell" do
       rendered_page
 
       expect(response.body).to include("request-123", "platform-logs-test", "Search journey events", "search_completed", "classic", "horse")
+    end
+
+    it "renders classic exact and fuzzy event summaries" do
+      rendered_page
+
+      expect(response.body).to include("Exact match - search reference - horse - commodities/0101210000", "Fuzzy results returned - 1 result", "6403990000", "14.2")
+    end
+
+    it "renders internal interactive event summaries" do
+      rendered_page
+
+      expect(response.body).to include("Interactive configuration used", "Retrieval method", "hybrid", "Rrf k", "60", "Questions returned - 1 question", "What material are the shoes made from?", "Hybrid - After rrf - 1 result", "12.7", "View self-text", "View labels")
     end
 
     context "when no events are found" do

--- a/spec/requests/search_diagnostics_controller_spec.rb
+++ b/spec/requests/search_diagnostics_controller_spec.rb
@@ -1,0 +1,111 @@
+RSpec.describe SearchDiagnosticsController do
+  subject(:rendered_page) { make_request && response }
+
+  include_context "with authenticated user"
+
+  describe "GET #index" do
+    let(:make_request) { get search_diagnostics_path }
+
+    it { is_expected.to have_http_status :success }
+
+    it "renders the search form" do
+      rendered_page
+
+      expect(response.body).to include("Search diagnostics", "Request ID", "Find diagnostics")
+    end
+
+    context "when a request id is submitted" do
+      let(:make_request) { get search_diagnostics_path, params: { request_id: " request-123 " } }
+
+      it { is_expected.to redirect_to(search_diagnostic_path("request-123")) }
+    end
+
+    context "when unauthorised" do
+      let(:current_user) { create(:user, :guest) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+  end
+
+  describe "GET #show" do
+    before do
+      stub_api_request("/search_diagnostics/request-123")
+        .to_return jsonapi_response(
+          :search_diagnostic,
+          {
+            resource_id: "request-123",
+            request_id: "request-123",
+            log_group_name: "platform-logs-test",
+            start_time: "2026-06-02T10:00:00Z",
+            end_time: "2026-06-05T10:00:00Z",
+            events: [
+              {
+                timestamp: "2026-06-05 09:59:00.000",
+                event: "search_completed",
+                search_type: "classic",
+                fields: {
+                  request_id: "request-123",
+                  query: "horse",
+                },
+              },
+            ],
+          },
+        )
+    end
+
+    let(:make_request) { get search_diagnostic_path("request-123") }
+
+    it { is_expected.to have_http_status :success }
+
+    it "renders the diagnostics journey" do
+      rendered_page
+
+      expect(response.body).to include("request-123", "platform-logs-test", "Search journey events", "search_completed", "classic", "horse")
+    end
+
+    context "when no events are found" do
+      before do
+        stub_api_request("/search_diagnostics/missing-request")
+          .to_return jsonapi_response(
+            :search_diagnostic,
+            {
+              resource_id: "missing-request",
+              request_id: "missing-request",
+              log_group_name: "platform-logs-test",
+              start_time: "2026-06-02T10:00:00Z",
+              end_time: "2026-06-05T10:00:00Z",
+              events: [],
+            },
+          )
+      end
+
+      let(:make_request) { get search_diagnostic_path("missing-request") }
+
+      it "renders an empty state" do
+        rendered_page
+
+        expect(response.body).to include("No search journey events were found for this request ID.")
+      end
+    end
+
+    context "when the backend cannot load diagnostics" do
+      before do
+        stub_api_request("/search_diagnostics/request-123").to_return(status: 502, body: "", headers: {})
+      end
+
+      it { is_expected.to redirect_to(search_diagnostics_path) }
+
+      it "shows a failure message" do
+        rendered_page
+
+        expect(flash[:alert]).to eq("Search diagnostics could not be loaded.")
+      end
+    end
+
+    context "when unauthorised" do
+      let(:current_user) { create(:user, :guest) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-589](https://transformuk.atlassian.net/browse/AI-589)

<img width="869" height="1259" alt="image" src="https://github.com/user-attachments/assets/dfe2710d-80af-4a16-ab8e-bb8a27bf3172" />


```mermaid
flowchart TD
    OPERATOR[Operator enters request ID]
    ADMIN[Search diagnostics screen]
    BACKEND[Backend diagnostics API]
    EVENTS[Search journey events]
    SCREEN[Read-only diagnostics view]

    OPERATOR --> ADMIN
    ADMIN --> BACKEND
    BACKEND --> EVENTS
    EVENTS --> SCREEN

    classDef box stroke:#6366f1,stroke-width:2px
    class OPERATOR,ADMIN,BACKEND,EVENTS,SCREEN box
```

### What?

I have added/removed/altered:

- [x] Added a read-only search diagnostics screen under Classification -> Diagnostics.
- [x] Added an admin API entity for fetching backend search diagnostics by request ID.
- [x] Added routing, policy, navigation, model, request, and view coverage for the new screen.
- [x] Rendered request metadata and the raw search journey event list.

### Why?

I am doing this because:

- Operators need an admin entry point for diagnosing search journeys from a request ID.
- The screen lets support users inspect search log payloads without needing direct log access.
- This is read-only diagnostics UI and does not change public search behaviour.

### Risk

**Risk level:** 🟢 Low

**Reason for rating:** This adds a new read-only admin screen behind existing admin permissions. It does not change trader-facing search behaviour, admin mutations, or persisted tariff data.
