### PR TITLE
AI-589: Add search diagnostics overview

### DIFF
--- a/app/helpers/search_diagnostics_helper.rb
+++ b/app/helpers/search_diagnostics_helper.rb
@@ -112,6 +112,26 @@ module SearchDiagnosticsHelper
     end
   end
 
+  def search_diagnostic_overview(events)
+    events = Array(events).map { |event| normalise_search_diagnostic_hash(event) }
+
+    {
+      query: overview_query(events),
+      outcome_tags: overview_outcome_tags(events),
+      route_tags: overview_route_tags(events),
+      results: overview_results(events),
+      selected_results: overview_selected_results(events),
+    }
+  end
+
+  def search_diagnostic_overview_tag(tag)
+    content_tag(:strong, tag[:label], class: "govuk-tag govuk-tag--#{tag[:colour]} govuk-!-margin-right-1")
+  end
+
+  def search_diagnostic_overview_selected_result_link(result)
+    link_to(result[:id], result[:href], class: "govuk-link", target: "_blank", rel: "noopener noreferrer")
+  end
+
   def search_diagnostic_event_time(event)
     timestamp = event[:timestamp].to_s
     return "-" if timestamp.blank?
@@ -237,7 +257,7 @@ private
       content_tag(:div, class: "govuk-!-margin-bottom-3") do
         safe_join([
           content_tag(:h4, match_type.to_s.humanize, class: "govuk-heading-s govuk-!-margin-bottom-2"),
-          safe_join(groups.map { |level, results| result_group(level, results) }),
+          safe_join(groups.map { |level, results| result_group(level, results, include_admin_links: false) }),
         ])
       end
     end
@@ -277,39 +297,51 @@ private
     ])
   end
 
-  def result_group(level, results)
+  def result_group(level, results, include_admin_links: true)
     safe_join([
       content_tag(:h5, level.to_s.humanize, class: "govuk-heading-s govuk-!-margin-bottom-1"),
-      result_table(Array(results)),
+      result_table(Array(results), include_admin_links:),
     ])
   end
 
-  def result_table(results)
+  def result_table(results, include_admin_links: true)
     return content_tag(:p, "No results were logged.", class: "govuk-body-s") if results.blank?
 
     content_tag(:table, class: "govuk-table govuk-!-margin-bottom-4 app-diagnostics-table") do
       safe_join([
         content_tag(:thead, class: "govuk-table__head") do
           content_tag(:tr, class: "govuk-table__row") do
-            safe_join(%w[Code Type Score Self-text Labels].map { |heading| content_tag(:th, heading, class: "govuk-table__header", scope: "col") })
+            safe_join(result_table_headings(include_admin_links).map { |heading| content_tag(:th, heading, class: "govuk-table__header", scope: "col") })
           end
         end,
         content_tag(:tbody, class: "govuk-table__body") do
-          safe_join(results.map { |result| result_row(normalise_search_diagnostic_hash(result)) })
+          safe_join(results.map { |result| result_row(normalise_search_diagnostic_hash(result), include_admin_links:) })
         end,
       ])
     end
   end
 
-  def result_row(result)
+  def result_table_headings(include_admin_links)
+    headings = %w[Code Type Score]
+    return headings unless include_admin_links
+
+    headings + %w[Self-text Labels]
+  end
+
+  def result_row(result, include_admin_links: true)
+    cells = [
+      content_tag(:td, goods_nomenclature_link(result), class: "govuk-table__cell"),
+      content_tag(:td, result[:goods_nomenclature_class].presence || "-", class: "govuk-table__cell"),
+      content_tag(:td, result[:score].presence || result[:confidence].presence || "-", class: "govuk-table__cell"),
+    ]
+
+    if include_admin_links
+      cells << content_tag(:td, self_text_link(result), class: "govuk-table__cell")
+      cells << content_tag(:td, label_link(result), class: "govuk-table__cell")
+    end
+
     content_tag(:tr, class: "govuk-table__row") do
