### PR TITLE
AI-868: Add compressed notes admin review UI

### DIFF
--- a/app/controllers/tariff_knowledge_compressed_notes_controller.rb
+++ b/app/controllers/tariff_knowledge_compressed_notes_controller.rb
@@ -1,0 +1,118 @@
+class TariffKnowledgeCompressedNotesController < AuthenticatedController
+  before_action :load_compressed_note, only: %i[regenerate approve reject update]
+
+  def index
+    authorize TariffKnowledgeCompressedNote, :index?
+
+    respond_to do |format|
+      format.html { redirect_to goods_nomenclature_self_texts_path(anchor: "compressed-notes") }
+      format.json { render json: TariffKnowledgeCompressedNote.listing(params) }
+    end
+  end
+
+  def search
+    authorize TariffKnowledgeCompressedNote, :index?
+
+    query = search_params[:q].to_s.gsub(/\s+/, " ").strip
+
+    if query.blank?
+      redirect_to goods_nomenclature_self_texts_path(anchor: "compressed-notes"), alert: "Please enter a search term."
+      return
+    end
+
+    redirect_to goods_nomenclature_self_texts_path(anchor: "compressed-notes", q: query)
+  end
+
+  def show
+    authorize TariffKnowledgeCompressedNote, :show?
+
+    @compressed_note = find_compressed_note
+    @versions = fetch_versions
+  rescue Faraday::ResourceNotFound
+    redirect_to goods_nomenclature_self_texts_path(anchor: "compressed-notes"), alert: "Compressed note not found."
+  end
+
+  def regenerate
+    authorize TariffKnowledgeCompressedNote, :update?
+
+    @compressed_note.regenerate
+
+    redirect_to tariff_knowledge_compressed_note_path(goods_nomenclature_id),
+                notice: "Compressed note regenerated successfully."
+  rescue Faraday::Error
+    redirect_to tariff_knowledge_compressed_note_path(goods_nomenclature_id),
+                alert: "Failed to regenerate compressed note."
+  end
+
+  def approve
+    authorize TariffKnowledgeCompressedNote, :update?
+
+    @compressed_note.approve
+
+    redirect_to tariff_knowledge_compressed_note_path(goods_nomenclature_id),
+                notice: "Compressed note approved."
+  rescue Faraday::Error
+    redirect_to tariff_knowledge_compressed_note_path(goods_nomenclature_id),
+                alert: "Failed to approve compressed note."
+  end
+
+  def reject
+    authorize TariffKnowledgeCompressedNote, :update?
+
+    @compressed_note.reject
+
+    redirect_to tariff_knowledge_compressed_note_path(goods_nomenclature_id),
+                notice: "Compressed note marked for review."
+  rescue Faraday::Error
+    redirect_to tariff_knowledge_compressed_note_path(goods_nomenclature_id),
+                alert: "Failed to reject compressed note."
+  end
+
+  def update
+    authorize TariffKnowledgeCompressedNote, :update?
+
+    @compressed_note.assign_attributes(content: compressed_note_params[:content])
+
+    if @compressed_note.save && @compressed_note.errors.empty?
+      redirect_to tariff_knowledge_compressed_note_path(goods_nomenclature_id),
+                  notice: "Compressed note updated successfully."
+    else
+      @versions = fetch_versions
+      render :show, status: :unprocessable_content
+    end
+  end
+
+private
+
+  def fetch_versions
+    Version.all(item_type: "TariffKnowledge::CompressedNote", item_id: @compressed_note.goods_nomenclature_sid)
+  rescue Faraday::Error => e
+    Rails.logger.error("Failed to fetch versions: #{e.message}")
+    []
+  end
+
+  def find_compressed_note(skip_oid: false)
+    opts = {}
+    opts[:oid] = params[:oid] if params[:oid].present? && !skip_oid
+
+    TariffKnowledgeCompressedNote.find(goods_nomenclature_id, opts)
+  end
+
+  def load_compressed_note
+    @compressed_note = find_compressed_note(skip_oid: true)
+  rescue Faraday::ResourceNotFound
+    redirect_to goods_nomenclature_self_texts_path(anchor: "compressed-notes"), alert: "Compressed note not found."
+  end
+
+  def goods_nomenclature_id
+    params[:goods_nomenclature_id]
+  end
+
+  def search_params
+    params.permit(:q)
+  end
+
+  def compressed_note_params
+    params.require(:tariff_knowledge_compressed_note).permit(:content)
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -86,7 +86,7 @@ module NavigationHelper
             text: "Descriptions",
             href: goods_nomenclature_self_texts_path,
             policy_class: GoodsNomenclatureSelfText,
