### PR TITLE
AI-517: Add admin UI for customs tariff chapter notes review and approval

### DIFF
--- a/app/controllers/customs_tariff/updates/chapter_notes_controller.rb
+++ b/app/controllers/customs_tariff/updates/chapter_notes_controller.rb
@@ -1,0 +1,121 @@
+module CustomsTariff
+  module Updates
+    class ChapterNotesController < AuthenticatedController
+      def new
+        @update = CustomsTariff::Update.find(params[:update_version])
+        authorize CustomsTariff::ChapterNote, :create?
+        @chapter_id = params[:chapter_id]
+        @section_id = params[:section_id]
+        @chapter_note = CustomsTariff::ChapterNote.new(
+          customs_tariff_update_version: params[:update_version],
+          chapter_id: @chapter_id,
+        )
+      end
+
+      def create
+        @update = CustomsTariff::Update.find(params[:update_version])
+        authorize CustomsTariff::ChapterNote, :create?
+        @chapter_id = params[:chapter_id]
+        @section_id = params[:section_id]
+
+        CustomsTariff::ChapterNote.api.post(
+          "admin/customs_tariff_updates/#{params[:update_version]}/chapter_notes",
+          {
+            data: {
+              type: "customs_tariff_chapter_note",
+              attributes: { chapter_id: @chapter_id, content: chapter_note_params[:content] },
+            },
+          },
+        )
+
+        redirect_to customs_tariff_update_section_chapter_notes_path(params[:update_version], @section_id),
+                    notice: "Chapter note added."
+      rescue Faraday::UnprocessableEntityError
+        @chapter_note = CustomsTariff::ChapterNote.new(
+          customs_tariff_update_version: params[:update_version],
+          chapter_id: @chapter_id,
+          content: chapter_note_params[:content],
+        )
+        render :new, status: :unprocessable_content
+      end
+
+      def index
+        @update = CustomsTariff::Update.find(params[:update_version])
+        authorize @update, :show?
+        @section_id      = params[:section_id]
+        @compare_version = params[:compare_version]
+        @section         = Section.find(@section_id)
+        @chapter_info    = @section.chapters.index_by(&:short_code)
+        @chapter_notes   = CustomsTariff::ChapterNote.all(
+          customs_tariff_update_version: params[:update_version],
+          section_id: @section_id,
+          compare_version: @compare_version,
+        )
+        notes_by_chapter = @chapter_notes.index_by(&:chapter_id)
+        all_codes = (@chapter_info.keys + notes_by_chapter.keys).uniq.sort
+        @rows = all_codes.map { |code| [code, notes_by_chapter[code]] }
+      end
+
+      def edit
+        @update = CustomsTariff::Update.find(params[:update_version])
+        @chapter_note = CustomsTariff::ChapterNote.find(
+          params[:id],
+          customs_tariff_update_version: params[:update_version],
+        )
+        authorize @chapter_note, :edit?
+        @section_id      = params[:section_id]
+        @compare_version = params[:compare_version]
+      end
+
+      def update
+        @update = CustomsTariff::Update.find(params[:update_version])
+        @chapter_note = CustomsTariff::ChapterNote.find(
+          params[:id],
+          customs_tariff_update_version: params[:update_version],
+        )
+        authorize @chapter_note, :update?
+        @section_id      = params[:section_id]
+        @compare_version = params[:compare_version]
+        @chapter_note.build(content: chapter_note_params[:content])
+
+        if @chapter_note.save && @chapter_note.errors.empty?
+          redirect_to customs_tariff_update_section_chapter_notes_path(
+            params[:update_version], @section_id
+          ),
+                      notice: "Chapter note updated."
+        else
+          render :edit
+        end
+      end
+
+      def destroy
+        @update = CustomsTariff::Update.find(params[:update_version])
+        @chapter_note = CustomsTariff::ChapterNote.find(
+          params[:id],
+          customs_tariff_update_version: params[:update_version],
+        )
+        authorize @chapter_note, :destroy?
+        @section_id = params[:section_id]
+        @chapter_note.destroy
+        redirect_to customs_tariff_update_section_chapter_notes_path(params[:update_version], @section_id),
+                    notice: "Chapter note removed."
+      rescue Faraday::ResourceNotFound
+        redirect_to customs_tariff_update_section_chapter_notes_path(params[:update_version], @section_id),
+                    alert: "Chapter note could not be found."
+      end
+
+      def preview
+        authorize CustomsTariff::ChapterNote, :update?
+        content   = params.fetch(:content, "")
+        formatted = TariffNoteFormatter.new(content).format
+        render json: { html: GovspeakPreview.new(formatted).render }
+      end
+
+    private
+
+      def chapter_note_params
+        params.require(:customs_tariff_chapter_note).permit(:content)
+      end
+    end
+  end
+end

--- a/app/controllers/customs_tariff/updates/comparisons_controller.rb
+++ b/app/controllers/customs_tariff/updates/comparisons_controller.rb
@@ -24,6 +24,18 @@ module CustomsTariff
         )
       end
 
+      def show_chapter_note
+        @update = CustomsTariff::Update.find(params[:update_version])
+        authorize @update, :show?
+        @compare_version = params[:compare_version]
+        @section_id = params[:section_id]
+        @chapter_note = CustomsTariff::ChapterNote.find(
+          params[:id],
+          customs_tariff_update_version: params[:update_version],
+          compare_version: @compare_version,
+        )
+      end
+
     private
 
       def require_compare_version

--- a/app/controllers/customs_tariff/updates/section_notes_controller.rb
+++ b/app/controllers/customs_tariff/updates/section_notes_controller.rb
@@ -1,6 +1,42 @@
 module CustomsTariff
   module Updates
     class SectionNotesController < AuthenticatedController
+      def new
+        @update = CustomsTariff::Update.find(params[:update_version])
+        authorize CustomsTariff::SectionNote, :create?
+        @section_id = params[:section_id]
+        @section_note = CustomsTariff::SectionNote.new(
+          customs_tariff_update_version: params[:update_version],
+          section_id: @section_id,
+        )
+      end
+
+      def create
+        @update = CustomsTariff::Update.find(params[:update_version])
+        authorize CustomsTariff::SectionNote, :create?
+        @section_id = params[:section_id]
+
+        CustomsTariff::SectionNote.api.post(
+          "admin/customs_tariff_updates/#{params[:update_version]}/section_notes",
+          {
+            data: {
+              type: "customs_tariff_section_note",
+              attributes: { section_id: @section_id, content: section_note_params[:content] },
+            },
+          },
+        )
+
+        redirect_to customs_tariff_update_path(params[:update_version]),
+                    notice: "Section note added."
+      rescue Faraday::UnprocessableEntityError
+        @section_note = CustomsTariff::SectionNote.new(
+          customs_tariff_update_version: params[:update_version],
+          section_id: @section_id,
+          content: section_note_params[:content],
+        )
+        render :new, status: :unprocessable_content
+      end
+
       def edit
         @update = CustomsTariff::Update.find(params[:update_version])
         @section_note = CustomsTariff::SectionNote.find(
@@ -25,6 +61,21 @@ module CustomsTariff
         else
           render :edit
         end
+      end
+
+      def destroy
+        @update = CustomsTariff::Update.find(params[:update_version])
+        @section_note = CustomsTariff::SectionNote.find(
+          params[:id],
+          customs_tariff_update_version: params[:update_version],
+        )
+        authorize @section_note, :destroy?
+        @section_note.destroy
+        redirect_to customs_tariff_update_path(params[:update_version]),
+                    notice: "Section note removed."
+      rescue Faraday::ResourceNotFound
+        redirect_to customs_tariff_update_path(params[:update_version]),
+                    alert: "Section note could not be found."
       end
 
       def preview

--- a/app/controllers/customs_tariff/updates_controller.rb
+++ b/app/controllers/customs_tariff/updates_controller.rb
@@ -9,7 +9,12 @@ module CustomsTariff
       @update = CustomsTariff::Update.find(params[:version])
       authorize @update, :show?
       @updates = CustomsTariff::Update.all
-      @section_notes = CustomsTariff::SectionNote.all(customs_tariff_update_version: params[:version])
+      @section_summaries = CustomsTariff::SectionSummary.all(customs_tariff_update_version: params[:version])
+      @baseline_version = @updates
+        .reject { |u| u.version == @update.version || u.status == "failed" }
+        .select { |u| u.validity_start_date.present? && u.validity_start_date < @update.validity_start_date }
+        .max_by(&:validity_start_date)
+        &.version
     end
 
     def update_status
@@ -21,11 +26,24 @@ module CustomsTariff
         { data: { attributes: { status: params.require(:status) } } },
       )
 
