### PR TITLE
AI-589: Improve search diagnostics timeline

### DIFF
--- a/app/helpers/search_diagnostics_helper.rb
+++ b/app/helpers/search_diagnostics_helper.rb
@@ -1,8 +1,54 @@
 module SearchDiagnosticsHelper
+  EVENT_DETAIL_KEYS = {
+    "search_started" => %i[query search_type],
+    "query_expanded" => %i[original_query expanded_query reason duration_ms],
+    "query_refined" => %i[original_query refined_query answer_count],
+    "query_expansion_decided" => %i[query expand reason result_count max_score],
+    "api_call_completed" => %i[model response_type attempt_number duration_ms error_message error_message_truncated],
+    "description_intercept_checked" => %i[matched term excluded filtering filter_prefix_count guidance_level guidance_location escalate_to_webchat],
+    "question_returned" => %i[question_count attempt_number],
+    "answer_returned" => %i[answer_count confidence_levels attempt_number],
+    "search_completed" => %i[query search_type results_type final_result_type total_attempts total_questions result_count max_score total_duration_ms description_intercept_matched description_intercept_term description_intercept_excluded description_intercept_filtering description_intercept_filter_prefix_count description_intercept_guidance_level description_intercept_guidance_location description_intercept_escalate_to_webchat error_message error_message_truncated],
+    "retrieval_leg_completed" => %i[leg status result_count duration_ms error_message error_message_truncated],
+    "result_selected" => %i[goods_nomenclature_item_id goods_nomenclature_class],
+    "search_failed" => %i[search_type error_type error_message error_message_truncated],
+  }.freeze
+
+  FIELD_LABELS = {
+    attempt_number: "Attempt",
+    duration_ms: "Duration",
+    total_duration_ms: "Total duration",
+    final_result_type: "Final result",
+    expand: "Expand query",
+  }.freeze
+
+  SIGNIFICANT_TIMELINE_EVENTS = %w[
+    exact_match_selected
+    fuzzy_results_returned
+    api_call_completed
+    retrieval_leg_completed
+    retrieval_results_returned
+    question_returned
+    answer_returned
+    search_completed
+    search_failed
+  ].freeze
+
   def search_diagnostic_event_summary(event)
     fields = search_diagnostic_fields(event)
 
     case event[:event].to_s
+    when "search_started"
+      ["Search started", fields[:query]].compact_blank.join(" - ")
+    when "query_expanded"
+      query_change_summary("Query expanded", fields[:original_query], fields[:expanded_query])
+    when "query_refined"
+      "Query refined - added #{pluralize(fields[:answer_count].to_i, 'answer')}"
+    when "query_expansion_decided"
+      decision = truthy?(fields[:expand]) ? "used" : "skipped"
+      ["Query expansion #{decision}", readable_value(fields[:reason])].compact_blank.join(" - ")
+    when "api_call_completed"
+      ["Model returned #{readable_value(fields[:response_type]) || 'response'}", attempt_label(fields)].compact_blank.join(" - ")
     when "exact_match_selected"
       code = target_label(fields)
       source = fields[:match_source].to_s.humanize.downcase.presence || "source"
@@ -22,11 +68,94 @@ module SearchDiagnosticsHelper
       "Questions returned - #{pluralize(fields[:question_count].to_i, 'question')}"
     when "answer_returned"
       "Answers returned - #{pluralize(fields[:answer_count].to_i, 'answer')}"
+    when "description_intercept_checked"
+      description_intercept_summary(fields)
     when "search_completed"
-      "Search completed - #{fields[:results_type].presence || fields[:final_result_type].presence || pluralize(fields[:result_count].to_i, 'result')}"
+      result_type = fields[:results_type].presence || fields[:final_result_type].presence
+      ["Search completed", readable_value(result_type) || pluralize(fields[:result_count].to_i, "result")].compact_blank.join(" - ")
+    when "retrieval_leg_completed"
+      ["#{readable_value(fields[:leg]).to_s.capitalize} retrieval #{status_label(fields[:status])}", pluralize(fields[:result_count].to_i, "result")].compact_blank.join(" - ")
+    when "result_selected"
+      ["Result selected", [readable_value(fields[:goods_nomenclature_class]).to_s.downcase.presence, fields[:goods_nomenclature_item_id]].compact_blank.join(" ")].compact_blank.join(" - ")
+    when "search_failed"
+      ["Search failed", fields[:error_type]].compact_blank.join(" - ")
     else
-      event[:event].presence || "Event"
+      search_diagnostic_event_name(event)
     end