-            active_when: /\/goods_nomenclature_(self_texts|labels)/,
+            active_when: /\/(goods_nomenclature_(self_texts|labels)|tariff_knowledge_compressed_notes)/,
             service: nil,
           ),
           NavigationItem.new(

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -12,6 +12,8 @@ module VersionsHelper
       goods_nomenclature_label_path(item_id, **opts) if item_id.present?
     when "GoodsNomenclatureSelfText"
       goods_nomenclature_self_text_path(version.item_id, **opts) if version.item_id.present?
+    when "TariffKnowledge::CompressedNote"
+      tariff_knowledge_compressed_note_path(version.item_id, **opts) if version.item_id.present?
     when "AdminConfiguration"
       name = version.object&.dig("name")
       classification_configuration_path(name, **opts) if name.present?

--- a/app/models/tariff_knowledge_compressed_note.rb
+++ b/app/models/tariff_knowledge_compressed_note.rb
@@ -1,0 +1,59 @@
+class TariffKnowledgeCompressedNote
+  include ApiEntity
+  include GeneratedContentResource
+
+  set_collection_path "admin/tariff_knowledge_compressed_notes"
+  set_singular_path "admin/goods_nomenclatures/:goods_nomenclature_id/tariff_knowledge_compressed_note"
+
+  attributes :goods_nomenclature_sid,
+             :goods_nomenclature_item_id,
+             :producline_suffix,
+             :goods_nomenclature_type,
+             :content,
+             :metadata,
+             :context_hash,
+             :needs_review,
+             :manually_edited,
+             :stale,
+             :approved,
+             :expired,
+             :generated_at,
+             :created_at,
+             :updated_at
+
+  def to_param
+    goods_nomenclature_sid&.to_s || goods_nomenclature_id
+  end
+
+  def source_node_keys
+    metadata_array("source_node_keys")
+  end
+
+  def range_node_keys
+    metadata_array("range_node_keys")
+  end
+
+private
+
+  def generated_content_member_path
+    "admin/goods_nomenclatures/#{to_param}/tariff_knowledge_compressed_note"
+  end
+
+  def listing_description
+    content
+  end
+
+  def listing_description_key
+    :content
+  end
+
+  def listing_score
+    nil
+  end
+
+  def metadata_array(key)
+    return [] unless metadata.is_a?(Hash)
+
+    Array(metadata[key]).compact
+  end
+end

--- a/app/policies/tariff_knowledge_compressed_note_policy.rb
+++ b/app/policies/tariff_knowledge_compressed_note_policy.rb
@@ -1,0 +1,14 @@
+# UK Service - TariffKnowledgeCompressedNote: TECHNICAL_OPERATOR only
+class TariffKnowledgeCompressedNotePolicy < ApplicationPolicy
+  def index?
+    technical_operator?
+  end
+
+  def show?
+    technical_operator?
+  end
+
+  def update?
+    technical_operator?
+  end
+end

--- a/app/views/goods_nomenclature_self_texts/index.html.erb
+++ b/app/views/goods_nomenclature_self_texts/index.html.erb
@@ -10,6 +10,9 @@
     <li class="govuk-tabs__list-item">
       <a class="govuk-tabs__tab" href="#labels">Labels</a>
     </li>
+    <li class="govuk-tabs__list-item">
+      <a class="govuk-tabs__tab" href="#compressed-notes">Compressed notes</a>
+    </li>
   </ul>
 
   <%# ===== Self-texts tab ===== %>
@@ -198,6 +201,77 @@
       <div class="govuk-grid-column-three-quarters">
         <p class="govuk-body" data-generated-content-table-target="loading">Loading...</p>
         <div class="label-table-container" data-generated-content-table-target="table"></div>
+        <div data-generated-content-table-target="pagination"></div>
+      </div>
+    </div>
+  </div>
+
+  <%# ===== Compressed notes tab ===== %>
+  <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="compressed-notes"
+       data-controller="generated-content-table"
+       data-generated-content-table-url-value="<%= tariff_knowledge_compressed_notes_path(format: :json) %>"
+       data-generated-content-table-show-url-value="<%= tariff_knowledge_compressed_notes_path %>/__ID__"
+       data-generated-content-table-show-id-field-value="goods_nomenclature_sid"
+       data-generated-content-table-description-field-value="content"
+       data-generated-content-table-description-heading-value="Compressed note"
+       data-generated-content-table-empty-message-value="No compressed notes found."
+       data-generated-content-table-error-message-value="Failed to load compressed notes."
+       data-generated-content-table-table-class-value="compressed-note-table"
+       data-generated-content-table-q-value="<%= params[:q] %>">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <%= form_with url: search_tariff_knowledge_compressed_notes_path, method: :get, local: true do |f| %>
+          <div class="govuk-form-group">
+            <%= f.label :q, "Search", class: "govuk-label govuk-label--m" %>
+            <div class="govuk-hint">
+              Search by commodity code or compressed note content.
+            </div>
+            <%= f.text_field :q,
+                             value: params[:q],
+                             class: "govuk-input govuk-input--width-20" %>
+          </div>
+
+          <%= f.submit "Search", class: "govuk-button", data: { module: "govuk-button" } %>
+        <% end %>
+      </div>
+    </div>
+
+    <details class="govuk-details">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">About compressed notes</span>
+      </summary>
+      <div class="govuk-details__text">
+        <p class="govuk-body">Compressed notes are short summaries generated from tariff knowledge graph evidence. The note keeps source and referenced range keys so reviewers can compare the generated output with the underlying archive-backed evidence.</p>
+
+        <h3 class="govuk-heading-s">Tags</h3>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><strong>Needs review</strong> - an admin has flagged this compressed note for review</li>
+          <li><strong>Stale</strong> - the commodity or evidence context has changed since generation</li>
+          <li><strong>Manually edited</strong> - a human has edited the generated note</li>
+          <li><strong>Expired</strong> - the note no longer applies to the current commodity set</li>
+        </ul>
+      </div>
+    </details>
+
+    <h2 class="govuk-heading-m">Compressed notes</h2>
+
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-one-quarter">
+        <h3 class="govuk-heading-s">Filters</h3>
+
+        <%= render "shared/generated_content_filter_group",
+                   legend: "Tags",
+                   options: generated_content_tag_options,
+                   prefix: "cn",
+                   input_name: "cn_tags",
+                   action_name: "changeTags",
+                   data_attribute: "status",
+                   default_value: "" %>
+      </div>
+
+      <div class="govuk-grid-column-three-quarters">
+        <p class="govuk-body" data-generated-content-table-target="loading">Loading...</p>
+        <div class="compressed-note-table-container" data-generated-content-table-target="table"></div>
         <div data-generated-content-table-target="pagination"></div>
       </div>
     </div>

--- a/app/views/shared/_generated_content_action_buttons.html.erb
+++ b/app/views/shared/_generated_content_action_buttons.html.erb
@@ -14,11 +14,13 @@
                     data: { module: "govuk-button" } %>
     <% end %>
 
-    <%= button_to "Generate score",
-                  score_path,
-                  method: :post,
-                  class: "govuk-button govuk-button--secondary",
-                  data: { module: "govuk-button" } %>
+    <% if local_assigns[:score_path].present? %>
+      <%= button_to "Generate score",
+                    score_path,
+                    method: :post,
+                    class: "govuk-button govuk-button--secondary",
+                    data: { module: "govuk-button" } %>
+    <% end %>
 
     <%= button_to regenerate_label,
                   regenerate_path,

--- a/app/views/tariff_knowledge_compressed_notes/show.html.erb
+++ b/app/views/tariff_knowledge_compressed_notes/show.html.erb
@@ -1,0 +1,127 @@
+<%= govuk_breadcrumbs 'Descriptions': "#{goods_nomenclature_self_texts_path}#compressed-notes" %>
+
+<%= render "versions/version_banner",
+           record: @compressed_note,
+           current_path: tariff_knowledge_compressed_note_path(@compressed_note.to_param),
+           type_name: "compressed note" %>
+
+<h1 class="govuk-heading-l">
+  Compressed note <%= @compressed_note.goods_nomenclature_item_id %>
+</h1>
+
+<%= render "shared/generated_content_action_buttons",
+           record: @compressed_note,
+           approve_path: approve_tariff_knowledge_compressed_note_path(@compressed_note.to_param),
+           reject_path: reject_tariff_knowledge_compressed_note_path(@compressed_note.to_param),
+           regenerate_path: regenerate_tariff_knowledge_compressed_note_path(@compressed_note.to_param),
+           regenerate_label: "Regenerate compressed note",
+           regenerate_confirm: "This will regenerate the compressed note from tariff knowledge graph evidence. The current note will be overwritten. Continue?" %>
+
+<%= form_with model: @compressed_note,
+              url: tariff_knowledge_compressed_note_path(@compressed_note.to_param),
+              method: :patch,
+              local: true do |f| %>
+
+  <% if @compressed_note.errors.any? %>
+    <div class="govuk-error-summary" data-module="govuk-error-summary">
+      <div role="alert">
+        <h2 class="govuk-error-summary__title">There is a problem</h2>
+        <div class="govuk-error-summary__body">
+          <ul class="govuk-list govuk-error-summary__list">
+            <% @compressed_note.errors.full_messages.each do |message| %>
+              <li><%= message %></li>
+            <% end %>
+          </ul>
+        </div>
+      </div>
+    </div>
+  <% end %>
+
+  <dl class="govuk-summary-list govuk-!-margin-bottom-6">
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Commodity code</dt>
+      <dd class="govuk-summary-list__value"><%= link_to @compressed_note.goods_nomenclature_item_id, "#{TradeTariffAdmin.frontend_host}/commodities/#{@compressed_note.goods_nomenclature_item_id}", class: "govuk-link", target: "_blank", rel: "noopener noreferrer" %></dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">SID</dt>
+      <dd class="govuk-summary-list__value"><%= @compressed_note.goods_nomenclature_sid %></dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Created</dt>
+      <dd class="govuk-summary-list__value"><%= @compressed_note.formatted_created_at %></dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Last updated</dt>
+      <dd class="govuk-summary-list__value"><%= @compressed_note.formatted_updated_at %></dd>
+    </div>
+
+    <div class="govuk-summary-list__row">
+      <dt class="govuk-summary-list__key">Tags</dt>
+      <dd class="govuk-summary-list__value">
+        <%= render "shared/generated_content_tags", record: @compressed_note %>
+      </dd>
+    </div>
+  </dl>
+
+  <div class="govuk-form-group">
+    <%= f.label :content, "Compressed note", class: "govuk-label govuk-label--m" %>
+    <div class="govuk-hint">
+      A short reviewable summary generated from tariff knowledge graph evidence.
+    </div>
+    <%= f.text_area :content,
+                    class: "govuk-textarea",
+                    rows: 8,
+                    value: @compressed_note.content %>
+  </div>
+
+  <details class="govuk-details">
+    <summary class="govuk-details__summary">
+      <span class="govuk-details__summary-text">Knowledge graph evidence</span>
+    </summary>
+    <div class="govuk-details__text">
+      <h2 class="govuk-heading-s">Source nodes</h2>
+      <% if @compressed_note.source_node_keys.any? %>
+        <ul class="govuk-list govuk-list--bullet">
+          <% @compressed_note.source_node_keys.each do |key| %>
+            <li><code><%= key %></code></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="govuk-body">No source nodes recorded.</p>
+      <% end %>
+
+      <h2 class="govuk-heading-s">Referenced ranges</h2>
+      <% if @compressed_note.range_node_keys.any? %>
+        <ul class="govuk-list govuk-list--bullet">
+          <% @compressed_note.range_node_keys.each do |key| %>
+            <li><code><%= key %></code></li>
+          <% end %>
+        </ul>
+      <% else %>
+        <p class="govuk-body">No referenced ranges recorded.</p>
+      <% end %>
+    </div>
+  </details>
+
+  <% if @compressed_note.current? && policy(@compressed_note).update? %>
+    <div class="govuk-button-group">
+      <%= f.submit "Save changes", class: "govuk-button", data: { module: "govuk-button" } %>
+    </div>
+  <% end %>
+<% end %>
+
+<% if @versions.present? %>
+  <%= render "versions/history_section",
+             versions: @versions,
+             view_path_helper: ->(v) { tariff_knowledge_compressed_note_path(@compressed_note.to_param, oid: v.resource_id) },
+             restore_path_helper: ->(v) { restore_version_path(v.resource_id) },
+             can_restore: policy(@compressed_note).update?,
+             current_oid: @compressed_note.version_oid %>
+<% end %>
+
+<%= render "versions/version_navigation",
+           record: @compressed_note,
+           version_path_helper: ->(oid) { tariff_knowledge_compressed_note_path(@compressed_note.to_param, oid: oid) } %>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -272,6 +272,32 @@ $govuk-image-url-function: frontend-image-url;
   }
 }
 