-      redirect_to customs_tariff_update_path(params[:version]),
+      redirect_to customs_tariff_updates_path,
                   notice: "Status updated to #{params[:status]}."
     rescue Faraday::UnprocessableEntityError => e
       redirect_to customs_tariff_update_path(params[:version]),
                   alert: "Could not update status: #{e.response[:body].dig('errors', 0, 'detail')}"
+    end
+
+    def reimport
+      @update = CustomsTariff::Update.find(params[:version])
+      authorize @update, :update?
+
+      CustomsTariff::Update.api.post(
+        "admin/customs_tariff_updates/#{params[:version]}/reimport",
+      )
+
+      redirect_to customs_tariff_updates_path, notice: "Re-import queued."
+    rescue Faraday::ResourceNotFound
+      redirect_to customs_tariff_updates_path, alert: "Update could not be found."
     end
   end
 end

--- a/app/controllers/versions_controller.rb
+++ b/app/controllers/versions_controller.rb
@@ -17,7 +17,7 @@ class VersionsController < AuthenticatedController
     version_data = response.body["data"]
     restored = Version.new((version_data["attributes"] || {}).merge("id" => version_data["id"])) if version_data
 
-    redirect_to (restored && version_item_link(restored)) || versions_path,
+    redirect_to chapter_note_restore_path || (restored && version_item_link(restored)) || versions_path,
                 notice: "Restored successfully."
   rescue Faraday::ResourceNotFound
     redirect_to versions_path, alert: "Version not found."
@@ -26,6 +26,12 @@ class VersionsController < AuthenticatedController
   end
 
 private
+
+  def chapter_note_restore_path
+    return unless params[:section_id].present? && params[:update_version].present?
+
+    customs_tariff_update_section_chapter_notes_path(params[:update_version], params[:section_id])
+  end
 
   def version_params
     filter = { page: params[:page] || 1 }

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -4,7 +4,7 @@ module VersionsHelper
     opts = oid ? { oid: oid } : {}
 
     case version.item_type
-    when "CustomsTariffSectionNote"
+    when "CustomsTariffSectionNote", "CustomsTariffChapterNote"
       update_version = version.object&.dig("customs_tariff_update_version")
       customs_tariff_update_path(update_version) if update_version.present?
     when "GoodsNomenclatureLabel"

--- a/app/models/customs_tariff/chapter_note.rb
+++ b/app/models/customs_tariff/chapter_note.rb
@@ -1,0 +1,37 @@
+module CustomsTariff
+  class ChapterNote
+    include ApiEntity
+
+    attributes :chapter_id, :content, :customs_tariff_update_version, :file_diff, :versions
+
+    set_singular_path   "admin/customs_tariff_updates/:customs_tariff_update_version/chapter_notes/:id"
+    set_collection_path "admin/customs_tariff_updates/:customs_tariff_update_version/chapter_notes"
+
+    def file_diff_status
+      return :new       if file_diff.nil?
+      return :unchanged if file_diff.respond_to?(:empty?) && file_diff.empty?
+
+      :changed
+    end
+
+    def has_changeset?
+      file_diff_status == :changed
+    end
+
+    def changes
+      return {} unless file_diff.is_a?(Hash)
+
+      file_diff["changes"] || {}
+    end
+
+    def preview
+      return if content.blank?
+
+      GovspeakPreview.new(TariffNoteFormatter.new(content).format).render
+    end
+
+    def version_objects
+      @version_objects ||= (versions || []).map { |v| Version.new(v.merge("resource_id" => v["id"])) }
+    end
+  end
+end

--- a/app/models/customs_tariff/section_summary.rb
+++ b/app/models/customs_tariff/section_summary.rb
@@ -1,0 +1,26 @@
+module CustomsTariff
+  class SectionSummary
+    include ApiEntity
+
+    attributes :section_id, :section_title, :position,
+               :section_note_id, :section_note_status,
+               :chapter_notes_total, :chapter_notes_changed
+
+    set_singular_path   "admin/customs_tariff_updates/:customs_tariff_update_version/sections_summary"
+    set_collection_path "admin/customs_tariff_updates/:customs_tariff_update_version/sections_summary"
+
+    def section_note_status_symbol
+      section_note_status&.to_sym
+    end
+
+    def chapter_notes_changed?
+      chapter_notes_changed.to_i.positive?
+    end
+
+    def chapter_note_summary_label
+      return "Unchanged" unless chapter_notes_changed?
+
+      "#{chapter_notes_changed} changed"
+    end
+  end
+end

--- a/app/policies/customs_tariff/chapter_note_policy.rb
+++ b/app/policies/customs_tariff/chapter_note_policy.rb
@@ -1,5 +1,5 @@
 module CustomsTariff
-  class SectionNotePolicy < ApplicationPolicy
+  class ChapterNotePolicy < ApplicationPolicy
     def create?  = technical_operator?
     def edit?    = technical_operator?
     def update?  = technical_operator?

--- a/app/views/customs_tariff/updates/chapter_notes/edit.html.erb
+++ b/app/views/customs_tariff/updates/chapter_notes/edit.html.erb
@@ -1,0 +1,66 @@
+<h2>Edit Chapter <%= @chapter_note.chapter_id %> Note</h2>
+
+<p class="govuk-body">
+  Update version: <%= @update.version %>
+  &nbsp;
+  <%= link_to 'Back to chapter notes',
+        customs_tariff_update_section_chapter_notes_path(@update.version, @section_id),
+        class: 'govuk-link' %>
+</p>
+
+<% if @update.rejected? %>
+  <%= govuk_inset_text do %>
+    This file has been rejected. To edit individual notes, set it back to pending.
+  <% end %>
+<% else %>
+  <div class="govuk-grid-row"
+       data-controller="tariff-note-preview"
+       data-tariff-note-preview-url-value="<%= customs_tariff_chapter_note_preview_path %>">
+    <div class="govuk-grid-column-one-half">
+      <%= form_with model: @chapter_note,
+                    url: customs_tariff_update_chapter_note_path(@update.version, @chapter_note.id),
+                    method: :patch do |f| %>
+        <%= hidden_field_tag :section_id, @section_id %>
+        <div class="govuk-form-group">
+          <%= f.label :content, 'Content', class: 'govuk-label govuk-label--m' %>
+          <%= f.text_area :content, rows: 20, class: 'govuk-textarea',
+                          data: { tariff_note_preview_target: 'content',
+                                  action: 'input->tariff-note-preview#update' } %>
+        </div>
+        <div class="govuk-button-group">
+          <%= f.submit 'Save', class: 'govuk-button' %>
+          <%= link_to 'Cancel',
+                customs_tariff_update_section_chapter_notes_path(@update.version, @section_id),
+                class: 'govuk-link' %>
+        </div>
+      <% end %>
+    </div>
+
+    <div class="govuk-grid-column-one-half">
+      <h2 class="govuk-heading-m">Preview</h2>
+      <div class="govuk-body" data-tariff-note-preview-target="preview">
+        <%= @chapter_note.preview %>
+      </div>
+    </div>
+  </div>
+<% end %>
+
+<% if policy(@chapter_note).destroy? %>
+  <h3>Remove chapter note</h3>
+
+  <p>Remove this chapter note</p>
+
+  <%= link_to "Remove",
+              customs_tariff_update_chapter_note_path(@update.version, @chapter_note.id, section_id: @section_id),
+              method: :delete,
+              data: { confirm: 'Are you sure?', disable: 'Working' },
+              class: 'govuk-button govuk-button--warning' %>
+<% end %>
+
+<% if @chapter_note.version_objects.any? %>
+  <%= render 'versions/history_section',
+        versions: @chapter_note.version_objects,
+        can_restore: policy(@chapter_note).update?,
+        view_path_helper: nil,
+        restore_path_helper: ->(v) { restore_version_path(v.resource_id, section_id: @section_id, update_version: @update.version) } %>
+<% end %>