+  end
+
+  def search_diagnostic_event_name(event)
+    event[:event].to_s.humanize.presence || "Event"
+  end
+
+  def search_diagnostic_search_type(event)
+    case event[:search_type].presence
+    when "interactive" then "Internal"
+    when "classic" then "Classic"
+    else
+      event[:search_type].to_s.humanize.presence || "-"
+    end
+  end
+
+  def search_diagnostic_events_with_context(events)
+    current_search_type = nil
+
+    Array(events).map do |event|
+      event = normalise_search_diagnostic_hash(event).dup
+      current_search_type = event[:search_type].presence || current_search_type
+
+      if event[:event].to_s == "result_selected" && event[:search_type].blank?
+        event[:search_type] = current_search_type
+      end
+
+      event
+    end
+  end
+
+  def search_diagnostic_event_time(event)
+    timestamp = event[:timestamp].to_s
+    return "-" if timestamp.blank?
+
+    Time.zone.parse(timestamp).strftime("%H:%M:%S.%L")
+  rescue ArgumentError
+    timestamp
+  end
+
+  def search_diagnostic_time_range(diagnostic)
+    [diagnostic.start_time, diagnostic.end_time].filter_map { |timestamp| diagnostic_datetime(timestamp) }.join(" to ")
+  end
+
+  def search_diagnostic_timeline_events(events)
+    timed_events = Array(events).filter_map do |event|
+      timestamp = diagnostic_timestamp(event[:timestamp])
+      next if timestamp.blank?
+
+      {
+        name: search_diagnostic_event_name(event),
+        summary: search_diagnostic_event_summary(event),
+        search_type: search_diagnostic_search_type(event),
+        timestamp: timestamp,
+        time: search_diagnostic_event_time(event),
+        significant: SIGNIFICANT_TIMELINE_EVENTS.include?(event[:event].to_s),
+      }
+    end
+    return [] if timed_events.blank?
+
+    sorted_events = timed_events.sort_by { |event| event[:timestamp] }.each_with_index.map do |event, index|
+      event.merge(id: search_diagnostic_event_dom_id(index))
+    end
+
+    timeline_events_by_order(sorted_events)
+  end
+
+  def search_diagnostic_event_dom_id(index)
+    "search-event-#{index}"
+  end
+
+  def search_diagnostic_significant_timeline_events(events)
+    significant_events = events.select { |event| event[:significant] }
+
+    significant_events.presence || events
   end
 
   def search_diagnostic_event_details(event)
@@ -45,6 +174,8 @@ module SearchDiagnosticsHelper
                 questions_details(fields)
               when "answer_returned"
                 answers_details(fields)