+.compressed-note-table-container {
+  overflow-x: hidden;
+}
+
+.compressed-note-table {
+  table-layout: fixed;
+  width: 100%;
+
+  &__code {
+    width: 18%;
+  }
+
+  &__score {
+    width: 11%;
+  }
+
+  &__tags {
+    width: 12%;
+  }
+
+  &__description {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}
+
 #ca-search-container {
   display: flex;
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -126,6 +126,36 @@ Rails.application.routes.draw do
        as: :reject_goods_nomenclature_self_text,
        constraints: { goods_nomenclature_id: /\d+/ }
 
+  resources :tariff_knowledge_compressed_notes, only: %i[index] do
+    collection do
+      get :search
+    end
+  end
+
+  get "tariff_knowledge_compressed_notes/:goods_nomenclature_id",
+      to: "tariff_knowledge_compressed_notes#show",
+      as: :tariff_knowledge_compressed_note,
+      constraints: { goods_nomenclature_id: /\d+/ }
+
+  patch "tariff_knowledge_compressed_notes/:goods_nomenclature_id",
+        to: "tariff_knowledge_compressed_notes#update",
+        constraints: { goods_nomenclature_id: /\d+/ }
+
+  post "tariff_knowledge_compressed_notes/:goods_nomenclature_id/regenerate",
+       to: "tariff_knowledge_compressed_notes#regenerate",
+       as: :regenerate_tariff_knowledge_compressed_note,
+       constraints: { goods_nomenclature_id: /\d+/ }
+
+  post "tariff_knowledge_compressed_notes/:goods_nomenclature_id/approve",
+       to: "tariff_knowledge_compressed_notes#approve",
+       as: :approve_tariff_knowledge_compressed_note,
+       constraints: { goods_nomenclature_id: /\d+/ }
+
+  post "tariff_knowledge_compressed_notes/:goods_nomenclature_id/reject",
+       to: "tariff_knowledge_compressed_notes#reject",
+       as: :reject_tariff_knowledge_compressed_note,
+       constraints: { goods_nomenclature_id: /\d+/ }
+
   resources :versions, only: %i[index] do
     member do
       post :restore

--- a/spec/models/tariff_knowledge_compressed_note_spec.rb
+++ b/spec/models/tariff_knowledge_compressed_note_spec.rb
@@ -1,0 +1,117 @@
+RSpec.describe TariffKnowledgeCompressedNote do
+  subject(:compressed_note) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      goods_nomenclature_sid: 12_345,
+      goods_nomenclature_item_id: "0101210000",
+      producline_suffix: "80",
+      goods_nomenclature_type: "commodity",
+      content: "Live horses are covered by chapter notes for chapter 1.",
+      metadata: {
+        "source_node_keys" => ["chapter_note:01:fragment:1"],
+        "range_node_keys" => ["chapter:01"],
+      },
+      context_hash: "abc123",
+      needs_review: true,
+      manually_edited: false,
+      stale: false,
+      approved: false,
+      expired: false,
+      generated_at: "2025-06-15T10:00:00Z",
+      created_at: "2025-06-15T10:00:00Z",
+      updated_at: "#{Time.zone.today.iso8601}T10:00:00Z",
+    }
+  end
+
+  describe "#to_param" do
+    it "returns goods_nomenclature_sid as string" do
+      expect(compressed_note.to_param).to eq("12345")
+    end
+
+    it "falls back to goods_nomenclature_id" do
+      record = described_class.new(goods_nomenclature_id: "99999")
+
+      expect(record.to_param).to eq("99999")
+    end
+  end
+
+  describe "#source_node_keys" do
+    it "returns source evidence node keys from metadata" do
+      expect(compressed_note.source_node_keys).to eq(["chapter_note:01:fragment:1"])
+    end
+
+    it "returns an empty array when metadata is missing" do
+      compressed_note.metadata = nil
+
+      expect(compressed_note.source_node_keys).to eq([])
+    end
+  end
+
+  describe "#range_node_keys" do
+    it "returns referenced range node keys from metadata" do
+      expect(compressed_note.range_node_keys).to eq(["chapter:01"])
+    end
+  end
+
+  describe "#as_listing_json" do
+    # rubocop:disable RSpec/ExampleLength
+    it "uses content as the listing description and exposes lifecycle tags" do
+      record = described_class.new(attributes.merge(lifecycle_tag_attributes))
+
+      expect(record.as_listing_json).to include(
+        lifecycle_tag_attributes.merge(
+          content: "Live horses are covered by chapter notes for chapter 1.",
+          score: nil,
+        ),
+      )
+    end
+    # rubocop:enable RSpec/ExampleLength
+  end
+
+  describe "record date formatting" do
+    it "formats created_at" do
+      expect(compressed_note.formatted_created_at).to eq("15 June 2025")
+    end
+  end
+
+  describe ".find" do
+    before do
+      stub_api_request("/goods_nomenclatures/0101210000/tariff_knowledge_compressed_note")
+        .with(query: hash_including("filter" => { "oid" => "789" }))
+        .and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: {
+            data: {
+              type: "tariff_knowledge_compressed_note",
+              id: "12345",
+              attributes: attributes.merge(content: "Historical compressed note"),
+            },
+            meta: {
+              version: {
+                current: false,
+                oid: 789,
+                previous_oid: 788,
+                has_previous_version: true,
+                latest_event: "update",
+              },
+            },
+          }.to_json,
+        )
+    end
+
+    it "uses the path id and extracts version metadata through API entity", :aggregate_failures do
+      record = described_class.find("0101210000", oid: "789")
+
+      expect(record.goods_nomenclature_id).to eq("0101210000")
+      expect(record.content).to eq("Historical compressed note")
+      expect(record.version_oid).to eq(789)
+      expect(record.current?).to be(false)
+    end
+  end
+
+  def lifecycle_tag_attributes
+    { needs_review: true, manually_edited: true, stale: true, approved: true, expired: true }
+  end
+end