--- a/app/views/customs_tariff/updates/chapter_notes/index.html.erb
+++ b/app/views/customs_tariff/updates/chapter_notes/index.html.erb
@@ -1,0 +1,79 @@
+<p class="govuk-body">
+  <%= govuk_back_link(
+    text: "Back to update #{@update.version}",
+    href: customs_tariff_update_path(@update.version)
+  ) %>
+</p>
+
+<h2>Chapter Notes &mdash; <%= @section.title %></h2>
+<p class="govuk-body">Update version: <%= @update.version %></p>
+
+<% if @update.rejected? %>
+  <%= govuk_inset_text do %>
+    This file has been rejected. To edit individual notes, set it back to pending.
+  <% end %>
+<% end %>
+
+<%= govuk_table do |table|
+  table.with_head do |head|
+    head.with_row do |row|
+      row.with_cell(text: 'Chapter')
+      row.with_cell(text: 'Headings')
+      row.with_cell(text: 'Description')
+      row.with_cell(text: 'Change')
+      row.with_cell(text: 'Actions')
+    end
+  end
+
+  table.with_body do |body|
+    @rows.each do |chapter_code, note|
+      chapter = @chapter_info[chapter_code]
+
+      body.with_row do |row|
+        row.with_cell(text: chapter_code)
+        row.with_cell(text: chapter&.headings_range)
+        row.with_cell(text: chapter&.description&.titleize)
+        if note
+          chip_colour = { new: 'blue', changed: 'orange', unchanged: 'grey' }.fetch(note.file_diff_status, 'grey')
+          row.with_cell do
+            tag.strong(note.file_diff_status.to_s.capitalize, class: "govuk-tag govuk-tag--#{chip_colour}")
+          end
+          row.with_cell do
+            if !@update.rejected? && policy(note).edit?
+              if @compare_version.present? && note.file_diff_status == :changed
+                link_to 'View diff',
+                        customs_tariff_update_comparison_chapter_note_path(
+                          @update.version, note.id,
+                          compare_version: @compare_version,
+                          section_id: @section_id,
+                        ),
+                        class: 'govuk-link'
+              else
+                link_to 'View/Edit',
+                        edit_customs_tariff_update_chapter_note_path(
+                          @update.version, note.id,
+                          section_id: @section_id,
+                          compare_version: @compare_version,
+                        ),
+                        class: 'govuk-link'
+              end
+            end
+          end
+        else
+          row.with_cell
+          row.with_cell do
+            if !@update.rejected? && policy(CustomsTariff::ChapterNote.new(customs_tariff_update_version: @update.version, chapter_id: chapter_code)).create?
+              link_to "Add",
+                      new_customs_tariff_update_chapter_note_path(
+                        @update.version,
+                        chapter_id: chapter_code,
+                        section_id: @section_id,
+                      ),
+                      class: "govuk-link"
+            end
+          end
+        end
+      end
+    end
+  end
+end %>

--- a/app/views/customs_tariff/updates/chapter_notes/new.html.erb
+++ b/app/views/customs_tariff/updates/chapter_notes/new.html.erb
@@ -1,0 +1,36 @@
+<h2>Add Chapter <%= @chapter_id %> Note</h2>
+
+<p class="govuk-body">
+  Update version: <%= @update.version %>
+  &nbsp;
+  <%= link_to 'Back to chapter notes', customs_tariff_update_section_chapter_notes_path(@update.version, @section_id), class: 'govuk-link' %>
+</p>
+
+<div class="govuk-grid-row"
+     data-controller="tariff-note-preview"
+     data-tariff-note-preview-url-value="<%= customs_tariff_chapter_note_preview_path %>">
+  <div class="govuk-grid-column-one-half">
+    <%= form_with model: @chapter_note,
+                  url: customs_tariff_update_chapter_notes_path(@update.version),
+                  method: :post do |f| %>
+      <%= hidden_field_tag :chapter_id, @chapter_id %>
+      <%= hidden_field_tag :section_id, @section_id %>
+      <div class="govuk-form-group">
+        <%= f.label :content, 'Content', class: 'govuk-label govuk-label--m' %>
+        <%= f.text_area :content, rows: 20, class: 'govuk-textarea',
+                        data: { tariff_note_preview_target: 'content',
+                                action: 'input->tariff-note-preview#update' } %>
+      </div>
+      <div class="govuk-button-group">
+        <%= f.submit 'Save', class: 'govuk-button' %>
+        <%= link_to 'Cancel', customs_tariff_update_section_chapter_notes_path(@update.version, @section_id), class: 'govuk-link' %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">Preview</h2>
+    <div class="govuk-body" data-tariff-note-preview-target="preview">
+    </div>
+  </div>
+</div>

--- a/app/views/customs_tariff/updates/comparisons/index.html.erb
+++ b/app/views/customs_tariff/updates/comparisons/index.html.erb
@@ -10,6 +10,7 @@
       row.with_cell(text: "Section")
       row.with_cell(text: "Change")
       row.with_cell(text: "Actions")
+      row.with_cell(text: "Chapter Notes")
     end
   end
 
@@ -23,14 +24,26 @@
           tag.strong(note.file_diff_status.to_s.capitalize, class: "govuk-tag govuk-tag--#{chip_colour}")
         end
         row.with_cell do
-          unless note.file_diff_status == :new || note.file_diff_status == :unchanged
+          if note.file_diff_status == :changed
             link_to "View diff",
                     customs_tariff_update_comparison_section_note_path(
                       @update.version, note.id,
                       compare_version: @compare_version
                     ),
                     class: "govuk-link"
+          else
+            link_to "View/Edit",
+                    edit_customs_tariff_update_section_note_path(@update.version, note.id),
+                    class: "govuk-link"
           end
+        end
+        row.with_cell do
+          link_to "View chapter notes",
+                  customs_tariff_update_section_chapter_notes_path(
+                    @update.version, note.section_id,
+                    compare_version: @compare_version
+                  ),
+                  class: "govuk-link"
         end
       end
     end