+              when *EVENT_DETAIL_KEYS.keys
+                generic_event_details(event[:event].to_s, fields)
               end
 
     safe_join([
@@ -58,6 +189,31 @@ module SearchDiagnosticsHelper
   end
 
 private
+
+  def diagnostic_datetime(timestamp)
+    parsed = diagnostic_timestamp(timestamp)
+    return if parsed.blank?
+
+    "#{parsed.to_date.to_formatted_s(:govuk)} at #{parsed.strftime('%H:%M')}"
+  end
+
+  def diagnostic_timestamp(timestamp)
+    return if timestamp.blank?
+
+    Time.zone.parse(timestamp.to_s)
+  rescue ArgumentError
+    nil
+  end
+
+  def timeline_events_by_order(events)
+    return events.map { |event| event.merge(position: 0) } if events.one?
+
+    event_count = events.size - 1
+
+    events.each_with_index.map do |event, index|
+      event.merge(position: ((index.to_f / event_count) * 100).round)
+    end
+  end
 
   def exact_match_details(fields)
     rows = {
@@ -114,9 +270,11 @@ private
 
   def answers_details(fields)
     answers = Array(search_diagnostic_details(fields)[:answers])
-    return content_tag(:p, "No answer details were logged.", class: "govuk-body-s") if answers.blank?
 
-    result_table(answers)
+    safe_join([
+      key_value_list(fields.slice(:answer_count, :confidence_levels, :attempt_number)),
+      answers.blank? ? content_tag(:p, "No answer details were logged.", class: "govuk-body-s") : result_table(answers),
+    ])
   end
 
   def result_group(level, results)
@@ -129,7 +287,7 @@ private
   def result_table(results)
     return content_tag(:p, "No results were logged.", class: "govuk-body-s") if results.blank?
 
-    content_tag(:table, class: "govuk-table govuk-!-margin-bottom-4") do
+    content_tag(:table, class: "govuk-table govuk-!-margin-bottom-4 app-diagnostics-table") do
       safe_join([
         content_tag(:thead, class: "govuk-table__head") do
           content_tag(:tr, class: "govuk-table__row") do
@@ -161,8 +319,8 @@ private
 
       content_tag(:div, class: "govuk-summary-list__row") do
         safe_join([
-          content_tag(:dt, key.to_s.humanize, class: "govuk-summary-list__key"),
-          content_tag(:dd, diagnostic_value(value), class: "govuk-summary-list__value"),
+          content_tag(:dt, field_label(key), class: "govuk-summary-list__key"),
+          content_tag(:dd, diagnostic_value(key, value), class: "govuk-summary-list__value"),
         ])
       end
     end
@@ -178,12 +336,14 @@ private
     end
   end
 
-  def diagnostic_value(value)
+  def diagnostic_value(key, value)
     return value if value.is_a?(ActiveSupport::SafeBuffer)
-    return value.join(", ") if value.is_a?(Array)
-    return JSON.pretty_generate(value) if value.is_a?(Hash)
+    return value.map { |item| readable_value(item) }.join(", ") if value.is_a?(Array)
+    return value.map { |key, item| "#{readable_value(key)}: #{readable_value(item)}" }.join(", ") if value.is_a?(Hash)
+    return "#{number_with_delimiter(value)} ms" if key.to_s.end_with?("_ms")
+    return value if key.to_sym == :description_intercept
 
-    value
+    readable_value(value)
   end
 
   def raw_event_details(event)
@@ -201,10 +361,11 @@ private
 
   def goods_nomenclature_link(result)
     endpoint = result[:target_endpoint].presence || endpoint_for_class(result[:goods_nomenclature_class])
-    id = result[:target_id].presence || result[:goods_nomenclature_item_id]
+    id = result[:target_id].presence || result[:goods_nomenclature_item_id].presence || result[:commodity_code]
+    return id if endpoint.blank? && id.present?
     return "-" if endpoint.blank? || id.blank?
 
-    link_to(target_label(result), "#{TradeTariffAdmin.frontend_host}/#{endpoint}/#{id}", class: "govuk-link", target: "_blank", rel: "noopener noreferrer")
+    link_to(id, "#{TradeTariffAdmin.frontend_host}/#{endpoint}/#{id}", class: "govuk-link", target: "_blank", rel: "noopener noreferrer")
   end
 
   def self_text_link(result)
@@ -215,7 +376,7 @@ private
   end
 
   def label_link(result)
-    id = result[:goods_nomenclature_item_id] || result[:target_id]
+    id = result[:goods_nomenclature_item_id] || result[:target_id] || result[:commodity_code]
     return "-" if id.blank?
 
     link_to("View labels", goods_nomenclature_label_path(id), class: "govuk-link")
@@ -231,9 +392,81 @@ private
 
   def target_label(result)
     endpoint = result[:target_endpoint].presence || endpoint_for_class(result[:goods_nomenclature_class])
-    id = result[:target_id].presence || result[:goods_nomenclature_item_id]
+    id = result[:target_id].presence || result[:goods_nomenclature_item_id].presence || result[:commodity_code]
 
     [endpoint, id].compact_blank.join("/")
+  end
+
+  def generic_event_details(event_name, fields)
+    key_value_list(detail_rows(event_name, fields))
+  end
+
+  def detail_rows(event_name, fields)
+    rows = fields.slice(*EVENT_DETAIL_KEYS.fetch(event_name, []))
+    return rows.merge(goods_nomenclature_item_id: goods_nomenclature_link(fields)) if event_name == "result_selected"
+    return rows unless event_name == "search_completed"
+
+    rows[:description_intercept] = description_intercept_value(fields) if fields.key?(:description_intercept_matched)
+    rows.except(
+      :description_intercept_matched,
+      :description_intercept_term,
+      :description_intercept_excluded,
+      :description_intercept_filtering,
+      :description_intercept_filter_prefix_count,
+      :description_intercept_guidance_level,
+      :description_intercept_guidance_location,
+      :description_intercept_escalate_to_webchat,
+    )
+  end
+
+  def field_label(key)
+    FIELD_LABELS.fetch(key.to_sym, key.to_s.humanize)
+  end
+
+  def attempt_label(fields)
+    return if fields[:attempt_number].blank?
+
+    "attempt #{fields[:attempt_number]}"
+  end
+
+  def query_change_summary(label, original_query, changed_query)
+    return label if original_query.blank? && changed_query.blank?
+    return [label, original_query].compact_blank.join(" - ") if changed_query.blank?
+    return [label, changed_query].compact_blank.join(" - ") if original_query.blank?
+
+    "#{label} - #{original_query} to #{changed_query}"
+  end
+
+  def description_intercept_summary(fields)
+    return "Description intercept not matched" unless truthy?(fields[:matched])
+
+    ["Description intercept matched", fields[:term]].compact_blank.join(" - ")
+  end
+
+  def description_intercept_value(fields)
+    return "Not matched" unless truthy?(fields[:description_intercept_matched])
+
+    [
+      "Matched",
+      fields[:description_intercept_term],
+      fields[:description_intercept_excluded].present? ? "excluded" : nil,
+      fields[:description_intercept_filtering].present? ? "filtering" : nil,
+    ].compact_blank.join(" ")
+  end
+
+  def status_label(value)
+    value.to_s == "success" ? "succeeded" : readable_value(value)
+  end
+
+  def readable_value(value)
+    return value if value.is_a?(ActiveSupport::SafeBuffer)
+    return if value.nil?
+
+    value.to_s.humanize.downcase
+  end
+
+  def truthy?(value)
+    value == true || value.to_s == "true"
   end
 
   def normalise_search_diagnostic_hash(value)

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -14,33 +14,73 @@
         <dd class="govuk-summary-list__value"><%= @search_diagnostic.log_group_name %></dd>
       </div>
       <div class="govuk-summary-list__row">
-        <dt class="govuk-summary-list__key">Time range</dt>
+        <dt class="govuk-summary-list__key">Log search window</dt>
         <dd class="govuk-summary-list__value">
-          <%= @search_diagnostic.start_time %> to <%= @search_diagnostic.end_time %>
+          <%= search_diagnostic_time_range(@search_diagnostic) %>
         </dd>
       </div>
     </dl>
 
     <% if @search_diagnostic.events? %>
-      <table class="govuk-table">
+      <% contextual_events = search_diagnostic_events_with_context(@search_diagnostic.events) %>
+      <% timeline_events = search_diagnostic_timeline_events(contextual_events) %>
+
+      <% if timeline_events.any? %>
+        <% highlighted_timeline_events = search_diagnostic_significant_timeline_events(timeline_events) %>
+
+        <section class="search-diagnostics-timeline" aria-labelledby="search-diagnostics-timeline-title">
+          <div class="search-diagnostics-timeline__header">
+            <h2 class="govuk-heading-m govuk-!-margin-bottom-0" id="search-diagnostics-timeline-title">Search event timeline</h2>
+            <p class="govuk-body-s govuk-!-margin-bottom-0">Key events are listed below. Significant events are shown with larger markers.</p>
+          </div>
+
+          <div class="search-diagnostics-timeline__track" aria-hidden="true">
+            <ol class="search-diagnostics-timeline__events">
+              <% timeline_events.each do |event| %>
+                <li class="search-diagnostics-timeline__event <%= 'search-diagnostics-timeline__event--significant' if event[:significant] %>" style="--position: <%= event[:position] %>%;">
+                  <a class="search-diagnostics-timeline__marker-link" href="#<%= event[:id] %>">
+                    <span class="search-diagnostics-timeline__marker"></span>
+                    <span class="search-diagnostics-timeline__label">
+                    <span class="search-diagnostics-timeline__time"><%= event[:time] %></span>
+                    <span class="search-diagnostics-timeline__name"><%= event[:name] %></span>
+                    </span>
+                  </a>
+                </li>
+              <% end %>
+            </ol>
+          </div>
+
+          <ol class="search-diagnostics-timeline__list govuk-list">
+            <% highlighted_timeline_events.each do |event| %>
+              <li>
+                <span class="search-diagnostics-timeline__list-time"><%= event[:time] %></span>
+                <span class="search-diagnostics-timeline__list-name"><%= event[:name] %></span>
+                <span class="search-diagnostics-timeline__list-type"><%= event[:search_type] %></span>
+              </li>
+            <% end %>
+          </ol>
+        </section>
+      <% end %>
+
+      <table class="govuk-table search-diagnostics-events">
         <caption class="govuk-table__caption govuk-table__caption--m">Search journey events</caption>
         <thead class="govuk-table__head">
           <tr class="govuk-table__row">
-            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Time</th>
-            <th scope="col" class="govuk-table__header">Event</th>
-            <th scope="col" class="govuk-table__header">Search type</th>
-            <th scope="col" class="govuk-table__header">Summary</th>
-            <th scope="col" class="govuk-table__header">Diagnostics</th>
+            <th scope="col" class="govuk-table__header">Time</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Event</th>
+            <th scope="col" class="govuk-table__header">Type</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-third">Summary</th>
+            <th scope="col" class="govuk-table__header govuk-!-width-one-quarter">Diagnostics</th>
           </tr>
         </thead>
         <tbody class="govuk-table__body">
-          <% @search_diagnostic.events.each do |event| %>
-            <tr class="govuk-table__row">
-              <td class="govuk-table__cell"><%= event[:timestamp].presence || "-" %></td>
-              <td class="govuk-table__cell"><%= event[:event].presence || "-" %></td>
-              <td class="govuk-table__cell"><%= event[:search_type].presence || "-" %></td>
-              <td class="govuk-table__cell"><%= search_diagnostic_event_summary(event) %></td>
-              <td class="govuk-table__cell">
+          <% contextual_events.each_with_index do |event, index| %>
+            <tr class="govuk-table__row" id="<%= search_diagnostic_event_dom_id(index) %>">
+              <td class="govuk-table__cell" data-label="Time"><%= search_diagnostic_event_time(event) %></td>
+              <td class="govuk-table__cell" data-label="Event"><%= search_diagnostic_event_name(event) %></td>
+              <td class="govuk-table__cell" data-label="Type"><%= search_diagnostic_search_type(event) %></td>
+              <td class="govuk-table__cell" data-label="Summary"><%= search_diagnostic_event_summary(event) %></td>
+              <td class="govuk-table__cell" data-label="Diagnostics">
                 <details class="govuk-details">
                   <summary class="govuk-details__summary">
                     <span class="govuk-details__summary-text">View diagnostics</span>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -476,3 +476,204 @@ $govuk-image-url-function: frontend-image-url;
     background-color: govuk-tint(govuk-colour("blue"), 90%);
   }
 }
+
+.search-diagnostics-events {
+  @include govuk-media-query($until: tablet) {
+    thead {
+      @include govuk-visually-hidden;
+    }
+
+    tbody,
+    tr,
+    td {
+      display: block;
+    }
+
+    tr {
+      border-bottom: 2px solid govuk-colour("black", $variant: "tint-80");
+      padding: govuk-spacing(2) 0;
+    }
+
+    td {
+      border-bottom: 0;
+      padding: govuk-spacing(1) 0;
+
+      &::before {
+        @include govuk-font($size: 16, $weight: bold);
+        content: attr(data-label);
+        display: block;
+        margin-bottom: govuk-spacing(1);
+      }
+    }
+
+    .govuk-details {
+      margin-bottom: 0;
+    }
+  }
+}
+
+.search-diagnostics-timeline {
+  border: 1px solid govuk-colour("black", $variant: "tint-80");
+  margin-bottom: govuk-spacing(6);
+  padding: govuk-spacing(4);
+
+  &__header {
+    align-items: flex-start;
+    display: flex;
+    gap: govuk-spacing(3);
+    justify-content: space-between;
+    margin-bottom: govuk-spacing(4);
+  }
+
+  &__track {
+    padding: govuk-spacing(6) govuk-spacing(2) govuk-spacing(8);
+    position: relative;
+
+    &::before {
+      background: govuk-colour("blue");
+      content: "";
+      height: 4px;
+      left: govuk-spacing(2);
+      position: absolute;
+      right: govuk-spacing(2);
+      top: govuk-spacing(6);
+    }
+  }
+
+  &__events {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    position: relative;
+  }
+
+  &__event {
+    left: var(--position);
+    position: absolute;
+    top: -9px;
+    transform: translateX(-50%);
+  }
+
+  &__marker {
+    background: govuk-colour("white");
+    border: 3px solid govuk-colour("blue");
+    border-radius: 50%;
+    display: block;
+    height: 14px;
+    margin: 0 auto;
+    transition: box-shadow 120ms ease-out, transform 120ms ease-out;
+    width: 14px;
+  }
+
+  &__marker-link {
+    display: block;
+    text-decoration: none;
+
+    &:focus {
+      @include govuk-focused-text;
+      outline: 3px solid transparent;
+    }
+
+    &:hover .search-diagnostics-timeline__marker,
+    &:focus .search-diagnostics-timeline__marker {
+      box-shadow: 0 0 0 4px govuk-colour("yellow"), 0 0 0 7px govuk-colour("blue");
+      transform: scale(1.2);
+    }
+  }
+
+  &__event--significant &__marker {
+    background: govuk-colour("blue");
+    box-shadow: 0 0 0 4px govuk-colour("white"), 0 0 0 6px govuk-colour("blue");
+    height: 18px;
+    width: 18px;
+  }
+
+  &__label {
+    @include govuk-font($size: 16);
+    background: govuk-colour("black");
+    color: govuk-colour("white");
+    left: 50%;
+    opacity: 0;
+    padding: govuk-spacing(1) govuk-spacing(2);
+    pointer-events: none;
+    position: absolute;
+    text-align: left;
+    top: govuk-spacing(4);
+    transform: translateX(-50%) translateY(-4px);
+    transition: opacity 120ms ease-out, transform 120ms ease-out;
+    white-space: nowrap;
+    z-index: 1;
+  }
+
+  &__marker-link:hover &__label,
+  &__marker-link:focus &__label {
+    opacity: 1;
+    transform: translateX(-50%);
+  }
+
+  &__time {
+    color: govuk-colour("black", $variant: "tint-25");
+    display: block;
+  }
+
+  &__name {
+    display: block;
+    font-weight: bold;
+  }
+
+  &__list {
+    border-top: 1px solid govuk-colour("black", $variant: "tint-80");
+    display: grid;
+    gap: govuk-spacing(2);
+    grid-template-columns: repeat(auto-fit, minmax(12rem, 1fr));
+    margin-bottom: 0;
+    padding-top: govuk-spacing(3);
+
+    li {
+      @include govuk-font($size: 16);
+      border-left: 4px solid govuk-colour("blue");
+      padding-left: govuk-spacing(2);
+    }
+  }
+
+  &__list-time,
+  &__list-type {
+    color: govuk-colour("black", $variant: "tint-25");
+    display: block;
+  }
+
+  &__list-name {
+    display: block;
+    font-weight: bold;
+  }
+
+  @include govuk-media-query($until: tablet) {
+    padding: govuk-spacing(3);
+
+    &__header {
+      display: block;
+    }
+
+    &__track {
+      display: none;
+    }
+
+    &__list {
+      border-top: 0;
+      display: block;
+      padding-top: 0;
+
+      li {
+        margin-bottom: govuk-spacing(3);
+      }
+    }
+  }
+}
+
+.search-diagnostics-events {
+  .govuk-table__row:target {
+    background-color: govuk-colour("yellow");
+    outline: 3px solid govuk-colour("black");
+    outline-offset: -3px;
+  }
+}

--- a/spec/helpers/search_diagnostics_helper_spec.rb
+++ b/spec/helpers/search_diagnostics_helper_spec.rb
@@ -1,0 +1,310 @@
+RSpec.describe SearchDiagnosticsHelper do
+  describe "#search_diagnostic_event_summary" do
+    it "summarises query preparation and expansion events" do
+      expect(query_preparation_summaries).to eq(expected_query_preparation_summaries)
+    end
+
+    it "summarises model, intercept, retrieval leg, selection and failure events" do
+      expect(operational_summaries).to eq(expected_operational_summaries)
+    end
+
+    it "uses readable labels for generic event names" do
+      expect(summary("unknown_event", query: "horse")).to eq("Unknown event")
+    end
+
+    it "does not render awkward query expansion copy when a query value is missing" do
+      expect(summary("query_expanded", original_query: "trainers")).to eq("Query expanded - trainers")
+    end
+
+    it "humanises search completion result types" do
+      expect(summary("search_completed", results_type: "fuzzy_search", result_count: 0)).to eq("Search completed - fuzzy search")
+    end
+  end
+
+  describe "#search_diagnostic_event_details" do
+    it "renders relevant fields as readable key value rows and keeps raw fields available" do
+      html = details("search_completed", search_completed_fields)
+
+      expect(html).to include(*search_completed_detail_fragments)
+    end
+
+    it "renders answer detail rows with commodity code and confidence" do
+      html = details("answer_returned", answer_returned_fields)
+
+      expect(html).to include(*answer_detail_fragments)
+    end
+
+    it "uses the goods nomenclature code as frontend link text in result tables" do
+      page = Capybara.string(details("fuzzy_results_returned", fuzzy_results_fields))
+
+      expect(page).to have_css("a.govuk-link[href='#{TradeTariffAdmin.frontend_host}/commodities/6110301000']", exact_text: "6110301000")
+    end
+
+    it "links selected result details to the frontend goods nomenclature path" do
+      page = Capybara.string(details("result_selected", selected_heading_fields))
+
+      expect(page).to have_link("6110", href: "#{TradeTariffAdmin.frontend_host}/headings/6110")
+    end
+  end
+
+  describe "#search_diagnostic_event_name" do
+    it "humanises event names for display" do
+      expect(helper.search_diagnostic_event_name(event: "query_expansion_decided")).to eq("Query expansion decided")
+    end
+  end
+
+  describe "#search_diagnostic_search_type" do
+    it "humanises search type values for display" do
+      expect(search_type_labels).to eq("interactive" => "Internal", "classic" => "Classic")
+    end
+  end
+
+  describe "#search_diagnostic_events_with_context" do
+    it "applies the original search type to selected results when the event has no type" do
+      contextual_events = helper.search_diagnostic_events_with_context(classic_selection_events)
+
+      expect(contextual_events.pluck(:search_type)).to eq(%w[classic classic classic])
+    end
+  end
+
+  describe "#search_diagnostic_event_time" do
+    it "shows compact time for timestamped events" do
+      expect(helper.search_diagnostic_event_time(timestamp: "2026-06-05 09:58:58.123")).to eq("09:58:58.123")
+    end
+
+    it "falls back when the timestamp is absent" do
+      expect(helper.search_diagnostic_event_time({})).to eq("-")
+    end
+  end
+
+  describe "#search_diagnostic_time_range" do
+    it "formats the range using GOV.UK date style with times" do
+      diagnostic = SearchDiagnostic.new(start_time: "2026-06-05T09:55:00Z", end_time: "2026-06-05T10:00:00Z")
+
+      expect(helper.search_diagnostic_time_range(diagnostic)).to eq("5 June 2026 at 09:55 to 5 June 2026 at 10:00")
+    end
+  end
+
+  describe "#search_diagnostic_timeline_events" do
+    it "positions events across the request duration and flags significant events" do
+      expect(timeline_summary(timeline_events)).to eq(expected_timeline_summary)
+    end
+
+    it "spreads sub-second journeys by event order" do
+      expect(timeline_summary(sub_second_timeline_events)).to eq(expected_sub_second_timeline_summary)
+    end
+
+    it "spreads longer journeys by event order rather than elapsed time" do
+      expect(timeline_summary(uneven_timeline_events).pluck(1)).to eq([0, 25, 50, 75, 100])
+    end
+  end
+
+  describe "#search_diagnostic_significant_timeline_events" do
+    it "returns significant events when present" do
+      timeline_events = helper.search_diagnostic_timeline_events(self.timeline_events)
+
+      expect(helper.search_diagnostic_significant_timeline_events(timeline_events).pluck(:name)).to eq(["Answer returned", "Search failed"])
+    end
+
+    it "falls back to all events when no significant events were logged" do
+      events = helper.search_diagnostic_timeline_events([{ timestamp: "2026-06-05 09:59:00.000", event: "search_started" }])
+
+      expect(helper.search_diagnostic_significant_timeline_events(events).pluck(:name)).to eq(["Search started"])
+    end
+  end
+
+  def summary(event_name, fields)
+    helper.search_diagnostic_event_summary(event: event_name, fields: fields)
+  end
+
+  def details(event_name, fields)
+    helper.search_diagnostic_event_details(event: event_name, fields: fields)
+  end
+
+  def query_preparation_summaries
+    {
+      "search_started" => summary("search_started", query: "red shoes", search_type: "interactive"),
+      "query_expanded" => summary("query_expanded", original_query: "trainers", expanded_query: "athletic shoes", reason: "colloquial", duration_ms: 123.45),
+      "query_refined" => summary("query_refined", original_query: "shoes", refined_query: "shoes leather", answer_count: 1),
+      "query_expansion_decided" => summary("query_expansion_decided", query: "shoes", expand: true, reason: "low_results", result_count: 2, max_score: 4.5),
+    }
+  end
+
+  def expected_query_preparation_summaries
+    {
+      "search_started" => "Search started - red shoes",
+      "query_expanded" => "Query expanded - trainers to athletic shoes",
+      "query_refined" => "Query refined - added 1 answer",
+      "query_expansion_decided" => "Query expansion used - low results",
+    }
+  end
+
+  def operational_summaries
+    {
+      "api_call_completed" => summary("api_call_completed", model: "gpt-4.1-mini", response_type: "questions", attempt_number: 2, duration_ms: 450.1),
+      "description_intercept_checked" => summary("description_intercept_checked", matched: true, term: "gift", excluded: false, filtering: true),
+      "retrieval_leg_completed" => summary("retrieval_leg_completed", leg: "vector", status: "success", result_count: 12, duration_ms: 50.4),
+      "result_selected" => summary("result_selected", goods_nomenclature_item_id: "6403990000", goods_nomenclature_class: "Commodity"),
+      "search_failed" => summary("search_failed", search_type: "interactive", error_type: "Faraday::TimeoutError"),
+    }
+  end
+
+  def expected_operational_summaries
+    {
+      "api_call_completed" => "Model returned questions - attempt 2",
+      "description_intercept_checked" => "Description intercept matched - gift",
+      "retrieval_leg_completed" => "Vector retrieval succeeded - 12 results",
+      "result_selected" => "Result selected - commodity 6403990000",
+      "search_failed" => "Search failed - Faraday::TimeoutError",
+    }
+  end
+
+  def search_completed_fields
+    {
+      search_type: "interactive",
+      query: "red shoes",
+      results_type: "hybrid",
+      final_result_type: "answers",
+      total_attempts: 2,
+      total_questions: 1,
+      result_count: 3,
+      max_score: 12.3456,
+      total_duration_ms: 1500.25,
+      description_intercept_matched: true,
+      description_intercept_term: "gift",
+    }
+  end
+
+  def search_completed_detail_fragments
+    [
+      "Query",
+      "red shoes",
+      "Results type",
+      "hybrid",
+      "Final result",
+      "answers",
+      "Total attempts",
+      "2",
+      "Total questions",
+      "1",
+      "Result count",
+      "3",
+      "Max score",
+      "12.3456",
+      "Total duration",
+      "1,500.25 ms",
+      "Description intercept",
+      "Matched gift",
+      "View raw fields",
+    ]
+  end
+
+  def answer_returned_fields
+    {
+      answer_count: 2,
+      confidence_levels: { "strong" => 1, "possible" => 1 },
+      attempt_number: 1,
+      details: {
+        answers: [
+          { commodity_code: "6403990000", confidence: "strong" },
+          { commodity_code: "4202210000", confidence: "possible" },
+        ],
+      },
+    }
+  end
+
+  def answer_detail_fragments
+    ["Attempt", "1", "Confidence levels", "strong: 1, possible: 1", "6403990000", "strong", "4202210000", "possible", "View labels"]
+  end
+
+  def fuzzy_results_fields
+    {
+      result_count: 1,
+      details: {
+        goods_nomenclature_match: {
+          commodities: [
+            {
+              goods_nomenclature_item_id: "6110301000",
+              goods_nomenclature_class: "Commodity",
+              score: 8.09,
+            },
+          ],
+        },
+      },
+    }
+  end
+
+  def selected_heading_fields
+    {
+      goods_nomenclature_item_id: "6110",
+      goods_nomenclature_class: "Heading",
+    }
+  end
+
+  def search_type_labels
+    %w[interactive classic].index_with do |search_type|
+      helper.search_diagnostic_search_type(search_type: search_type)
+    end
+  end
+
+  def timeline_summary(events)
+    helper.search_diagnostic_timeline_events(events).map do |event|
+      [
+        event[:name],
+        event[:position],
+        event[:significant],
+        event[:search_type],
+      ]
+    end
+  end
+
+  def timeline_events
+    [
+      { timestamp: "2026-06-05 09:59:02.000", event: "answer_returned", search_type: "interactive", fields: { answer_count: 1 } },
+      { timestamp: "2026-06-05 09:59:00.000", event: "search_started", search_type: "interactive", fields: { query: "shoes" } },
+      { timestamp: "2026-06-05 09:59:04.000", event: "search_failed", search_type: "interactive", fields: { error_type: "Faraday::TimeoutError" } },
+    ]
+  end
+
+  def expected_timeline_summary
+    [
+      ["Search started", 0, false, "Internal"],
+      ["Answer returned", 50, true, "Internal"],
+      ["Search failed", 100, true, "Internal"],
+    ]
+  end
+
+  def sub_second_timeline_events
+    [
+      { timestamp: "2026-06-05 09:59:02.537", event: "search_started", search_type: "classic", fields: { query: "shoes" } },
+      { timestamp: "2026-06-05 09:59:02.598", event: "fuzzy_results_returned", search_type: "classic", fields: { result_count: 0 } },
+      { timestamp: "2026-06-05 09:59:02.598", event: "search_completed", search_type: "classic", fields: { result_count: 0, results_type: "fuzzy_search" } },
+    ]
+  end
+
+  def expected_sub_second_timeline_summary
+    [
+      ["Search started", 0, false, "Classic"],
+      ["Fuzzy results returned", 50, true, "Classic"],
+      ["Search completed", 100, true, "Classic"],
+    ]
+  end
+
+  def uneven_timeline_events
+    [
+      { timestamp: "2026-06-05 09:33:44.114", event: "search_started", search_type: "classic", fields: { query: "jumper" } },
+      { timestamp: "2026-06-05 09:33:44.114", event: "fuzzy_results_returned", search_type: "classic", fields: { result_count: 3 } },
+      { timestamp: "2026-06-05 09:33:44.114", event: "search_completed", search_type: "classic", fields: { result_count: 3, results_type: "fuzzy_search" } },
+      { timestamp: "2026-06-05 09:33:46.500", event: "result_selected", search_type: "classic", fields: { goods_nomenclature_item_id: "6110", goods_nomenclature_class: "Heading" } },
+      { timestamp: "2026-06-05 09:33:52.000", event: "result_selected", search_type: "classic", fields: { goods_nomenclature_item_id: "6110309900", goods_nomenclature_class: "Commodity" } },
+    ]
+  end
+
+  def classic_selection_events
+    [
+      { timestamp: "2026-06-05 09:59:00.000", event: "search_started", search_type: "classic", fields: { query: "jumper" } },
+      { timestamp: "2026-06-05 09:59:02.000", event: "fuzzy_results_returned", search_type: "classic", fields: { result_count: 3 } },
+      { timestamp: "2026-06-05 09:59:04.000", event: "result_selected", search_type: nil, fields: { goods_nomenclature_item_id: "6110", goods_nomenclature_class: "Heading" } },
+    ]
+  end
+end

--- a/spec/requests/search_diagnostics_controller_spec.rb
+++ b/spec/requests/search_diagnostics_controller_spec.rb
@@ -40,6 +40,33 @@ RSpec.describe SearchDiagnosticsController do
             end_time: "2026-06-05T10:00:00Z",
             events: [
               {
+                timestamp: "2026-06-05 09:58:58.000",
+                event: "search_started",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  search_type: "interactive",
+                  query: "red leather shoes",
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:58:59.000",
+                event: "description_intercept_checked",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  query: "red leather shoes",
+                  matched: true,
+                  term: "shoes",
+                  excluded: false,
+                  filtering: true,
+                  filter_prefix_count: 1,
+                  guidance_level: "info",
+                  guidance_location: "results",
+                  escalate_to_webchat: false,
+                },
+              },
+              {
                 timestamp: "2026-06-05 09:59:00.000",
                 event: "search_completed",
                 search_type: "classic",
@@ -109,6 +136,42 @@ RSpec.describe SearchDiagnosticsController do
                 },
               },
               {
+                timestamp: "2026-06-05 09:59:03.500",
+                event: "query_expansion_decided",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  query: "red leather shoes",
+                  expand: true,
+                  reason: "low_results",
+                  result_count: 2,
+                  max_score: 4.5,
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:03.750",
+                event: "query_expanded",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  original_query: "red leather shoes",
+                  expanded_query: "red leather footwear",
+                  reason: "colloquial",
+                  duration_ms: 120.25,
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:03.900",
+                event: "query_refined",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  original_query: "red leather footwear",
+                  refined_query: "red leather footwear womens",
+                  answer_count: 1,
+                },
+              },
+              {
                 timestamp: "2026-06-05 09:59:04.000",
                 event: "question_returned",
                 search_type: "interactive",
@@ -120,6 +183,30 @@ RSpec.describe SearchDiagnosticsController do
                       { question: "What material are the shoes made from?" },
                     ],
                   },
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:04.500",
+                event: "api_call_completed",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  model: "gpt-4.1-mini",
+                  response_type: "questions",
+                  attempt_number: 1,
+                  duration_ms: 450.1,
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:04.750",
+                event: "retrieval_leg_completed",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  leg: "vector",
+                  status: "success",
+                  result_count: 1,
+                  duration_ms: 50.4,
                 },
               },
               {
@@ -147,6 +234,44 @@ RSpec.describe SearchDiagnosticsController do
                   },
                 },
               },