--- a/spec/requests/tariff_knowledge_compressed_notes_controller_spec.rb
+++ b/spec/requests/tariff_knowledge_compressed_notes_controller_spec.rb
@@ -1,0 +1,197 @@
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+RSpec.describe TariffKnowledgeCompressedNotesController, type: :request do
+  subject(:rendered_page) { make_request && response }
+
+  include_context "with authenticated user"
+
+  let(:current_user) { create(:user, :technical_operator) }
+  let(:goods_nomenclature_sid) { 12_345 }
+  let(:commodity_code) { "0101210000" }
+  let(:compressed_note_attributes) do
+    {
+      "goods_nomenclature_sid" => goods_nomenclature_sid,
+      "goods_nomenclature_item_id" => commodity_code,
+      "producline_suffix" => "80",
+      "goods_nomenclature_type" => "commodity",
+      "content" => "Live horses are covered by chapter notes for chapter 1.",
+      "metadata" => {
+        "source_node_keys" => ["chapter_note:01:fragment:1"],
+        "range_node_keys" => ["chapter:01"],
+      },
+      "context_hash" => "abc123",
+      "needs_review" => true,
+      "manually_edited" => false,
+      "stale" => false,
+      "approved" => false,
+      "expired" => false,
+      "generated_at" => "2025-06-15T10:00:00Z",
+      "created_at" => "2025-06-15T10:00:00Z",
+      "updated_at" => "#{Time.zone.today.iso8601}T10:00:00Z",
+    }
+  end
+  let(:compressed_note_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: {
+          type: "tariff_knowledge_compressed_note",
+          id: goods_nomenclature_sid.to_s,
+          attributes: compressed_note_attributes,
+        },
+      }.to_json,
+    }
+  end
+
+  before do
+    TradeTariffAdmin::ServiceChooser.service_choice = "uk"
+  end
+
+  describe "GET #index" do
+    context "with HTML format" do
+      let(:make_request) { get tariff_knowledge_compressed_notes_path }
+
+      it { is_expected.to redirect_to(goods_nomenclature_self_texts_path(anchor: "compressed-notes")) }
+    end
+
+    context "with JSON format" do
+      let(:make_request) { get tariff_knowledge_compressed_notes_path(format: :json) }
+      let(:collection_response) do
+        jsonapi_response("tariff_knowledge_compressed_note", [
+          compressed_note_attributes.merge("content" => "Live horses are covered by chapter notes."),
+        ])
+      end
+
+      before do
+        stub_api_request("/tariff_knowledge_compressed_notes", backend: "uk")
+          .with(query: hash_including({}))
+          .and_return(collection_response)
+      end
+
+      it { is_expected.to have_http_status :success }
+
+      # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+      it "returns compressed note data with pagination" do
+        json = JSON.parse(rendered_page.body)
+
+        expect(json["data"].first).to include(
+          "goods_nomenclature_sid" => goods_nomenclature_sid,
+          "goods_nomenclature_item_id" => commodity_code,
+          "content" => "Live horses are covered by chapter notes.",
+          "score" => nil,
+        )
+        expect(json["pagination"]).to include("page", "total_count", "total_pages")
+      end
+      # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+    end
+  end
+
+  describe "GET descriptions page" do
+    let(:make_request) { get goods_nomenclature_self_texts_path }
+
+    # rubocop:disable RSpec/MultipleExpectations
+    it "adds compressed notes as a reviewable generated content tab" do
+      expect(rendered_page.body).to include("Compressed notes")
+      expect(rendered_page.body).to include('id="compressed-notes"')
+      expect(rendered_page.body).to include("compressed-note-table-container")
+      expect(rendered_page.body).to include(tariff_knowledge_compressed_notes_path(format: :json))
+    end
+    # rubocop:enable RSpec/MultipleExpectations
+  end
+
+  describe "GET #search" do
+    context "with valid query" do
+      let(:make_request) { get search_tariff_knowledge_compressed_notes_path(q: "horses") }
+
+      it { is_expected.to redirect_to(goods_nomenclature_self_texts_path(anchor: "compressed-notes", q: "horses")) }
+    end
+
+    context "with blank query" do
+      let(:make_request) { get search_tariff_knowledge_compressed_notes_path(q: "") }
+
+      it { is_expected.to redirect_to(goods_nomenclature_self_texts_path(anchor: "compressed-notes")) }
+    end
+  end
+
+  describe "GET #show" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note", backend: "uk")
+        .and_return(compressed_note_response)
+      stub_api_request("/versions", backend: "uk")
+        .with(query: hash_including("item_type" => "TariffKnowledge::CompressedNote", "item_id" => goods_nomenclature_sid.to_s))
+        .and_return(status: 200, headers: { "content-type" => "application/json; charset=utf-8" }, body: { data: [] }.to_json)
+    end
+
+    let(:make_request) { get tariff_knowledge_compressed_note_path(goods_nomenclature_sid) }
+
+    it { is_expected.to have_http_status :success }
+    it { is_expected.to render_template(:show) }
+
+    # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
+    it "displays note content and evidence keys without score controls" do
+      expect(rendered_page.body).to include(commodity_code)
+      expect(rendered_page.body).to include("Live horses are covered by chapter notes for chapter 1.")
+      expect(rendered_page.body).to include("chapter_note:01:fragment:1")
+      expect(rendered_page.body).to include("chapter:01")
+      expect(rendered_page.body).to include("Save changes")
+      expect(rendered_page.body).not_to include("Generate score")
+    end
+    # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
+  end
+
+  describe "PATCH #update" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note", backend: "uk")
+        .and_return(compressed_note_response)
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note", :patch, backend: "uk")
+        .and_return(compressed_note_response)
+    end
+
+    let(:make_request) do
+      patch tariff_knowledge_compressed_note_path(goods_nomenclature_sid),
+            params: { tariff_knowledge_compressed_note: { content: "Updated evidence note" } }
+    end
+
+    it { is_expected.to redirect_to(tariff_knowledge_compressed_note_path(goods_nomenclature_sid)) }
+  end
+
+  describe "POST #regenerate" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note", backend: "uk")
+        .and_return(compressed_note_response)
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note/regenerate", :post, backend: "uk")
+        .and_return(status: 200, body: {}.to_json)
+    end
+
+    let(:make_request) { post regenerate_tariff_knowledge_compressed_note_path(goods_nomenclature_sid) }
+
+    it { is_expected.to redirect_to(tariff_knowledge_compressed_note_path(goods_nomenclature_sid)) }
+  end
+
+  describe "POST #approve" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note", backend: "uk")
+        .and_return(compressed_note_response)
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note/approve", :post, backend: "uk")
+        .and_return(status: 200, body: {}.to_json)
+    end
+
+    let(:make_request) { post approve_tariff_knowledge_compressed_note_path(goods_nomenclature_sid) }
+
+    it { is_expected.to redirect_to(tariff_knowledge_compressed_note_path(goods_nomenclature_sid)) }
+  end
+
+  describe "POST #reject" do
+    before do
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note", backend: "uk")
+        .and_return(compressed_note_response)
+      stub_api_request("/goods_nomenclatures/#{goods_nomenclature_sid}/tariff_knowledge_compressed_note/reject", :post, backend: "uk")
+        .and_return(status: 200, body: {}.to_json)
+    end
+
+    let(:make_request) { post reject_tariff_knowledge_compressed_note_path(goods_nomenclature_sid) }
+
+    it { is_expected.to redirect_to(tariff_knowledge_compressed_note_path(goods_nomenclature_sid)) }
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/support/shared_contexts/with_authenticated_user.rb
+++ b/spec/support/shared_contexts/with_authenticated_user.rb
@@ -39,7 +39,7 @@ RSpec.shared_context "with authenticated user" do # rubocop:disable RSpec/Multip
 
         ActionDispatch::Session::CookieStore.new(setter, key: "_trade-tariff-admin_app_session").call(env)
         cookies_key_value = env["action_dispatch.cookies"].as_json.first