--- a/app/views/customs_tariff/updates/comparisons/show_chapter_note.html.erb
+++ b/app/views/customs_tariff/updates/comparisons/show_chapter_note.html.erb
@@ -1,0 +1,27 @@
+<p class="govuk-body">
+  <%= govuk_back_link(
+    text: "Back to chapter notes",
+    href: customs_tariff_update_section_chapter_notes_path(
+      @update.version, @section_id, compare_version: @compare_version
+    )
+  ) %>
+</p>
+
+<h2>Chapter <%= @chapter_note.chapter_id %> &mdash; <%= @update.version %> compared against <%= @compare_version %></h2>
+
+<% if @chapter_note.has_changeset? %>
+  <%= side_by_side_diff_html(@chapter_note, from_version: @compare_version, to_version: @update.version) %>
+<% else %>
+  <%= govuk_inset_text do %>
+    No changes in chapter <%= @chapter_note.chapter_id %> between <%= @update.version %> and <%= @compare_version %>.
+  <% end %>
+<% end %>
+
+<% if !@update.rejected? && policy(@chapter_note).edit? %>
+  <p class="govuk-body">
+    <%= link_to "Edit this note",
+          edit_customs_tariff_update_chapter_note_path(@update.version, @chapter_note.id,
+            section_id: @section_id, compare_version: @compare_version),
+          class: "govuk-link" %>
+  </p>
+<% end %>

--- a/app/views/customs_tariff/updates/index.html.erb
+++ b/app/views/customs_tariff/updates/index.html.erb
@@ -8,6 +8,7 @@
       row.with_cell(text: 'Valid to')
       row.with_cell(text: 'Status')
       row.with_cell(text: 'Actions')
+      row.with_cell(text: '')
     end
   end
 
@@ -21,7 +22,16 @@
           tag.strong(update.status.capitalize, class: "govuk-tag govuk-tag--#{update.status_tag_colour}")
         end
         row.with_cell do
-          link_to 'Review', customs_tariff_update_path(update.version), class: 'govuk-link'
+          link_to('Review', customs_tariff_update_path(update.version), class: 'govuk-link')
+        end
+        row.with_cell do
+          if policy(update).update?
+            button_to('Re-import',
+                               reimport_customs_tariff_update_path(update.version),
+                               method: :post,
+                               class: 'govuk-button govuk-button--secondary govuk-!-margin-bottom-0',
+                               data: { confirm: 'This will reset all notes for this update to their originally imported content. Are you sure?' })
+          end
         end
       end
     end

--- a/app/views/customs_tariff/updates/section_notes/new.html.erb
+++ b/app/views/customs_tariff/updates/section_notes/new.html.erb
@@ -1,4 +1,4 @@
-<h2> Edit Section <%= @section_note.section_id %> Note </h2>
+<h2>Add Section <%= @section_id %> Note</h2>
 
 <p class="govuk-body">
   Update version: <%= @update.version %>
@@ -11,8 +11,9 @@
      data-tariff-note-preview-url-value="<%= customs_tariff_section_note_preview_path %>">
   <div class="govuk-grid-column-one-half">
     <%= form_with model: @section_note,
-                  url: customs_tariff_update_section_note_path(@update.version, @section_note.id),
-                  method: :patch do |f| %>
+                  url: customs_tariff_update_section_notes_path(@update.version),
+                  method: :post do |f| %>
+      <%= hidden_field_tag :section_id, @section_id %>
       <div class="govuk-form-group">
         <%= f.label :content, 'Content', class: 'govuk-label govuk-label--m' %>
         <%= f.text_area :content, rows: 20, class: 'govuk-textarea',
@@ -29,26 +30,6 @@
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-m">Preview</h2>
     <div class="govuk-body" data-tariff-note-preview-target="preview">
-      <%= @section_note.preview %>
     </div>
   </div>
 </div>
-
-<% if policy(@section_note).destroy? %>
-  <h3>Remove section note</h3>
-
-  <p>Remove this section note</p>
-  <%= link_to "Remove",
-              customs_tariff_update_section_note_path(@update.version, @section_note.id),
-              method: :delete,
-              data: { confirm: 'Are you sure?', disable: 'Working' },
-              class: 'govuk-button govuk-button--warning' %>
-<% end %>
-
-<% if @section_note.version_objects.any? %>
-  <%= render 'versions/history_section',
-        versions: @section_note.version_objects,
-        can_restore: policy(@section_note).update?,
-        view_path_helper: nil,
-        restore_path_helper: ->(v) { restore_version_path(v.resource_id) } %>
-<% end %>

--- a/app/views/customs_tariff/updates/show.html.erb
+++ b/app/views/customs_tariff/updates/show.html.erb
@@ -56,38 +56,79 @@
   <%= f.submit "Compare", class: "govuk-button govuk-button--secondary" %>
 <% end %>
 
+<p class="govuk-body govuk-hint">
+  <% if @baseline_version %>
+    Comparing notes against version <%= @baseline_version %> (previous version).
+    To compare against a different version, use the form above.
+  <% else %>
+    No previous version found — notes shown without a comparison baseline.
+  <% end %>
+</p>
+
 <h2 class="govuk-heading-m">Section Notes</h2>
 
 <%= govuk_table do |table|
   table.with_head do |head|
     head.with_row do |row|
       row.with_cell(text: 'Section')
-      row.with_cell(text: 'Change')
+      row.with_cell(text: 'Section Note')
       row.with_cell(text: 'Actions')
+      row.with_cell(text: 'Chapter Notes')
     end
   end
 
   table.with_body do |body|
-    @section_notes.each do |note|
-      chip_colour = { new: 'blue', changed: 'orange', unchanged: 'grey' }.fetch(note.file_diff_status, 'grey')
+    @section_summaries.each do |summary|
+      chip_colour = { new: 'blue', changed: 'orange', unchanged: 'grey', absent: 'grey' }
+                      .fetch(summary.section_note_status_symbol, 'grey')
 
       body.with_row do |row|
-        row.with_cell(text: "Section #{note.section_id}")
+        row.with_cell(text: "Section #{summary.section_id}")
         row.with_cell do
-          tag.strong(note.file_diff_status.to_s.capitalize, class: "govuk-tag govuk-tag--#{chip_colour}")
-        end
-        row.with_cell do
-          if !@update.rejected? && policy(note).edit?
-            link_to 'Edit',
-                    edit_customs_tariff_update_section_note_path(@update.version, note.id),
-                    class: 'govuk-link'
+          if summary.section_note_status_symbol == :absent
+            "—"
+          else
+            tag.strong(summary.section_note_status.capitalize, class: "govuk-tag govuk-tag--#{chip_colour}")
           end
         end
-      end
-
-      if note.file_diff_status == :changed
-        body.with_row do |row|
-          row.with_cell(colspan: 3) { changeset_detail_html(note) }
+        row.with_cell do
+          if !@update.rejected? && summary.section_note_id.present?
+            note_stub = CustomsTariff::SectionNote.new(
+              id: summary.section_note_id,
+              customs_tariff_update_version: @update.version
+            )
+            if policy(note_stub).edit?
+              if summary.section_note_status_symbol == :changed && @baseline_version.present?
+                link_to 'View diff',
+                        customs_tariff_update_comparison_section_note_path(
+                          @update.version, summary.section_note_id,
+                          compare_version: @baseline_version
+                        ),
+                        class: 'govuk-link'
+              else
+                link_to 'View/Edit',
+                        edit_customs_tariff_update_section_note_path(@update.version, summary.section_note_id),
+                        class: 'govuk-link'
+              end
+            end
+          elsif !@update.rejected? && summary.section_note_status_symbol == :absent
+            if policy(CustomsTariff::SectionNote.new(customs_tariff_update_version: @update.version, section_id: summary.section_id)).create?
+              link_to 'Add',
+                      new_customs_tariff_update_section_note_path(
+                        @update.version, section_id: summary.section_id
+                      ),
+                      class: 'govuk-link'
+            end
+          end
+        end
+        row.with_cell do
+          chapter_colour = summary.chapter_notes_changed? ? 'orange' : 'grey'
+          link_to summary.chapter_note_summary_label,
+                  customs_tariff_update_section_chapter_notes_path(
+                    @update.version, summary.section_id,
+                    compare_version: @baseline_version,
+                  ),
+                  class: "govuk-link govuk-tag govuk-tag--#{chapter_colour}"
         end
       end
     end