-      safe_join([
-        content_tag(:td, goods_nomenclature_link(result), class: "govuk-table__cell"),
-        content_tag(:td, result[:goods_nomenclature_class].presence || "-", class: "govuk-table__cell"),
-        content_tag(:td, result[:score].presence || result[:confidence].presence || "-", class: "govuk-table__cell"),
-        content_tag(:td, self_text_link(result), class: "govuk-table__cell"),
-        content_tag(:td, label_link(result), class: "govuk-table__cell"),
-      ])
+      safe_join(cells)
     end
   end
 
@@ -386,15 +418,124 @@ private
     normalise_search_diagnostic_hash(fields[:details] || {})
   end
 
+  def overview_query(events)
+    events.filter_map { |event| search_diagnostic_fields(event)[:query].presence }.first
+  end
+
+  def overview_outcome_tags(events)
+    tags = []
+    result_count = overview_result_count(events)
+
+    tags << { label: "Failed", colour: "red" } if events.any? { |event| event[:event].to_s == "search_failed" }
+    tags << { label: "Zero results", colour: "yellow" } if result_count&.zero?
+    tags << { label: "Result selected", colour: "green" } if events.any? { |event| event[:event].to_s == "result_selected" }
+    tags << { label: "Results returned", colour: "green" } if result_count.to_i.positive?
+
+    tags
+  end
+
+  def overview_route_tags(events)
+    type_tags = events.pluck(:search_type).compact_blank.uniq.filter_map do |search_type|
+      case search_type
+      when "classic" then { label: "Classic", colour: "blue" }
+      when "interactive" then { label: "Internal", colour: "blue" }
+      end
+    end
+
+    behaviour_tags = [
+      ({ label: "Exact match", colour: "turquoise" } if events.any? { |event| event[:event].to_s == "exact_match_selected" }),
+      ({ label: "Fuzzy", colour: "purple" } if fuzzy_search?(events)),
+      ({ label: "Description intercept", colour: "orange" } if description_intercept_matched?(events)),
+      ({ label: "Query expanded", colour: "grey" } if events.any? { |event| event[:event].to_s == "query_expanded" }),
+      ({ label: "Questions returned", colour: "grey" } if events.any? { |event| event[:event].to_s == "question_returned" }),
+      ({ label: "Answers returned", colour: "grey" } if events.any? { |event| event[:event].to_s == "answer_returned" }),
+    ].compact
+
+    type_tags + behaviour_tags
+  end
+
+  def overview_results(events)
+    count = overview_result_count(events)
+    return if count.blank? && count != 0
+
+    pluralize(count, "#{overview_result_type(events)} result")
+  end
+
+  def overview_selected_results(events)
+    events.select { |event| event[:event].to_s == "result_selected" }.filter_map do |event|
+      fields = search_diagnostic_fields(event)
+      id = target_id(fields)
+      href = goods_nomenclature_href(fields)
+      next if id.blank? || href.blank?
+
+      { id:, href: }
+    end
+  end
+
   def endpoint_for_class(goods_nomenclature_class)
     goods_nomenclature_class.to_s.underscore.pluralize.presence
   end
 
+  def goods_nomenclature_href(result)
+    endpoint = result[:target_endpoint].presence || endpoint_for_class(result[:goods_nomenclature_class])
+    id = target_id(result)
+    return if endpoint.blank? || id.blank?
+
+    "#{TradeTariffAdmin.frontend_host}/#{endpoint}/#{id}"
+  end
+
+  def target_id(result)
+    result[:target_id].presence || result[:goods_nomenclature_item_id].presence || result[:commodity_code]
+  end
+
   def target_label(result)
     endpoint = result[:target_endpoint].presence || endpoint_for_class(result[:goods_nomenclature_class])
-    id = result[:target_id].presence || result[:goods_nomenclature_item_id].presence || result[:commodity_code]
+    id = target_id(result)
 
     [endpoint, id].compact_blank.join("/")