+              {
+                timestamp: "2026-06-05 09:59:06.000",
+                event: "answer_returned",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  answer_count: 1,
+                  confidence_levels: { strong: 1 },
+                  attempt_number: 2,
+                  details: {
+                    answers: [
+                      { commodity_code: "6403990000", confidence: "strong" },
+                    ],
+                  },
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:07.000",
+                event: "result_selected",
+                search_type: nil,
+                fields: {
+                  request_id: "request-123",
+                  goods_nomenclature_item_id: "6403990000",
+                  goods_nomenclature_class: "Commodity",
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:08.000",
+                event: "search_failed",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  search_type: "interactive",
+                  error_type: "Faraday::TimeoutError",
+                  error_message: "connection timed out",
+                  error_message_truncated: false,
+                },
+              },
             ],
           },
         )
@@ -159,7 +284,7 @@ RSpec.describe SearchDiagnosticsController do
     it "renders the diagnostics journey shell" do
       rendered_page
 
-      expect(response.body).to include("request-123", "platform-logs-test", "Search journey events", "search_completed", "classic", "horse")
+      expect(response.body).to include("request-123", "platform-logs-test", "Search journey events", "Search completed", "Classic", "horse")
     end
 
     it "renders classic exact and fuzzy event summaries" do
@@ -172,6 +297,35 @@ RSpec.describe SearchDiagnosticsController do
       rendered_page
 
       expect(response.body).to include("Interactive configuration used", "Retrieval method", "hybrid", "Rrf k", "60", "Questions returned - 1 question", "What material are the shoes made from?", "Hybrid - After rrf - 1 result", "12.7", "View self-text", "View labels")