--- a/app/views/versions/_history_table.html.erb
+++ b/app/views/versions/_history_table.html.erb
@@ -43,7 +43,7 @@
         <td class="govuk-table__cell" style="<%= cell_style %>"><%= version.created_at_formatted %></td>
         <% if defined?(can_restore) && can_restore %>
           <td class="govuk-table__cell" style="<%= cell_style %>">
-            <% unless index == 0 %>
+            <% unless version.event == 'create' %>
               <%= button_to "Restore",
                             restore_path_helper.call(version),
                             method: :post,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,18 +166,40 @@ Rails.application.routes.draw do
   scope path: "customs_tariff", module: "customs_tariff" do
     get  "updates", to: "updates#index", as: :customs_tariff_updates
     post "updates/section_notes/preview", to: "updates/section_notes#preview", as: :customs_tariff_section_note_preview
+    post "updates/chapter_notes/preview", to: "updates/chapter_notes#preview", as: :customs_tariff_chapter_note_preview
 
     constraints(version: /[^\/]+/) do
       get   "updates/:version",               to: "updates#show",          as: :customs_tariff_update
       patch "updates/:version/update_status", to: "updates#update_status", as: :update_status_customs_tariff_update
       get   "updates/:version/compare",       to: "updates/comparisons#index", as: :customs_tariff_update_comparison
+      post  "updates/:version/reimport",      to: "updates#reimport",      as: :reimport_customs_tariff_update
     end
 
     constraints(update_version: /[^\/]+/) do
+      get  "updates/:update_version/section_notes/new",
+           to: "updates/section_notes#new",
+           as: :new_customs_tariff_update_section_note
+      post "updates/:update_version/section_notes",
+           to: "updates/section_notes#create",
+           as: :customs_tariff_update_section_notes
       get   "updates/:update_version/section_notes/:id/edit", to: "updates/section_notes#edit",   as: :edit_customs_tariff_update_section_note
       patch "updates/:update_version/section_notes/:id",      to: "updates/section_notes#update", as: :customs_tariff_update_section_note
-      put   "updates/:update_version/section_notes/:id",      to: "updates/section_notes#update"
+      put    "updates/:update_version/section_notes/:id",      to: "updates/section_notes#update"
+      delete "updates/:update_version/section_notes/:id",      to: "updates/section_notes#destroy"
       get   "updates/:update_version/compare/section_notes/:id", to: "updates/comparisons#show", as: :customs_tariff_update_comparison_section_note
+      get   "updates/:update_version/compare/chapter_notes/:id", to: "updates/comparisons#show_chapter_note", as: :customs_tariff_update_comparison_chapter_note
+
+      get  "updates/:update_version/chapter_notes/new",
+           to: "updates/chapter_notes#new",
+           as: :new_customs_tariff_update_chapter_note
+      post "updates/:update_version/chapter_notes",
+           to: "updates/chapter_notes#create",
+           as: :customs_tariff_update_chapter_notes
+      get   "updates/:update_version/sections/:section_id/chapter_notes", to: "updates/chapter_notes#index",  as: :customs_tariff_update_section_chapter_notes
+      get   "updates/:update_version/chapter_notes/:id/edit",             to: "updates/chapter_notes#edit",   as: :edit_customs_tariff_update_chapter_note
+      patch  "updates/:update_version/chapter_notes/:id",                  to: "updates/chapter_notes#update", as: :customs_tariff_update_chapter_note
+      put    "updates/:update_version/chapter_notes/:id",                  to: "updates/chapter_notes#update"
+      delete "updates/:update_version/chapter_notes/:id",                  to: "updates/chapter_notes#destroy"
     end
   end
 

--- a/spec/models/customs_tariff/chapter_note_spec.rb
+++ b/spec/models/customs_tariff/chapter_note_spec.rb
@@ -1,0 +1,71 @@
+RSpec.describe CustomsTariff::ChapterNote do
+  subject(:chapter_note) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      chapter_id: "01",
+      content: "Chapter note content",
+      customs_tariff_update_version: "1.31",
+      file_diff: nil,
+      versions: [],
+    }
+  end
+
+  describe "#file_diff_status" do
+    it "returns :new when file_diff is nil" do
+      expect(chapter_note.file_diff_status).to eq(:new)
+    end
+
+    it "returns :unchanged when file_diff is empty" do
+      chapter_note.file_diff = []
+      expect(chapter_note.file_diff_status).to eq(:unchanged)
+    end
+
+    it "returns :changed when file_diff has entries" do
+      chapter_note.file_diff = [{ "type" => "change", "value" => "updated text" }]
+      expect(chapter_note.file_diff_status).to eq(:changed)
+    end
+  end
+
+  describe "#preview" do
+    it "returns nil when content is blank" do
+      chapter_note.content = ""
+      expect(chapter_note.preview).to be_nil
+    end
+
+    it "passes content through TariffNoteFormatter then GovspeakPreview" do
+      formatter = instance_double(TariffNoteFormatter, format: "formatted content")
+      renderer  = instance_double(GovspeakPreview, render: "<p>formatted content</p>")
+      allow(TariffNoteFormatter).to receive(:new).with("Chapter note content").and_return(formatter)
+      allow(GovspeakPreview).to receive(:new).with("formatted content").and_return(renderer)
+
+      expect(chapter_note.preview).to eq("<p>formatted content</p>")
+    end
+  end
+
+  describe "#version_objects" do
+    it "returns an empty array when versions is nil" do
+      chapter_note.versions = nil
+      expect(chapter_note.version_objects).to eq([])
+    end
+
+    it "maps each version hash to a Version with resource_id from the id key", :aggregate_failures do
+      chapter_note.versions = [{ "id" => 42, "event" => "update", "object" => {} }]
+      version = chapter_note.version_objects.first
+
+      expect(version).to be_a(Version)
+      expect(version.resource_id).to eq(42)
+    end
+  end
+
+  describe "#has_changeset?" do
+    it "returns true when file_diff has changed_fields" do
+      chapter_note.file_diff = { "changed_fields" => %w[content], "changes" => {} }
+      expect(chapter_note.has_changeset?).to be true
+    end
+
+    it "returns false when file_diff is nil" do
+      expect(chapter_note.has_changeset?).to be false
+    end
+  end
+end

--- a/spec/models/customs_tariff/section_summary_spec.rb
+++ b/spec/models/customs_tariff/section_summary_spec.rb
@@ -1,0 +1,48 @@
+RSpec.describe CustomsTariff::SectionSummary do
+  subject(:summary) { described_class.new(attributes) }
+
+  let(:attributes) do
+    {
+      section_id: 1,
+      section_title: "Live animals; animal products",
+      position: 1,
+      section_note_id: nil,
+      section_note_status: "absent",
+      chapter_notes_total: 5,
+      chapter_notes_changed: 2,
+    }
+  end
+
+  describe "#chapter_notes_changed?" do
+    it "returns true when chapter_notes_changed is greater than zero" do
+      expect(summary.chapter_notes_changed?).to be true
+    end
+
+    it "returns false when chapter_notes_changed is zero" do
+      summary.chapter_notes_changed = 0
+      expect(summary.chapter_notes_changed?).to be false
+    end
+  end
+
+  describe "#chapter_note_summary_label" do
+    it "returns 'N changed' when chapters have changed" do
+      expect(summary.chapter_note_summary_label).to eq("2 changed")
+    end
+
+    it "returns 'Unchanged' when no chapters changed" do
+      summary.chapter_notes_changed = 0
+      expect(summary.chapter_note_summary_label).to eq("Unchanged")
+    end
+  end
+
+  describe "#section_note_status_symbol" do
+    it "returns the status as a symbol" do
+      expect(summary.section_note_status_symbol).to eq(:absent)
+    end
+
+    it "returns nil when section_note_status is nil" do
+      summary.section_note_status = nil
+      expect(summary.section_note_status_symbol).to be_nil
+    end
+  end
+end