+  end
+
+  def overview_result_count(events)
+    completed_count = overview_result_count_for(events, "search_completed")
+    return completed_count.to_i if logged_value?(completed_count)
+
+    fuzzy_count = overview_result_count_for(events, "fuzzy_results_returned")
+    fuzzy_count.to_i if logged_value?(fuzzy_count)
+  end
+
+  def overview_result_count_for(events, event_name)
+    event = events.reverse_each.find do |item|
+      item[:event].to_s == event_name && logged_value?(search_diagnostic_fields(item)[:result_count])
+    end
+
+    search_diagnostic_fields(event)[:result_count] if event
+  end
+
+  def logged_value?(value)
+    value.present? || (value.respond_to?(:zero?) && value.zero?)
+  end
+
+  def overview_result_type(events)
+    results_type = events.reverse_each.filter_map { |event| search_diagnostic_fields(event)[:results_type].presence }.first
+
+    case results_type.to_s
+    when "fuzzy_search" then "fuzzy"
+    when "exact_search" then "exact"
+    else
+      fuzzy_search?(events) ? "fuzzy" : "search"
+    end
+  end
+
+  def fuzzy_search?(events)
+    events.any? { |event| event[:event].to_s == "fuzzy_results_returned" } ||
+      events.any? { |event| search_diagnostic_fields(event)[:results_type].to_s == "fuzzy_search" }
+  end
+
+  def description_intercept_matched?(events)
+    events.any? do |event|
+      event[:event].to_s == "description_intercept_checked" &&
+        truthy?(search_diagnostic_fields(event)[:matched])
+    end
   end
 
   def generic_event_details(event_name, fields)

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -4,6 +4,9 @@
 
     <h1 class="govuk-heading-l">Search diagnostics</h1>
 
+    <% contextual_events = @search_diagnostic.events? ? search_diagnostic_events_with_context(@search_diagnostic.events) : [] %>
+    <% overview = search_diagnostic_overview(contextual_events) if contextual_events.any? %>
+
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">
         <dt class="govuk-summary-list__key">Request ID</dt>
@@ -19,10 +22,39 @@
           <%= search_diagnostic_time_range(@search_diagnostic) %>
         </dd>
       </div>
+      <% if overview&.dig(:query).present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Query</dt>
+          <dd class="govuk-summary-list__value"><%= overview[:query] %></dd>
+        </div>
+      <% end %>
+      <% if overview&.dig(:outcome_tags).present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Outcome</dt>
+          <dd class="govuk-summary-list__value"><%= safe_join(overview[:outcome_tags].map { |tag| search_diagnostic_overview_tag(tag) }, " ") %></dd>
+        </div>
+      <% end %>
+      <% if overview&.dig(:route_tags).present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Route</dt>
+          <dd class="govuk-summary-list__value"><%= safe_join(overview[:route_tags].map { |tag| search_diagnostic_overview_tag(tag) }, " ") %></dd>
+        </div>
+      <% end %>
+      <% if overview&.dig(:results).present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Results</dt>
+          <dd class="govuk-summary-list__value"><%= overview[:results] %></dd>
+        </div>
+      <% end %>
+      <% if overview&.dig(:selected_results).present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Selected</dt>
+          <dd class="govuk-summary-list__value"><%= safe_join(overview[:selected_results].map { |result| search_diagnostic_overview_selected_result_link(result) }, ", ") %></dd>
+        </div>
+      <% end %>
     </dl>
 
     <% if @search_diagnostic.events? %>
-      <% contextual_events = search_diagnostic_events_with_context(@search_diagnostic.events) %>
       <% timeline_events = search_diagnostic_timeline_events(contextual_events) %>
 
       <% if timeline_events.any? %>

--- a/spec/helpers/search_diagnostics_helper_spec.rb
+++ b/spec/helpers/search_diagnostics_helper_spec.rb
@@ -40,6 +40,18 @@ RSpec.describe SearchDiagnosticsHelper do
       expect(page).to have_css("a.govuk-link[href='#{TradeTariffAdmin.frontend_host}/commodities/6110301000']", exact_text: "6110301000")
     end
 
+    it "omits self-text and label columns from classic fuzzy result tables" do
+      page = Capybara.string(details("fuzzy_results_returned", fuzzy_results_fields))
+
+      expect(table_headings(page)).to eq(%w[Code Type Score])
+    end
+
+    it "keeps self-text and label columns in internal retrieval result tables" do
+      page = Capybara.string(details("retrieval_results_returned", retrieval_results_fields))
+
+      expect(table_headings(page)).to eq(%w[Code Type Score Self-text Labels])
+    end
+
     it "links selected result details to the frontend goods nomenclature path" do
       page = Capybara.string(details("result_selected", selected_heading_fields))
 
