### PR TITLE
BAU: Add search diagnostics iteration summary

### DIFF
--- a/app/helpers/search_diagnostics_helper.rb
+++ b/app/helpers/search_diagnostics_helper.rb
@@ -2,12 +2,12 @@ module SearchDiagnosticsHelper
   EVENT_DETAIL_KEYS = {
     "search_started" => %i[query search_type],
     "query_expanded" => %i[original_query expanded_query reason duration_ms],
-    "query_refined" => %i[original_query refined_query answer_count],
+    "query_refined" => %i[base_query original_query refined_query effective_query added_answers answer_count iteration],
     "query_expansion_decided" => %i[query expand reason result_count max_score],
-    "api_call_completed" => %i[model response_type attempt_number duration_ms error_message error_message_truncated],
+    "api_call_completed" => %i[model response_type attempt_number iteration effective_query duration_ms error_message error_message_truncated],
     "description_intercept_checked" => %i[matched term excluded filtering filter_prefix_count guidance_level guidance_location escalate_to_webchat],
-    "question_returned" => %i[question_count attempt_number],
-    "answer_returned" => %i[answer_count confidence_levels attempt_number],
+    "question_returned" => %i[question_count attempt_number iteration effective_query],
+    "answer_returned" => %i[answer_count confidence_levels attempt_number iteration effective_query],
     "search_completed" => %i[query search_type results_type final_result_type total_attempts total_questions result_count max_score total_duration_ms description_intercept_matched description_intercept_term description_intercept_excluded description_intercept_filtering description_intercept_filter_prefix_count description_intercept_guidance_level description_intercept_guidance_location description_intercept_escalate_to_webchat error_message error_message_truncated],
     "retrieval_leg_completed" => %i[leg status result_count duration_ms error_message error_message_truncated],
     "result_selected" => %i[goods_nomenclature_item_id goods_nomenclature_class],
@@ -43,7 +43,7 @@ module SearchDiagnosticsHelper
     when "query_expanded"
       query_change_summary("Query expanded", fields[:original_query], fields[:expanded_query])
     when "query_refined"
-      "Query refined - added #{pluralize(fields[:answer_count].to_i, 'answer')}"
+      ["Query refined", iteration_label(fields), added_answers_label(fields) || "added #{pluralize(fields[:answer_count].to_i, 'answer')}"].compact_blank.join(" - ")
     when "query_expansion_decided"
       decision = truthy?(fields[:expand]) ? "used" : "skipped"
       ["Query expansion #{decision}", readable_value(fields[:reason])].compact_blank.join(" - ")
@@ -63,6 +63,8 @@ module SearchDiagnosticsHelper
         fields[:stage].to_s.humanize.presence,
         fields[:leg].to_s.humanize.presence,
         pluralize(fields[:result_count].to_i, "result"),
+        iteration_label(fields),
+        effective_query_label(fields),
       ].compact_blank.join(" - ")
     when "question_returned"
       "Questions returned - #{pluralize(fields[:question_count].to_i, 'question')}"
@@ -166,6 +168,49 @@ module SearchDiagnosticsHelper
     end
 
     timeline_events_by_order(sorted_events)
+  end
+
+  def search_diagnostic_iteration_summaries(events)
+    summaries = {}
+
+    Array(events).each do |event|
+      fields = search_diagnostic_fields(event)
+      iteration = fields[:iteration].presence
+      next if iteration.blank?
+
+      summary = summaries[iteration.to_i] ||= {
+        iteration: iteration.to_i,
+        effective_query: nil,
+        added_answers: [],
+        retrieval: nil,
+        model: nil,
+      }
+      summary[:effective_query] ||= fields[:effective_query].presence
+
+      case event[:event].to_s
+      when "query_refined"
+        summary[:effective_query] = fields[:effective_query].presence || summary[:effective_query]
+        summary[:added_answers] = Array(fields[:added_answers]).presence || summary[:added_answers]
+      when "retrieval_results_returned"
+        method_and_stage = [
+          fields[:retrieval_method].to_s.humanize.presence,
+          fields[:stage].to_s.humanize.downcase.presence,
+        ].compact_blank.join(" ")
+        summary[:retrieval] = [
+          method_and_stage.presence,
+          fields[:leg].to_s.humanize.downcase.presence,
+          pluralize(fields[:result_count].to_i, "result"),
+        ].compact_blank.join(" - ")
+      when "question_returned"
+        summary[:model] = "Questions returned - #{pluralize(fields[:question_count].to_i, 'question')}"
+      when "answer_returned"
+        summary[:model] = "Answers returned - #{pluralize(fields[:answer_count].to_i, 'answer')}"
+      when "api_call_completed"
+        summary[:model] ||= ["Model returned #{readable_value(fields[:response_type]) || 'response'}", attempt_label(fields)].compact_blank.join(" - ")
+      end
+    end
+
+    summaries.values.sort_by { |summary| summary[:iteration] }
   end
 
   def search_diagnostic_event_dom_id(index)
@@ -275,6 +320,7 @@ private
         "Stage" => fields[:stage],
         "Leg" => fields[:leg],
         "Iteration" => fields[:iteration],
+        "Effective query" => fields[:effective_query],
         "Result count" => fields[:result_count],
       ),
       result_table(results),
@@ -568,6 +614,25 @@ private
     return if fields[:attempt_number].blank?
 
     "attempt #{fields[:attempt_number]}"