--- a/spec/policies/customs_tariff/chapter_note_policy_spec.rb
+++ b/spec/policies/customs_tariff/chapter_note_policy_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe CustomsTariff::ChapterNotePolicy do
+  subject(:policy) { described_class }
+
+  let(:chapter_note) { CustomsTariff::ChapterNote.new(chapter_id: "01") }
+
+  permissions :edit?, :update? do
+    it "grants access to technical operator" do
+      expect(policy).to permit(create(:user, :technical_operator), chapter_note)
+    end
+
+    it "denies access to auditor" do
+      expect(policy).not_to permit(create(:user, :auditor), chapter_note)
+    end
+
+    it "denies access to hmrc admin" do
+      expect(policy).not_to permit(create(:user, :hmrc_admin), chapter_note)
+    end
+
+    it "denies access to guest" do
+      expect(policy).not_to permit(create(:user, :guest), chapter_note)
+    end
+  end
+end

--- a/spec/requests/customs_tariff/updates/chapter_notes_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates/chapter_notes_controller_spec.rb
@@ -1,0 +1,446 @@
+# rubocop:disable RSpec/MultipleMemoizedHelpers
+RSpec.describe CustomsTariff::Updates::ChapterNotesController, type: :request do
+  subject(:rendered_page) { make_request && response }
+
+  before { TradeTariffAdmin::ServiceChooser.service_choice = "uk" }
+
+  let(:update_version) { "1.31" }
+  let(:section_id)     { "3" }
+
+  let(:update_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: {
+          type: "customs_tariff_update",
+          id: update_version,
+          attributes: {
+            "version" => update_version,
+            "status" => "pending",
+            "validity_start_date" => "2026-01-01",
+            "validity_end_date" => nil,
+            "source_url" => "https://example.com/doc.pdf",
+            "document_created_on" => "2026-01-01",
+            "created_at" => "2026-01-01T00:00:00Z",
+            "updated_at" => "2026-01-01T00:00:00Z",
+          },
+        },
+      }.to_json,
+    }
+  end
+
+  let(:chapter_notes_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: [
+          {
+            type: "customs_tariff_chapter_note",
+            id: "101",
+            attributes: {
+              "chapter_id" => "15",
+              "content" => "## Chapter 15\n\nSome content.",
+              "customs_tariff_update_version" => update_version,
+              "file_diff" => nil,
+              "versions" => [],
+            },
+          },
+        ],
+      }.to_json,
+    }
+  end
+
+  let(:chapter_note_id) { "101" }
+
+  let(:chapter_note_attributes) do
+    {
+      "chapter_id" => "15",
+      "content" => "## Chapter 15\n\nSome content.",
+      "customs_tariff_update_version" => update_version,
+      "file_diff" => nil,
+      "versions" => [],
+    }
+  end
+
+  let(:chapter_note_response) do
+    {
+      status: 200,
+      headers: { "content-type" => "application/json; charset=utf-8" },
+      body: {
+        data: {
+          type: "customs_tariff_chapter_note",
+          id: chapter_note_id,
+          attributes: chapter_note_attributes,
+        },
+      }.to_json,
+    }
+  end
+
+  describe "GET #index" do
+    let(:make_request) do
+      get customs_tariff_update_section_chapter_notes_path(update_version, section_id)
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/sections/#{section_id}")
+        .and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: {
+            data: {
+              type: "section",
+              id: section_id,
+              attributes: { "title" => "Section #{section_id}", "position" => section_id.to_i },
+              relationships: { chapters: { data: [] } },
+            },
+          }.to_json,
+        )
+      stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes")
+        .with(query: hash_including("section_id" => section_id))
+        .and_return(chapter_notes_response)
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:index) }
+
+    context "when compare_version is present and a note has changed" do
+      let(:compare_version) { "1.30" }
+
+      let(:changed_notes_response) do
+        {
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: {
+            data: [
+              {
+                type: "customs_tariff_chapter_note",
+                id: "101",
+                attributes: {
+                  "chapter_id" => "15",
+                  "content" => "## Chapter 15\n\nUpdated content.",
+                  "customs_tariff_update_version" => update_version,
+                  "file_diff" => {
+                    "changed_fields" => %w[content],
+                    "changes" => { "content" => { "type" => "text", "diff" => [] } },
+                  },
+                  "versions" => [],
+                },
+              },
+            ],
+          }.to_json,
+        }
+      end
+
+      let(:make_request) do
+        get customs_tariff_update_section_chapter_notes_path(update_version, section_id),
+            params: { compare_version: }
+      end
+
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}")
+          .and_return(update_response)
+        stub_api_request("/sections/#{section_id}")
+          .and_return(
+            status: 200,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              data: {
+                type: "section",
+                id: section_id,
+                attributes: { "title" => "Section #{section_id}", "position" => section_id.to_i },
+                relationships: { chapters: { data: [] } },
+              },
+            }.to_json,
+          )
+        stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes")
+          .with(query: hash_including("section_id" => section_id, "compare_version" => compare_version))
+          .and_return(changed_notes_response)
+      end
+
+      it "renders a View diff link for the changed note", :aggregate_failures do
+        make_request
+        expect(response.body).to include("View diff")
+        expect(response.body).to include(
+          customs_tariff_update_comparison_chapter_note_path(update_version, "101"),
+        )
+      end
+
+      it "does not render the inline changeset detail row" do
+        make_request
+        expect(response.body).not_to include("diff-field")
+      end
+    end
+
+    context "when a section has a chapter with no corresponding note" do
+      let(:absent_chapter_id) { "03" }
+
+      let(:section_with_chapter_response) do
+        {
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: {
+            data: {
+              type: "section",
+              id: section_id,
+              attributes: { "title" => "Section #{section_id}", "position" => section_id.to_i },
+              relationships: {
+                chapters: { data: [{ "type" => "chapter", "id" => "#{absent_chapter_id}00000000" }] },
+              },
+            },
+            included: [
+              {
+                type: "chapter",
+                id: "#{absent_chapter_id}00000000",
+                attributes: {
+                  "goods_nomenclature_item_id" => "#{absent_chapter_id}00000000",
+                  "headings_from" => "#{absent_chapter_id}01",
+                  "headings_to" => "#{absent_chapter_id}99",
+                  "description" => "Chapter #{absent_chapter_id}",
+                },
+              },
+            ],
+          }.to_json,
+        }
+      end
+
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}").and_return(update_response)
+        stub_api_request("/sections/#{section_id}").and_return(section_with_chapter_response)
+        stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes")
+          .with(query: hash_including("section_id" => section_id))
+          .and_return(
+            status: 200,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: { data: [] }.to_json,
+          )
+        get customs_tariff_update_section_chapter_notes_path(update_version, section_id)
+      end
+
+      it "includes the Add link URL for the absent chapter" do
+        expected_path = CGI.escapeHTML(new_customs_tariff_update_chapter_note_path(update_version, chapter_id: absent_chapter_id, section_id:))
+        expect(response.body).to include(expected_path)
+      end
+
+      it "renders the Add link text for the absent chapter" do
+        expect(response.body).to match(/>\s*Add\s*</)
+      end
+    end
+  end
+
+  describe "GET #new" do
+    let(:chapter_id) { "03" }
+
+    let(:make_request) do
+      get new_customs_tariff_update_chapter_note_path(update_version),
+          params: { chapter_id:, section_id: }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:new) }
+  end
+
+  describe "POST #create" do
+    let(:chapter_id) { "03" }
+
+    let(:make_request) do
+      post customs_tariff_update_chapter_notes_path(update_version),
+           params: {
+             customs_tariff_chapter_note: { content: "New chapter note content." },
+             chapter_id:,
+             section_id:,
+           }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+    end
+
+    context "when the backend accepts the create" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes", :post)
+          .and_return(
+            status: 201,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              data: {
+                type: "customs_tariff_chapter_note",
+                id: "201",
+                attributes: {
+                  "chapter_id" => chapter_id,
+                  "content" => "New chapter note content.",
+                  "customs_tariff_update_version" => update_version,
+                  "file_diff" => nil,
+                  "versions" => [],
+                },
+              },
+            }.to_json,
+          )
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_section_chapter_notes_path(update_version, section_id)) }
+
+      it "sets a success flash notice" do
+        make_request
+        expect(session.dig("flash", "flashes", "notice")).to eq("Chapter note added.")
+      end
+    end
+
+    context "when the backend rejects the create with a 422" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes", :post)
+          .and_return(
+            status: 422,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: { errors: [{ detail: "Chapter can't be blank" }] }.to_json,
+          )
+      end
+
+      it { is_expected.to have_http_status(:unprocessable_content) }
+      it { is_expected.to render_template(:new) }
+    end
+  end
+
+  describe "GET #edit" do
+    let(:make_request) do
+      get edit_customs_tariff_update_chapter_note_path(update_version, chapter_note_id),
+          params: { section_id: }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes/#{chapter_note_id}")
+        .with(query: hash_including("customs_tariff_update_version" => update_version))
+        .and_return(chapter_note_response)
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:edit) }
+  end
+
+  describe "PATCH #update" do
+    let(:make_request) do
+      patch customs_tariff_update_chapter_note_path(update_version, chapter_note_id),
+            params: {
+              customs_tariff_chapter_note: { content: "Updated content." },
+              section_id:,
+            }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes/#{chapter_note_id}")
+        .with(query: hash_including("customs_tariff_update_version" => update_version))
+        .and_return(chapter_note_response)
+    end
+
+    context "when the backend accepts the update" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes/#{chapter_note_id}", :patch)
+          .and_return(
+            status: 200,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              data: {
+                type: "customs_tariff_chapter_note",
+                id: chapter_note_id,
+                attributes: chapter_note_attributes.merge("content" => "Updated content."),
+              },
+            }.to_json,
+          )
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_section_chapter_notes_path(update_version, section_id)) }
+
+      it "sets a success flash notice" do
+        make_request
+        expect(session.dig("flash", "flashes", "notice")).to eq("Chapter note updated.")
+      end
+    end
+
+    context "when the backend rejects the update with a 422" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes/#{chapter_note_id}", :patch)
+          .and_return(
+            status: 422,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              errors: [
+                { source: { pointer: "/data/attributes/content" }, detail: "is invalid" },
+              ],
+            }.to_json,
+          )
+      end
+
+      it { is_expected.to render_template(:edit) }
+    end
+  end
+
+  describe "POST #preview" do
+    let(:make_request) do
+      post customs_tariff_chapter_note_preview_path, params: { content: "some markdown" }
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+
+    it "returns JSON with an html key" do
+      json = JSON.parse(rendered_page.body)
+      expect(json).to have_key("html")
+    end
+  end
+
+  describe "DELETE #destroy" do
+    let(:make_request) do
+      delete customs_tariff_update_chapter_note_path(update_version, chapter_note_id),
+             params: { section_id: }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes/#{chapter_note_id}")
+        .with(query: hash_including("customs_tariff_update_version" => update_version))
+        .and_return(chapter_note_response)
+    end
+
+    context "when the backend accepts the delete" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes/#{chapter_note_id}", :delete)
+          .and_return(status: 204, body: "", headers: {})
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_section_chapter_notes_path(update_version, section_id)) }
+
+      it "sets a success flash notice" do
+        make_request
+        expect(session.dig("flash", "flashes", "notice")).to eq("Chapter note removed.")
+      end
+    end
+
+    context "when the backend returns 404" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes/#{chapter_note_id}", :delete)
+          .and_return(status: 404, body: "", headers: {})
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_section_chapter_notes_path(update_version, section_id)) }
+
+      it "sets an alert flash" do
+        make_request
+        expect(session.dig("flash", "flashes", "alert")).to eq("Chapter note could not be found.")
+      end
+    end
+  end
+end
+# rubocop:enable RSpec/MultipleMemoizedHelpers