+    end
+
+    it "renders the GOV.UK formatted log search window and event timeline chart" do
+      rendered_page
+
+      expect(response.body).to include("Log search window", "2 June 2026 at 10:00 to 5 June 2026 at 10:00", "Search event timeline", "Exact match selected", "Search failed")
+    end
+
+    it "links timeline markers to their matching event rows" do
+      rendered_page
+
+      page = Capybara.string(response.body)
+
+      expect(page).to have_css(".search-diagnostics-timeline__marker-link[href='#search-event-0']", text: "09:58:58.000 Search started", normalize_ws: true)
+        .and have_css("tr#search-event-0", text: "Search started")
+    end
+
+    it "renders query preparation, model, selection and failure events with readable copy" do
+      rendered_page
+
+      expect(response.body).to include(*readable_event_summaries)
+    end
+
+    it "shows the original search type for selected-result events with no logged type" do
+      rendered_page
+
+      selected_result_row = Capybara.string(response.body).find("tr", text: "Result selected")
+
+      expect(selected_result_row).to have_css("td[data-label='Type']", text: "Internal")
     end
 
     context "when no events are found" do
@@ -218,5 +372,20 @@ RSpec.describe SearchDiagnosticsController do
 
       it { is_expected.to have_http_status :forbidden }
     end