@@ -64,6 +76,16 @@ RSpec.describe SearchDiagnosticsHelper do
       contextual_events = helper.search_diagnostic_events_with_context(classic_selection_events)
 
       expect(contextual_events.pluck(:search_type)).to eq(%w[classic classic classic])
+    end
+  end
+
+  describe "#search_diagnostic_overview" do
+    it "summarises a selected fuzzy classic search for operator triage" do
+      expect(overview_summary(classic_overview_events)).to eq(classic_overview_summary)
+    end
+
+    it "summarises a zero-result search as needing attention" do
+      expect(overview_summary(zero_result_events)).to eq(zero_result_overview_summary)
     end
   end
 
@@ -119,6 +141,10 @@ RSpec.describe SearchDiagnosticsHelper do
 
   def details(event_name, fields)
     helper.search_diagnostic_event_details(event: event_name, fields: fields)
+  end
+
+  def table_headings(page)
+    page.all("table.app-diagnostics-table:first-of-type th").map(&:text)
   end
 
   def query_preparation_summaries
@@ -234,6 +260,24 @@ RSpec.describe SearchDiagnosticsHelper do
     }
   end
 
+  def retrieval_results_fields
+    {
+      retrieval_method: "hybrid",
+      stage: "after_rrf",
+      result_count: 1,
+      details: {
+        results: [
+          {
+            goods_nomenclature_item_id: "6110301000",
+            goods_nomenclature_class: "Commodity",
+            score: 8.09,
+            self_text_id: 123,
+          },
+        ],
+      },
+    }
+  end
+
   def selected_heading_fields
     {
       goods_nomenclature_item_id: "6110",
@@ -256,6 +300,41 @@ RSpec.describe SearchDiagnosticsHelper do
         event[:search_type],
       ]
     end
+  end
+
+  def overview_summary(events)
+    overview = helper.search_diagnostic_overview(events)
+
+    {
+      query: overview[:query],
+      outcome_tags: overview[:outcome_tags].pluck(:label, :colour),
+      route_tags: overview[:route_tags].pluck(:label, :colour),
+      results: overview[:results],
+      selected_results: overview[:selected_results],
+    }
+  end
+
+  def classic_overview_summary
+    {
+      query: "jumper",
+      outcome_tags: [["Result selected", "green"], ["Results returned", "green"]],
+      route_tags: [%w[Classic blue], %w[Fuzzy purple]],
+      results: "3 fuzzy results",
+      selected_results: [
+        { id: "6110", href: "#{TradeTariffAdmin.frontend_host}/headings/6110" },
+        { id: "6110309900", href: "#{TradeTariffAdmin.frontend_host}/commodities/6110309900" },
+      ],
+    }
+  end
+
+  def zero_result_overview_summary
+    {
+      query: "women's breif",
+      outcome_tags: [["Zero results", "yellow"]],
+      route_tags: [%w[Classic blue], %w[Fuzzy purple]],
+      results: "0 fuzzy results",
+      selected_results: [],
+    }
   end
 
   def timeline_events
@@ -305,6 +384,24 @@ RSpec.describe SearchDiagnosticsHelper do
       { timestamp: "2026-06-05 09:59:00.000", event: "search_started", search_type: "classic", fields: { query: "jumper" } },
       { timestamp: "2026-06-05 09:59:02.000", event: "fuzzy_results_returned", search_type: "classic", fields: { result_count: 3 } },
       { timestamp: "2026-06-05 09:59:04.000", event: "result_selected", search_type: nil, fields: { goods_nomenclature_item_id: "6110", goods_nomenclature_class: "Heading" } },