--- a/spec/requests/customs_tariff/updates/comparisons_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates/comparisons_controller_spec.rb
@@ -105,6 +105,62 @@ RSpec.describe CustomsTariff::Updates::ComparisonsController, type: :request do
     end
   end
 
+  describe "GET #show_chapter_note" do
+    let(:chapter_note_id) { "2164" }
+
+    let(:chapter_note_attributes) do
+      {
+        "chapter_id" => "41",
+        "content" => "## Chapter 41\n\nSome content.",
+        "customs_tariff_update_version" => update_version,
+        "file_diff" => { "changed_fields" => %w[content], "changes" => {} },
+        "versions" => [],
+      }
+    end
+
+    let(:chapter_note_response) do
+      {
+        status: 200,
+        headers: { "content-type" => "application/json; charset=utf-8" },
+        body: {
+          data: {
+            type: "customs_tariff_chapter_note",
+            id: chapter_note_id,
+            attributes: chapter_note_attributes,
+          },
+        }.to_json,
+      }
+    end
+
+    let(:make_request) do
+      get customs_tariff_update_comparison_chapter_note_path(update_version, chapter_note_id),
+          params: { compare_version:, section_id: "8" }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/chapter_notes/#{chapter_note_id}")
+        .with(query: hash_including(
+          "customs_tariff_update_version" => update_version,
+          "compare_version" => compare_version,
+        ))
+        .and_return(chapter_note_response)
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:show_chapter_note) }
+
+    context "when compare_version param is missing" do
+      let(:make_request) do
+        get customs_tariff_update_comparison_chapter_note_path(update_version, chapter_note_id),
+            params: { section_id: "8" }
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+    end
+  end
+
   describe "GET #index" do
     let(:make_request) do
       get customs_tariff_update_comparison_path(update_version),

--- a/spec/requests/customs_tariff/updates/section_notes_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates/section_notes_controller_spec.rb
@@ -132,6 +132,34 @@ RSpec.describe CustomsTariff::Updates::SectionNotesController, type: :request do
     end
   end
 
+  describe "DELETE #destroy" do
+    let(:make_request) do
+      delete customs_tariff_update_section_note_path(update_version, section_note_id)
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+      stub_api_request("/customs_tariff_updates/#{update_version}/section_notes/#{section_note_id}")
+        .with(query: hash_including("customs_tariff_update_version" => update_version))
+        .and_return(section_note_response)
+    end
+
+    context "when the backend accepts the delete" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/section_notes/#{section_note_id}", :delete)
+          .and_return(status: 204, body: "", headers: {})
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+
+      it "sets a success flash notice" do
+        make_request
+        expect(session.dig("flash", "flashes", "notice")).to eq("Section note removed.")
+      end
+    end
+  end
+
   describe "POST #preview" do
     let(:make_request) do
       post customs_tariff_section_note_preview_path, params: { content: "some markdown" }