+  end
+
+  def readable_event_summaries
+    [
+      "Search started - red leather shoes",
+      "Description intercept matched - shoes",
+      "Query expansion used - low results",
+      "Query expanded - red leather shoes to red leather footwear",
+      "Query refined - added 1 answer",
+      "Model returned questions - attempt 1",
+      "Vector retrieval succeeded - 1 result",
+      "Answers returned - 1 answer",
+      "Result selected - commodity 6403990000",
+      "Search failed - Faraday::TimeoutError",
+    ]
   end
 end


### PR DESCRIPTION
### Jira link

[AI-589](https://transformuk.atlassian.net/browse/AI-589)

```mermaid
flowchart TD
    EVENTS[Search journey events]
    TIMELINE[Event timeline]
    TABLE[Event table]
    MARKER[Interactive markers]
    ROW[Matching event row]
    DETAILS[Diagnostics details]

    EVENTS --> TIMELINE
    EVENTS --> TABLE
    TIMELINE --> MARKER
    MARKER --> ROW
    TABLE --> DETAILS

    classDef box stroke:#6366f1,stroke-width:2px
    class EVENTS,TIMELINE,TABLE,MARKER,ROW,DETAILS box
```

### What?

I have added/removed/altered:

- [x] Added a GOV.UK-styled search event timeline.
- [x] Spaced timeline markers by event order and highlighted significant events.
- [x] Linked timeline markers to their matching event rows.
- [x] Added hover and focus animation for timeline markers.
- [x] Added contextual event summaries and openable diagnostics details.
- [x] Rendered selected-result links with code-only link text.

### Why?

I am doing this because:

- Operators need to understand the order and significance of search events quickly.
- Timeline markers make it easier to jump from the visual summary to the relevant event details.
- Readable event summaries reduce the need to inspect raw log fields for common diagnostics work.

### Risk

**Risk level:** 🟢 Low

**Reason for rating:** This is read-only presentation logic on a new admin diagnostics screen. Existing public search behaviour, admin mutations, and persisted tariff data are unchanged.