-        cookies[:id_token] = id_token
+        cookies[TradeTariffAdmin.id_token_cookie_name] = id_token
         cookies[cookies_key_value.first] = cookies_key_value.last if cookies_key_value
       end
     elsif example.metadata[:type] == :feature && session_instance
@@ -53,7 +53,7 @@ RSpec.shared_context "with authenticated user" do # rubocop:disable RSpec/Multip
       cookies_key_value = env["action_dispatch.cookies"].as_json.first
 
       rack_session = page.driver.browser.rack_mock_session
-      rack_session.cookie_jar[:id_token] = "mock-id-token"
+      rack_session.cookie_jar[TradeTariffAdmin.id_token_cookie_name] = "mock-id-token"
       rack_session.cookie_jar[cookies_key_value.first] = cookies_key_value.last if cookies_key_value
     elsif session_instance
       session[:token] = session_instance.token


### PR DESCRIPTION
### Jira link

[AI-868](https://transformuk.atlassian.net/browse/AI-868)

### What?

I have added/removed/altered:

- [x] Added an admin API client model for tariff knowledge compressed notes.
- [x] Added a compressed notes tab to the Descriptions review page.
- [x] Added compressed note show/edit/review actions for approve, needs review, and regenerate.
- [x] Displayed source node and referenced range evidence keys so reviewers can compare generated notes with the graph evidence.
- [x] Updated generated-content shared controls so reviewable content without score generation does not render a score action.
- [x] Added request and model coverage for compressed notes review flows.

### Why?

Compressed notes need the same reviewable admin workflow as other generated content. The review screen exposes the generated note and its graph evidence keys so differences can be inspected and corrected before the notes are treated as reviewed content.

### Risk

**Risk level:** 🟢

**Reason for rating:** This is staging-only, technical-operator functionality for generating, reviewing, refreshing, exposing, or consuming compressed notes. Production and other environments should leave the consuming feature disabled, so this does not change live trader journeys or production search behaviour.

### Have you? (optional)

- [x] Added request/model coverage for the new review workflow
- [x] Validated generated-content regressions for self-texts and labels

### Environment note
Compressed notes are intended to be consumed only in staging. Staging is the only environment where this capability will be enabled; production and other environments should leave the consuming feature disabled.