@@ -142,6 +170,81 @@ RSpec.describe CustomsTariff::Updates::SectionNotesController, type: :request do
     it "returns JSON with an html key" do
       json = JSON.parse(rendered_page.body)
       expect(json).to have_key("html")
+    end
+  end
+
+  describe "GET #new" do
+    let(:section_id) { "5" }
+
+    let(:make_request) do
+      get new_customs_tariff_update_section_note_path(update_version),
+          params: { section_id: }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+    end
+
+    it { is_expected.to have_http_status(:ok) }
+    it { is_expected.to render_template(:new) }
+  end
+
+  describe "POST #create" do
+    let(:section_id) { "5" }
+
+    let(:make_request) do
+      post customs_tariff_update_section_notes_path(update_version),
+           params: {
+             customs_tariff_section_note: { content: "Manually added content." },
+             section_id:,
+           }
+    end
+
+    before do
+      stub_api_request("/customs_tariff_updates/#{update_version}")
+        .and_return(update_response)
+    end
+
+    context "when the backend accepts the create" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/section_notes", :post)
+          .and_return(
+            status: 201,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              data: {
+                type: "customs_tariff_section_note",
+                id: "200",
+                attributes: section_note_attributes.merge(
+                  "section_id" => 5,
+                  "content" => "Manually added content.",
+                ),
+              },
+            }.to_json,
+          )
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+
+      it "sets a success flash notice" do
+        make_request
+        expect(session.dig("flash", "flashes", "notice")).to eq("Section note added.")
+      end
+    end
+
+    context "when the backend rejects the create with a 422" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}/section_notes", :post)
+          .and_return(
+            status: 422,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: { errors: [{ detail: "Content can't be blank" }] }.to_json,
+          )
+      end
+
+      it { is_expected.to have_http_status(:unprocessable_content) }
+      it { is_expected.to render_template(:new) }
     end
   end
 end

--- a/spec/requests/customs_tariff/updates_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates_controller_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
     before do
       stub_api_request("/customs_tariff_updates/#{update_version}")
         .and_return(update_response)
-      stub_api_request("/customs_tariff_updates/#{update_version}/section_notes")
+      stub_api_request("/customs_tariff_updates/#{update_version}/sections_summary")
         .and_return(
           status: 200,
           headers: { "content-type" => "application/json; charset=utf-8" },
@@ -87,6 +87,72 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
     it "renders the compare form" do
       make_request
       expect(response.body).to include(customs_tariff_update_comparison_path(update_version))
+    end
+
+    context "when a previous version exists in the updates list" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}").and_return(update_response)
+        stub_api_request("/customs_tariff_updates/#{update_version}/sections_summary").and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: { data: [] }.to_json,
+        )
+        stub_api_request("/customs_tariff_updates").and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: {
+            data: [
+              { type: "customs_tariff_update", id: update_version, attributes: update_attributes },
+              {
+                type: "customs_tariff_update",
+                id: "1.30",
+                attributes: update_attributes.merge("version" => "1.30", "status" => "pending", "validity_start_date" => "2025-12-01"),
+              },
+            ],
+          }.to_json,
+        )
+        get customs_tariff_update_path(update_version)
+      end
+
+      it "displays the baseline version in explanatory text" do
+        expect(response.body).to include("Comparing notes against version 1.30")
+      end
+    end
+
+    context "when a section summary has absent section note status" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}").and_return(update_response)
+        stub_api_request("/customs_tariff_updates/#{update_version}/sections_summary").and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: {
+            data: [
+              {
+                type: "section_summary",
+                id: "3",
+                attributes: {
+                  "section_id" => 3,
+                  "section_title" => "Section 3",
+                  "position" => 3,
+                  "section_note_id" => nil,
+                  "section_note_status" => "absent",
+                  "chapter_notes_total" => 0,
+                  "chapter_notes_changed" => 0,
+                },
+              },
+            ],
+          }.to_json,
+        )
+        stub_api_request("/customs_tariff_updates").and_return(updates_list_response)
+        get customs_tariff_update_path(update_version)
+      end
+
+      it "renders an Add link for the absent section", :aggregate_failures do
+        expect(response.body).to include(">Add<")
+        expect(response.body).to include(
+          new_customs_tariff_update_section_note_path(update_version, section_id: 3),
+        )
+      end
     end
   end
 
@@ -107,7 +173,7 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
           )
       end
 
-      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
+      it { is_expected.to redirect_to(customs_tariff_updates_path) }
 
       it "sets a success flash notice" do
         make_request
@@ -136,6 +202,48 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
       it "sets a flash alert containing the backend error detail" do
         make_request
         expect(session.dig("flash", "flashes", "alert")).to eq("Could not update status: Version is already approved")
+      end
+    end
+  end
+
+  describe "POST #reimport" do
+    let(:make_request) do
+      post reimport_customs_tariff_update_path(update_version)
+    end
+
+    context "when the backend accepts the reimport" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}")
+          .and_return(update_response)
+        stub_api_request("/customs_tariff_updates/#{update_version}/reimport", :post)
+          .and_return(
+            status: 202,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: "",
+          )
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_updates_path) }
+
+      it "sets a success flash notice" do
+        make_request
+        expect(session.dig("flash", "flashes", "notice")).to eq("Re-import queued.")
+      end
+    end
+
+    context "when the backend returns 404" do
+      before do
+        stub_api_request("/customs_tariff_updates/#{update_version}")
+          .and_return(update_response)
+        stub_api_request("/customs_tariff_updates/#{update_version}/reimport", :post)
+          .and_return(status: 404, body: "", headers: { "content-type" => "application/json; charset=utf-8" })
+      end
+
+      it { is_expected.to redirect_to(customs_tariff_updates_path) }
+
+      it "sets an alert flash" do
+        make_request
+        expect(session.dig("flash", "flashes", "alert")).to eq("Update could not be found.")
       end
     end
   end


### PR DESCRIPTION
### Jira link

[AI-517](https://transformuk.atlassian.net/browse/AI-517)

### What?

This PR adds the admin UI for the customs tariff chapter notes review and approval workflow. It's the front-end counterpart to the backend API endpoints added in the related backend PR.

Here's what's been added or changed:

- **`ChapterNotesController`** — CRUD controller for chapter notes scoped to a customs tariff update, including an index that merges existing notes with absent chapters so operators can see the full picture at a glance
- **`SectionSummary` model** — wraps the new sections summary API response and drives the per-section counts on the update show page
- **`updates_controller#reimport`** — new action that POSTs to the backend reimport endpoint and redirects back with a flash notice; the "Re-import" button on the index page lets operators reset an update in one click
- **Chapter note views** — index, new, edit, and a comparison view for reviewing diffs against a previous version
- **Section notes** — added `new` and `create` views/actions to match what chapter notes already had
- **Updates show page** — extended to display per-section chapter note totals and changed counts alongside the existing section note statuses
- **Policy** — added `create?` to `ChapterNotePolicy` so operators can add back notes that have been deleted from an update

### Why?

The section notes approval flow was already in place but chapter notes were missing their own CRUD. This fills that gap and makes the two consistent.

The reimport button is a safety net — if an operator has edited notes and wants to start fresh from the original imported content, they can do that without needing a developer to run a rake task.

All of this is behind the customs tariff feature flag so nothing here affects production yet.

### Have you? (optional)

- [ ] Reviewed view changes with stake holders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks (optional)

- None — all new functionality behind a feature flag, no changes to existing production behaviour