+  end
+
+  def iteration_label(fields)
+    return if fields[:iteration].blank?
+
+    "iteration #{fields[:iteration]}"
+  end
+
+  def effective_query_label(fields)
+    return if fields[:effective_query].blank?
+
+    "query: #{fields[:effective_query]}"
+  end
+
+  def added_answers_label(fields)
+    answers = Array(fields[:added_answers]).compact_blank
+    return if answers.blank?
+
+    "added #{answers.join(', ')}"
   end
 
   def query_change_summary(label, original_query, changed_query)

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -94,6 +94,35 @@
         </section>
       <% end %>
 
+      <% iteration_summaries = search_diagnostic_iteration_summaries(contextual_events) %>
+      <% if iteration_summaries.any? %>
+        <section aria-labelledby="search-diagnostics-iterations-title">
+          <h2 class="govuk-heading-m" id="search-diagnostics-iterations-title">Internal search iterations</h2>
+          <table class="govuk-table search-diagnostics-iterations">
+            <thead class="govuk-table__head">
+              <tr class="govuk-table__row">
+                <th scope="col" class="govuk-table__header">Iteration</th>
+                <th scope="col" class="govuk-table__header">Effective query</th>
+                <th scope="col" class="govuk-table__header">Added answers</th>
+                <th scope="col" class="govuk-table__header">Retrieval</th>
+                <th scope="col" class="govuk-table__header">Model</th>
+              </tr>
+            </thead>
+            <tbody class="govuk-table__body">
+              <% iteration_summaries.each do |summary| %>
+                <tr class="govuk-table__row">
+                  <td class="govuk-table__cell">Iteration <%= summary[:iteration] %></td>
+                  <td class="govuk-table__cell"><%= summary[:effective_query].presence || "-" %></td>
+                  <td class="govuk-table__cell"><%= Array(summary[:added_answers]).presence&.join(", ") || "-" %></td>
+                  <td class="govuk-table__cell"><%= summary[:retrieval].presence || "-" %></td>
+                  <td class="govuk-table__cell"><%= summary[:model].presence || "-" %></td>
+                </tr>
+              <% end %>
+            </tbody>
+          </table>
+        </section>
+      <% end %>
+
       <table class="govuk-table search-diagnostics-events">
         <caption class="govuk-table__caption govuk-table__caption--m">Search journey events</caption>
         <thead class="govuk-table__head">

--- a/spec/requests/search_diagnostics_controller_spec.rb
+++ b/spec/requests/search_diagnostics_controller_spec.rb
@@ -166,9 +166,13 @@ RSpec.describe SearchDiagnosticsController do
                 search_type: "interactive",
                 fields: {
                   request_id: "request-123",
+                  base_query: "red leather footwear",
                   original_query: "red leather footwear",
                   refined_query: "red leather footwear womens",
+                  effective_query: "red leather footwear womens",
                   answer_count: 1,
+                  added_answers: %w[womens],
+                  iteration: 2,
                 },
               },
               {
@@ -217,9 +221,11 @@ RSpec.describe SearchDiagnosticsController do
                   request_id: "request-123",
                   search_type: "interactive",
                   query: "red leather shoes",
+                  effective_query: "red leather footwear womens",
                   retrieval_method: "hybrid",
                   stage: "after_rrf",
                   leg: nil,
+                  iteration: 2,
                   result_count: 1,
                   details: {
                     results: [
@@ -305,6 +311,14 @@ RSpec.describe SearchDiagnosticsController do
       expect(response.body).to include("Interactive configuration used", "Retrieval method", "hybrid", "Rrf k", "60", "Questions returned - 1 question", "What material are the shoes made from?", "Hybrid - After rrf - 1 result", "12.7", "View self-text", "View labels")
     end
 
+    it "renders internal search iterations" do
+      rendered_page
+
+      expect(Capybara.string(response.body).text).to include(
+        "Internal search iterations", "Iteration 2", "red leather footwear womens", "womens", "Hybrid after rrf - 1 result"
+      )
+    end
+
     it "renders the GOV.UK formatted log search window and event timeline chart" do
       rendered_page
 
@@ -386,8 +400,9 @@ RSpec.describe SearchDiagnosticsController do
       "Description intercept matched - shoes",
       "Query expansion used - low results",
       "Query expanded - red leather shoes to red leather footwear",
-      "Query refined - added 1 answer",
+      "Query refined - iteration 2 - added womens",
       "Model returned questions - attempt 1",
+      "Hybrid - After rrf - 1 result - iteration 2 - query: red leather footwear womens",
       "Vector retrieval succeeded - 1 result",
       "Answers returned - 1 answer",
       "Result selected - commodity 6403990000",


### PR DESCRIPTION
### Jira link

N/A - BAU

<img width="594" height="1146" alt="image" src="https://github.com/user-attachments/assets/cacc3a40-6b7c-41b3-bc59-5090070de421" />

<img width="525" height="816" alt="image" src="https://github.com/user-attachments/assets/cf935443-8394-4491-b290-0b4eaa997df8" />



### What?

I have altered:

- [x] Add an Internal search iterations table to the search diagnostics screen
- [x] Show each iteration's effective query, added answers, retrieval outcome and model outcome
- [x] Include iteration and effective query context in event summaries and diagnostics details
- [x] Cover the rendered diagnostics journey in request specs

### Why?

Operators need to understand how the internal search query changes as a user answers follow-up questions. The previous chronological event list exposed the raw events but made it hard to see what query was used for each retrieval iteration.

### Have you?

- [x] Reviewed view changes against the existing GOV.UK table-based diagnostics layout
- [x] Validated the rendered request spec for the diagnostics screen

### Risk

**Risk level:** 🟢

**Reason for rating:** This is an admin-only diagnostics UI improvement with no trader-facing journey change. It is covered by focused helper/request specs and RuboCop.