+    ]
+  end
+
+  def classic_overview_events
+    [
+      { timestamp: "2026-06-05 09:33:44.079", event: "search_started", search_type: "classic", fields: { query: "jumper" } },
+      { timestamp: "2026-06-05 09:33:44.114", event: "fuzzy_results_returned", search_type: "classic", fields: { result_count: 3 } },
+      { timestamp: "2026-06-05 09:33:44.114", event: "search_completed", search_type: "classic", fields: { query: "jumper", result_count: 3, results_type: "fuzzy_search" } },
+      { timestamp: "2026-06-05 09:33:52.989", event: "result_selected", search_type: "classic", fields: { goods_nomenclature_item_id: "6110", goods_nomenclature_class: "Heading" } },
+      { timestamp: "2026-06-05 09:34:03.893", event: "result_selected", search_type: "classic", fields: { goods_nomenclature_item_id: "6110309900", goods_nomenclature_class: "Commodity" } },
+    ]
+  end
+
+  def zero_result_events
+    [
+      { timestamp: "2026-06-05 09:33:44.079", event: "search_started", search_type: "classic", fields: { query: "women's breif" } },
+      { timestamp: "2026-06-05 09:33:44.114", event: "fuzzy_results_returned", search_type: "classic", fields: { result_count: 0 } },
+      { timestamp: "2026-06-05 09:33:44.114", event: "search_completed", search_type: "classic", fields: { query: "women's breif", result_count: 0, results_type: "fuzzy_search" } },
     ]
   end
 end

--- a/spec/requests/search_diagnostics_controller_spec.rb
+++ b/spec/requests/search_diagnostics_controller_spec.rb
@@ -287,6 +287,12 @@ RSpec.describe SearchDiagnosticsController do
       expect(response.body).to include("request-123", "platform-logs-test", "Search journey events", "Search completed", "Classic", "horse")
     end
 
+    it "renders an operator overview in the summary list" do
+      rendered_page
+
+      expect(response.body).to include(*operator_overview_fragments)
+    end
+
     it "renders classic exact and fuzzy event summaries" do
       rendered_page
 
@@ -386,6 +392,23 @@ RSpec.describe SearchDiagnosticsController do
       "Answers returned - 1 answer",
       "Result selected - commodity 6403990000",
       "Search failed - Faraday::TimeoutError",
+    ]
+  end
+
+  def operator_overview_fragments
+    [
+      "Query",
+      "red leather shoes",
+      "govuk-tag govuk-tag--green",
+      "Result selected",
+      "Results returned",
+      "govuk-tag govuk-tag--blue",
+      "Internal",
+      "Classic",
+      "govuk-tag govuk-tag--orange",
+      "Description intercept",
+      "1 fuzzy result",
+      "#{TradeTariffAdmin.frontend_host}/commodities/6403990000",
     ]
   end
 end


### PR DESCRIPTION
### Jira link

[AI-589](https://transformuk.atlassian.net/browse/AI-589)

```mermaid
flowchart TD
    EVENTS[Search journey events]
    OVERVIEW[Diagnostic overview]
    QUERY[Query]
    OUTCOME[Outcome tags]
    ROUTE[Route tags]
    SELECTION[Selected result links]
    DETAILS[Detailed event table]

    EVENTS --> OVERVIEW
    OVERVIEW --> QUERY
    OVERVIEW --> OUTCOME
    OVERVIEW --> ROUTE
    OVERVIEW --> SELECTION
    EVENTS --> DETAILS

    classDef box stroke:#6366f1,stroke-width:2px
    class EVENTS,OVERVIEW,QUERY,OUTCOME,ROUTE,SELECTION,DETAILS box
```

### What?

I have added/removed/altered:

- [x] Added an operator overview to the search diagnostics summary list.
- [x] Displayed query, outcome tags, route tags, result count, and selected result links when available.
- [x] Classified key diagnostics signals including zero-result, failed, result-selected, fuzzy, classic, internal, and description-intercept searches.
- [x] Simplified classic result tables to code, type, and score.
- [x] Kept self-text and label links for internal retrieval result diagnostics.

### Why?

I am doing this because:

- Operators need a quick read on what happened before scanning the full event table.
- Outcome and route tags surface the most diagnostic signals first.
- Compact classic result tables keep the common case easier to scan while preserving deeper diagnostics where they are useful.

### Risk

**Risk level:** 🟢 Low

**Reason for rating:** This is a read-only presentation change on a new admin diagnostics screen. It does not alter search execution, backend logging, public pages, or stored data.
