### PR TITLE
AI-521: Add search analytics dashboard

### DIFF
--- a/app/controllers/search_analytics_controller.rb
+++ b/app/controllers/search_analytics_controller.rb
@@ -29,9 +29,10 @@ private
   def prepare_improvement_terms
     @term_filter = normalised_term_filter
     filtered_terms = filter_improvement_terms(Array(@search_analytics.improvement_terms))
-    @term_total_pages = [(filtered_terms.size.to_f / IMPROVEMENT_TERMS_PER_PAGE).ceil, 1].max
-    @term_page = [[params.fetch(:term_page, 1).to_i, 1].max, @term_total_pages].min
-    @improvement_terms = filtered_terms.slice((@term_page - 1) * IMPROVEMENT_TERMS_PER_PAGE, IMPROVEMENT_TERMS_PER_PAGE) || []
+    @improvement_terms = Kaminari
+      .paginate_array(filtered_terms)
+      .page(params.fetch(:page, 1))
+      .per(IMPROVEMENT_TERMS_PER_PAGE)
   end
 
   def normalised_term_filter

--- a/app/controllers/search_analytics_controller.rb
+++ b/app/controllers/search_analytics_controller.rb
@@ -1,5 +1,5 @@
 class SearchAnalyticsController < AuthenticatedController
-  IMPROVEMENT_TERM_FILTERS = %w[all non_numeric numeric].freeze
+  ZERO_SEARCH_TERM_FILTERS = %w[all search_terms item_ids].freeze
   IMPROVEMENT_TERMS_PER_PAGE = 10
 
   def index
@@ -38,21 +38,21 @@ private
   def normalised_term_filter
     filter = params.fetch(:term_filter, "all")
 
-    IMPROVEMENT_TERM_FILTERS.include?(filter) ? filter : "all"
+    ZERO_SEARCH_TERM_FILTERS.include?(filter) ? filter : "all"
   end
 
   def filter_improvement_terms(terms)
     case @term_filter
-    when "numeric"
-      terms.select { |term| numeric_search_term?(term) }
-    when "non_numeric"
-      terms.reject { |term| numeric_search_term?(term) }
+    when "item_ids"
+      terms.select { |term| item_id_query?(term) }
+    when "search_terms"
+      terms.reject { |term| item_id_query?(term) }
     else
       terms
     end
   end
 
-  def numeric_search_term?(term)
+  def item_id_query?(term)
     term.with_indifferent_access.fetch(:query, "").to_s.match?(/\A[\d\s.-]+\z/)
   end
 end

--- a/app/controllers/search_analytics_controller.rb
+++ b/app/controllers/search_analytics_controller.rb
@@ -1,0 +1,57 @@
+class SearchAnalyticsController < AuthenticatedController
+  IMPROVEMENT_TERM_FILTERS = %w[all non_numeric numeric].freeze
+  IMPROVEMENT_TERMS_PER_PAGE = 10
+
+  def index
+    authorize SearchAnalytics, :index?
+
+    @period = params.fetch(:period, "24h")
+    @view = params.fetch(:view, "all")
+    @search_analytics = SearchAnalytics.fetch(period: @period, view: @view)
+    prepare_improvement_terms
+  rescue Faraday::ResourceNotFound
+    render_unavailable_dashboard("Search analytics are not available yet.")
+  rescue Faraday::Error => e
+    Rails.logger.error("Failed to fetch search analytics: #{e.class} #{e.message}")
+    render_unavailable_dashboard("Search analytics could not be loaded.")
+  end
+
+private
+
+  def render_unavailable_dashboard(message)
+    flash.now[:alert] = message
+    @search_analytics = SearchAnalytics.new(period: @period, view: @view)
+    prepare_improvement_terms
+
+    render :index
+  end
+
+  def prepare_improvement_terms
+    @term_filter = normalised_term_filter
+    filtered_terms = filter_improvement_terms(Array(@search_analytics.improvement_terms))
+    @term_total_pages = [(filtered_terms.size.to_f / IMPROVEMENT_TERMS_PER_PAGE).ceil, 1].max
+    @term_page = [[params.fetch(:term_page, 1).to_i, 1].max, @term_total_pages].min
+    @improvement_terms = filtered_terms.slice((@term_page - 1) * IMPROVEMENT_TERMS_PER_PAGE, IMPROVEMENT_TERMS_PER_PAGE) || []
+  end
+
+  def normalised_term_filter
+    filter = params.fetch(:term_filter, "all")
+
+    IMPROVEMENT_TERM_FILTERS.include?(filter) ? filter : "all"
+  end
+
+  def filter_improvement_terms(terms)
+    case @term_filter
+    when "numeric"
+      terms.select { |term| numeric_search_term?(term) }
+    when "non_numeric"
+      terms.reject { |term| numeric_search_term?(term) }
+    else
+      terms
+    end
+  end
+
+  def numeric_search_term?(term)
+    term.with_indifferent_access.fetch(:query, "").to_s.match?(/\A[\d\s.-]+\z/)
+  end
+end

--- a/app/controllers/search_analytics_controller.rb
+++ b/app/controllers/search_analytics_controller.rb
@@ -1,5 +1,5 @@
 class SearchAnalyticsController < AuthenticatedController
-  ZERO_SEARCH_TERM_FILTERS = %w[all search_terms item_ids].freeze
+  ZERO_SEARCH_TERM_FILTERS = %w[search_terms item_ids].freeze
   IMPROVEMENT_TERMS_PER_PAGE = 10
 
   def index
@@ -36,9 +36,9 @@ private
   end
 
   def normalised_term_filter
-    filter = params.fetch(:term_filter, "all")
+    filter = params.fetch(:term_filter, "search_terms")
 
-    ZERO_SEARCH_TERM_FILTERS.include?(filter) ? filter : "all"
+    ZERO_SEARCH_TERM_FILTERS.include?(filter) ? filter : "search_terms"
   end
 
   def filter_improvement_terms(terms)
@@ -53,6 +53,10 @@ private
   end
 
   def item_id_query?(term)
-    term.with_indifferent_access.fetch(:query, "").to_s.match?(/\A[\d\s.-]+\z/)
+    term = term.with_indifferent_access
+
+    return term[:term_type] == "item_ids" if term[:term_type].present?
+
+    term.fetch(:query, "").to_s.match?(/\A[\d\s.-]+\z/)
   end
 end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -104,7 +104,14 @@ module NavigationHelper
             service: :uk,
           ),
           NavigationItem.new(
-            text: "Diagnostics",
+            text: "Search dashboard",
+            href: search_analytics_path,
+            policy_class: SearchAnalytics,
+            active_when: /\/search_analytics/,
+            service: nil,
+          ),
+          NavigationItem.new(
+            text: "Search diagnostics",
             href: search_diagnostics_path,
             policy_class: SearchDiagnostic,
             active_when: /\/search_diagnostics/,

--- a/app/helpers/search_analytics_helper.rb
+++ b/app/helpers/search_analytics_helper.rb
@@ -1,0 +1,123 @@
+module SearchAnalyticsHelper
+  VIEW_SUMMARY_MINIMUM_INTERNAL_SHARE = 1.0
+
+  SEARCH_ANALYTICS_CHART_COLOURS = {
+    all: "#144e81",
+    classic: "#005a30",
+    internal: "#594d00",
+    completed: "#144e81",
+    failed: "#942514",
+    zero_result: "#594d00",
+    selected: "#005a30",
+    searches: "#144e81",
+  }.freeze
+
+  def search_analytics_number(value)
+    number_with_delimiter(value.to_i)
+  end
+
+  def search_analytics_percentage(value)
+    number_to_percentage(value.to_f * 100, precision: 1, strip_insignificant_zeros: true)
+  end
+
+  def search_analytics_latency(value)
+    "#{number_with_precision(value.to_f / 1_000, precision: 1, strip_insignificant_zeros: true)}s"
+  end
+
+  def search_analytics_status_tag_class(level)
+    colour = {
+      "good" => "green",
+      "watch" => "yellow",
+      "problem" => "red",
+      "neutral" => "blue",
+    }.fetch(level.to_s, "grey")
+
+    "govuk-tag govuk-tag--#{colour}"
+  end
+
+  def search_analytics_chart_payload(rows, series:)
+    {
+      labels: Array(rows).map { |row| search_analytics_bucket_label(row[:bucket] || row["bucket"]) },
+      datasets: series.map do |key, label|
+        {
+          label: label,
+          data: Array(rows).map { |row| row[key] || row[key.to_s] || 0 },
+        }.merge(search_analytics_chart_series_style(key))
+      end,
+    }.to_json
+  end
+
+  def search_analytics_comparison_chart_payload(comparisons)
+    rows = (comparisons || {}).with_indifferent_access
+    chart_rows = rows.slice(:classic, :internal)
+
+    {
+      labels: chart_rows.keys.map { |view| view.to_s.humanize },
+      datasets: [
+        {
+          label: "Searches",
+          data: chart_rows.values.map { |row| row[:searches] || row["searches"] || 0 },
+        }.merge(search_analytics_chart_series_style(:searches)),
+      ],
+    }.to_json
+  end
+
+  def search_analytics_view_summary_rows(comparisons)
+    rows = (comparisons || {}).with_indifferent_access.slice(:classic, :internal)
+    total_searches = rows.values.sum { |row| (row[:searches] || row["searches"]).to_i }
+
+    rows.map do |view, row|
+      searches = (row[:searches] || row["searches"]).to_i
+      percentage = total_searches.positive? ? ((searches.to_f / total_searches) * 100).round(1) : 0.0
+
+      {
+        key: view.to_s,
+        label: view.to_s.humanize,
+        searches: searches,
+        percentage: "#{number_with_precision(percentage, precision: 1, strip_insignificant_zeros: true)}%",
+        width: percentage,
+      }
+    end
+  end
+
+  def search_analytics_show_view_summary?(comparisons)
+    rows = (comparisons || {}).with_indifferent_access
+    total_searches = rows.slice(:classic, :internal).values.sum { |row| (row[:searches] || row["searches"]).to_i }
+    internal_searches = (rows.dig(:internal, :searches) || rows.dig(:internal, "searches")).to_i
+
+    return false unless total_searches.positive?
+
+    ((internal_searches.to_f / total_searches) * 100) >= VIEW_SUMMARY_MINIMUM_INTERNAL_SHARE
+  end
+
+  def search_analytics_timestamp(value)
+    return if value.blank?
+
+    time = Time.zone.parse(value.to_s)
+    time.strftime("%-d %B %Y at %H:%M")
+  rescue ArgumentError
+    value.to_s
+  end
+
+private
+
+  def search_analytics_bucket_label(bucket)
+    time = Time.zone.parse(bucket.to_s)
+    return time.strftime("%-d %b") if time.hour.zero? && time.min.zero?
+
+    time.strftime("%H:%M")
+  rescue ArgumentError
+    bucket.to_s
+  end
+
+  def search_analytics_chart_series_style(key)
+    colour = SEARCH_ANALYTICS_CHART_COLOURS.fetch(key.to_sym, SEARCH_ANALYTICS_CHART_COLOURS.fetch(:all))
+
+    {
+      borderColor: colour,
+      backgroundColor: colour,
+      pointBackgroundColor: colour,
+      pointBorderColor: colour,
+    }
+  end
+end

--- a/app/helpers/search_analytics_helper.rb
+++ b/app/helpers/search_analytics_helper.rb
@@ -25,23 +25,28 @@ module SearchAnalyticsHelper
   end
 
   def search_analytics_status_tag_class(level)
-    colour = {
+    "govuk-tag govuk-tag--#{search_analytics_status_tag_colour(level)}"
+  end
+
+  def search_analytics_status_tag_colour(level)
+    {
       "good" => "green",
       "watch" => "yellow",
       "problem" => "red",
       "neutral" => "blue",
     }.fetch(level.to_s, "grey")
-
-    "govuk-tag govuk-tag--#{colour}"
   end
 
   def search_analytics_chart_payload(rows, series:)
     {
       labels: Array(rows).map { |row| search_analytics_bucket_label(row[:bucket] || row["bucket"]) },
-      datasets: series.map do |key, label|
+      datasets: series.filter_map do |key, label|
+        data = Array(rows).map { |row| row[key] || row[key.to_s] || 0 }
+        next if data.all?(&:zero?)
+
         {
           label: label,
-          data: Array(rows).map { |row| row[key] || row[key.to_s] || 0 },
+          data: data,
         }.merge(search_analytics_chart_series_style(key))
       end,
     }.to_json
@@ -94,7 +99,7 @@ module SearchAnalyticsHelper
     return if value.blank?
 
     time = Time.zone.parse(value.to_s)
-    time.strftime("%-d %B %Y at %H:%M")
+    "#{time.to_date.to_fs(:govuk)} at #{time.strftime('%H:%M')}"
   rescue ArgumentError
     value.to_s
   end

--- a/app/helpers/search_analytics_helper.rb
+++ b/app/helpers/search_analytics_helper.rb
@@ -37,12 +37,18 @@ module SearchAnalyticsHelper
     }.fetch(level.to_s, "grey")
   end
 
-  def search_analytics_chart_payload(rows, series:)
+  def search_analytics_chart_payload(rows, series:, minimum_series_share: 0)
+    series_data = series.keys.index_with do |key|
+      Array(rows).map { |row| (row[key] || row[key.to_s]).to_i }
+    end
+    largest_series_total = series_data.values.map(&:sum).max.to_i
+
     {
       labels: Array(rows).map { |row| search_analytics_bucket_label(row[:bucket] || row["bucket"]) },
       datasets: series.filter_map do |key, label|
-        data = Array(rows).map { |row| row[key] || row[key.to_s] || 0 }
+        data = series_data.fetch(key)
         next if data.all?(&:zero?)
+        next if largest_series_total.positive? && ((data.sum.to_f / largest_series_total) * 100) < minimum_series_share
 
         {
           label: label,

--- a/app/models/search_analytics.rb
+++ b/app/models/search_analytics.rb
@@ -1,0 +1,23 @@
+class SearchAnalytics
+  include ApiEntity
+
+  attributes :service,
+             :period,
+             :view,
+             :bucket_size,
+             :generated_at,
+             :data_through,
+             :summary,
+             :summary_statuses,
+             :trends,
+             :comparisons,
+             :suggestions,
+             :improvement_terms
+
+  set_collection_path "admin/search_analytics"
+
+  def self.fetch(period:, view:)
+    response = api.get(collection_path, { period:, view: })
+    new(parse_jsonapi(response))
+  end
+end

--- a/app/policies/search_analytics_policy.rb
+++ b/app/policies/search_analytics_policy.rb
@@ -1,0 +1,5 @@
+class SearchAnalyticsPolicy < ApplicationPolicy
+  def index?
+    technical_operator? || hmrc_admin? || auditor?
+  end
+end

--- a/app/views/search_analytics/index.html.erb
+++ b/app/views/search_analytics/index.html.erb
@@ -94,7 +94,7 @@
         <h2 class="govuk-heading-m">Volume trend</h2>
         <div class="search-analytics-chart-container">
           <canvas class="search-analytics-chart"
-                  data-chart="<%= search_analytics_chart_payload(trends[:volume], series: { all: "All", classic: "Classic", internal: "Internal" }) %>"></canvas>
+                  data-chart="<%= search_analytics_chart_payload(trends[:volume], series: { all: "All", classic: "Classic", internal: "Internal" }, minimum_series_share: 1) %>"></canvas>
         </div>
       </section>
 
@@ -102,7 +102,7 @@
         <h2 class="govuk-heading-m">Outcome trend</h2>
         <div class="search-analytics-chart-container">
           <canvas class="search-analytics-chart"
-                  data-chart="<%= search_analytics_chart_payload(trends[:outcomes], series: { completed: "Completed", failed: "Failed", zero_result: "Zero result", selected: "Selected" }) %>"></canvas>
+                  data-chart="<%= search_analytics_chart_payload(trends[:outcomes], series: { completed: "Completed", failed: "Failed", zero_result: "Zero result", selected: "Selected" }, minimum_series_share: 1) %>"></canvas>
         </div>
       </section>
     </div>

--- a/app/views/search_analytics/index.html.erb
+++ b/app/views/search_analytics/index.html.erb
@@ -9,14 +9,9 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Search dashboard</h1>
-    <% if @search_analytics.generated_at.present? || @search_analytics.data_through.present? %>
+    <% if @search_analytics.generated_at.present? %>
       <p class="govuk-body-s govuk-!-margin-bottom-5">
-        <% if @search_analytics.generated_at.present? %>
-          Generated <%= search_analytics_timestamp(@search_analytics.generated_at) %>
-        <% end %>
-        <% if @search_analytics.data_through.present? %>
-          with data through <%= search_analytics_timestamp(@search_analytics.data_through) %>.
-        <% end %>
+        Generated <%= search_analytics_timestamp(@search_analytics.generated_at) %>.
       </p>
     <% end %>
 
@@ -56,7 +51,7 @@
           <h2 class="govuk-heading-s"><%= label %></h2>
           <p class="search-analytics-metric__value"><%= value %></p>
           <% if status[:level].present? %>
-            <strong class="<%= search_analytics_status_tag_class(status[:level]) %>"><%= status[:level].to_s.humanize %></strong>
+            <%= govuk_tag(text: status[:level].to_s.humanize, colour: search_analytics_status_tag_colour(status[:level])) %>
           <% end %>
           <% if status[:message].present? %>
             <p class="govuk-body-s govuk-!-margin-top-2"><%= status[:message] %></p>
@@ -65,37 +60,34 @@
       <% end %>
     </div>
 
-    <details class="govuk-details govuk-!-margin-top-4">
-      <summary class="govuk-details__summary">
-        <span class="govuk-details__summary-text">How these metrics are calculated</span>
-      </summary>
-      <div class="govuk-details__text">
-        <dl class="govuk-summary-list govuk-summary-list--no-border search-analytics-metric-definitions">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Searches</dt>
-            <dd class="govuk-summary-list__value">Completed and failed search requests for the selected period and view.</dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Failure rate</dt>
-            <dd class="govuk-summary-list__value">Failed searches divided by all searches.</dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Zero-result rate</dt>
-            <dd class="govuk-summary-list__value">Completed searches with no results divided by completed searches.</dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Selection rate</dt>
-            <dd class="govuk-summary-list__value">
-              Result selections divided by eligible searches. Eligible searches are classic fuzzy searches and internal searches that return ranked confidence results. Can exceed 100% when users open more than one result.
-            </dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">P90 latency</dt>
-            <dd class="govuk-summary-list__value">The response time that 90% of completed and failed searches were faster than.</dd>
-          </div>
-        </dl>
-      </div>
-    </details>
+    <%= render GovukComponent::DetailsComponent.new(summary_text: "How these metrics are calculated", classes: "govuk-!-margin-top-4") do %>
+      <%= govuk_summary_list(
+            borders: false,
+            classes: "search-analytics-metric-definitions",
+            rows: [
+              {
+                key: { text: "Searches" },
+                value: { text: "Completed and failed search requests for the selected period and view." },
+              },
+              {
+                key: { text: "Failure rate" },
+                value: { text: "Failed searches divided by all searches." },
+              },
+              {
+                key: { text: "Zero-result rate" },
+                value: { text: "Completed searches with no results divided by completed searches." },
+              },
+              {
+                key: { text: "Selection rate" },
+                value: { text: "Result selections divided by eligible searches. Eligible searches are classic fuzzy searches and internal searches that return ranked confidence results. Can exceed 100% when users open more than one result." },
+              },
+              {
+                key: { text: "P90 latency" },
+                value: { text: "The response time that 90% of completed and failed searches were faster than." },
+              },
+            ],
+          ) %>
+    <% end %>
 
     <div class="search-analytics-charts govuk-!-margin-top-6">
       <section>
@@ -165,24 +157,7 @@
           <% end %>
         </tbody>
       </table>
-      <% if @term_total_pages > 1 %>
-        <nav class="govuk-pagination" role="navigation" aria-label="Zero search terms">
-          <% if @term_page > 1 %>
-            <div class="govuk-pagination__prev">
-              <%= link_to "Previous",
-                          search_analytics_path(period: @period, view: @view, term_filter: @term_filter, term_page: @term_page - 1),
-                          class: "govuk-link govuk-pagination__link" %>
-            </div>
-          <% end %>
-          <% if @term_page < @term_total_pages %>
-            <div class="govuk-pagination__next">
-              <%= link_to "Next",
-                          search_analytics_path(period: @period, view: @view, term_filter: @term_filter, term_page: @term_page + 1),
-                          class: "govuk-link govuk-pagination__link" %>
-            </div>
-          <% end %>
-        </nav>
-      <% end %>
+      <%= paginate @improvement_terms, params: { period: @period, view: @view, term_filter: @term_filter } %>
     </section>
   </div>
 </div>

--- a/app/views/search_analytics/index.html.erb
+++ b/app/views/search_analytics/index.html.erb
@@ -134,7 +134,7 @@
     <section class="govuk-!-margin-top-6" aria-labelledby="zero-search-terms-heading">
       <h2 id="zero-search-terms-heading" class="govuk-heading-m">Zero search terms</h2>
       <div class="search-analytics-term-controls govuk-!-margin-bottom-3">
-        <% [["all", "All"], ["non_numeric", "Non-numeric"], ["numeric", "Numeric"]].each do |filter, label| %>
+        <% [["all", "All"], ["search_terms", "Search terms"], ["item_ids", "Item IDs"]].each do |filter, label| %>
           <%= link_to label,
                       search_analytics_path(period: @period, view: @view, term_filter: filter),
                       class: ["govuk-link", ("govuk-!-font-weight-bold" if @term_filter == filter)].compact.join(" ") %>

--- a/app/views/search_analytics/index.html.erb
+++ b/app/views/search_analytics/index.html.erb
@@ -134,7 +134,7 @@
     <section class="govuk-!-margin-top-6" aria-labelledby="zero-search-terms-heading">
       <h2 id="zero-search-terms-heading" class="govuk-heading-m">Zero search terms</h2>
       <div class="search-analytics-term-controls govuk-!-margin-bottom-3">
-        <% [["all", "All"], ["search_terms", "Search terms"], ["item_ids", "Item IDs"]].each do |filter, label| %>
+        <% [["search_terms", "Search terms"], ["item_ids", "Item IDs"]].each do |filter, label| %>
           <%= link_to label,
                       search_analytics_path(period: @period, view: @view, term_filter: filter),
                       class: ["govuk-link", ("govuk-!-font-weight-bold" if @term_filter == filter)].compact.join(" ") %>

--- a/app/views/search_analytics/index.html.erb
+++ b/app/views/search_analytics/index.html.erb
@@ -1,0 +1,188 @@
+<% content_for :page_title, "Search dashboard" %>
+<%= javascript_pack_tag "search-analytics-dashboard", defer: true %>
+
+<% summary = (@search_analytics.summary || {}).with_indifferent_access %>
+<% statuses = (@search_analytics.summary_statuses || {}).with_indifferent_access %>
+<% trends = (@search_analytics.trends || {}).with_indifferent_access %>
+<% comparisons = (@search_analytics.comparisons || {}).with_indifferent_access %>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Search dashboard</h1>
+    <% if @search_analytics.generated_at.present? || @search_analytics.data_through.present? %>
+      <p class="govuk-body-s govuk-!-margin-bottom-5">
+        <% if @search_analytics.generated_at.present? %>
+          Generated <%= search_analytics_timestamp(@search_analytics.generated_at) %>
+        <% end %>
+        <% if @search_analytics.data_through.present? %>
+          with data through <%= search_analytics_timestamp(@search_analytics.data_through) %>.
+        <% end %>
+      </p>
+    <% end %>
+
+    <div class="search-analytics-filters govuk-!-margin-bottom-5">
+      <div>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">Period</h2>
+        <div class="govuk-button-group">
+          <% [["24h", "24 hours"], ["7d", "7 days"], ["30d", "30 days"]].each do |period, label| %>
+            <%= link_to label,
+                        search_analytics_path(period: period, view: @view),
+                        class: ["govuk-link", ("govuk-!-font-weight-bold" if @period == period)].compact.join(" ") %>
+          <% end %>
+        </div>
+      </div>
+      <div>
+        <h2 class="govuk-heading-s govuk-!-margin-bottom-2">View</h2>
+        <div class="govuk-button-group">
+          <% [["all", "All"], ["classic", "Classic"], ["internal", "Internal"]].each do |view, label| %>
+            <%= link_to label,
+                        search_analytics_path(period: @period, view: view),
+                        class: ["govuk-link", ("govuk-!-font-weight-bold" if @view == view)].compact.join(" ") %>
+          <% end %>
+        </div>
+      </div>
+    </div>
+
+    <div class="search-analytics-metrics">
+      <% [
+        ["Searches", search_analytics_number(summary[:searches]), statuses[:searches]],
+        ["Failure rate", search_analytics_percentage(summary[:failure_rate]), statuses[:failure_rate]],
+        ["Zero-result rate", search_analytics_percentage(summary[:zero_result_rate]), statuses[:zero_result_rate]],
+        ["Selection rate", search_analytics_percentage(summary[:selection_rate]), statuses[:selection_rate]],
+        ["P90 latency", search_analytics_latency(summary[:p90_latency_ms]), statuses[:p90_latency_ms]],
+      ].each do |label, value, status| %>
+        <% status = (status || {}).with_indifferent_access %>
+        <section class="search-analytics-metric" aria-label="<%= label %>">
+          <h2 class="govuk-heading-s"><%= label %></h2>
+          <p class="search-analytics-metric__value"><%= value %></p>
+          <% if status[:level].present? %>
+            <strong class="<%= search_analytics_status_tag_class(status[:level]) %>"><%= status[:level].to_s.humanize %></strong>
+          <% end %>
+          <% if status[:message].present? %>
+            <p class="govuk-body-s govuk-!-margin-top-2"><%= status[:message] %></p>
+          <% end %>
+        </section>
+      <% end %>
+    </div>
+
+    <details class="govuk-details govuk-!-margin-top-4">
+      <summary class="govuk-details__summary">
+        <span class="govuk-details__summary-text">How these metrics are calculated</span>
+      </summary>
+      <div class="govuk-details__text">
+        <dl class="govuk-summary-list govuk-summary-list--no-border search-analytics-metric-definitions">
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Searches</dt>
+            <dd class="govuk-summary-list__value">Completed and failed search requests for the selected period and view.</dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Failure rate</dt>
+            <dd class="govuk-summary-list__value">Failed searches divided by all searches.</dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Zero-result rate</dt>
+            <dd class="govuk-summary-list__value">Completed searches with no results divided by completed searches.</dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">Selection rate</dt>
+            <dd class="govuk-summary-list__value">
+              Result selections divided by eligible searches. Eligible searches are classic fuzzy searches and internal searches that return ranked confidence results. Can exceed 100% when users open more than one result.
+            </dd>
+          </div>
+          <div class="govuk-summary-list__row">
+            <dt class="govuk-summary-list__key">P90 latency</dt>
+            <dd class="govuk-summary-list__value">The response time that 90% of completed and failed searches were faster than.</dd>
+          </div>
+        </dl>
+      </div>
+    </details>
+
+    <div class="search-analytics-charts govuk-!-margin-top-6">
+      <section>
+        <h2 class="govuk-heading-m">Volume trend</h2>
+        <div class="search-analytics-chart-container">
+          <canvas class="search-analytics-chart"
+                  data-chart="<%= search_analytics_chart_payload(trends[:volume], series: { all: "All", classic: "Classic", internal: "Internal" }) %>"></canvas>
+        </div>
+      </section>
+
+      <section>
+        <h2 class="govuk-heading-m">Outcome trend</h2>
+        <div class="search-analytics-chart-container">
+          <canvas class="search-analytics-chart"
+                  data-chart="<%= search_analytics_chart_payload(trends[:outcomes], series: { completed: "Completed", failed: "Failed", zero_result: "Zero result", selected: "Selected" }) %>"></canvas>
+        </div>
+      </section>
+    </div>
+
+    <% if search_analytics_show_view_summary?(comparisons) %>
+      <section class="search-analytics-view-summary govuk-!-margin-top-6">
+        <h2 class="govuk-heading-m">Searches by view</h2>
+        <table class="govuk-table search-analytics-view-summary__table">
+          <thead class="govuk-table__head">
+            <tr class="govuk-table__row">
+              <th scope="col" class="govuk-table__header">View</th>
+              <th scope="col" class="govuk-table__header govuk-table__header--numeric">Searches</th>
+              <th scope="col" class="govuk-table__header govuk-table__header--numeric">Share</th>
+            </tr>
+          </thead>
+          <tbody class="govuk-table__body">
+            <% search_analytics_view_summary_rows(comparisons).each do |row| %>
+              <tr class="govuk-table__row">
+                <th scope="row" class="govuk-table__header"><%= row[:label] %></th>
+                <td class="govuk-table__cell govuk-table__cell--numeric"><%= search_analytics_number(row[:searches]) %></td>
+                <td class="govuk-table__cell govuk-table__cell--numeric"><%= row[:percentage] %></td>
+              </tr>
+            <% end %>
+          </tbody>
+        </table>
+      </section>
+    <% end %>
+
+    <section class="govuk-!-margin-top-6" aria-labelledby="zero-search-terms-heading">
+      <h2 id="zero-search-terms-heading" class="govuk-heading-m">Zero search terms</h2>
+      <div class="search-analytics-term-controls govuk-!-margin-bottom-3">
+        <% [["all", "All"], ["non_numeric", "Non-numeric"], ["numeric", "Numeric"]].each do |filter, label| %>
+          <%= link_to label,
+                      search_analytics_path(period: @period, view: @view, term_filter: filter),
+                      class: ["govuk-link", ("govuk-!-font-weight-bold" if @term_filter == filter)].compact.join(" ") %>
+        <% end %>
+      </div>
+      <table class="govuk-table">
+        <thead class="govuk-table__head">
+          <tr class="govuk-table__row">
+            <th scope="col" class="govuk-table__header">Query</th>
+            <th scope="col" class="govuk-table__header govuk-table__header--numeric">Zero-result searches</th>
+          </tr>
+        </thead>
+        <tbody class="govuk-table__body">
+          <% @improvement_terms.each do |term| %>
+            <% term = term.with_indifferent_access %>
+            <tr class="govuk-table__row">
+              <td class="govuk-table__cell" data-improvement-term-query><%= term[:query] %></td>
+              <td class="govuk-table__cell govuk-table__cell--numeric"><%= search_analytics_number(term[:zero_results]) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+      <% if @term_total_pages > 1 %>
+        <nav class="govuk-pagination" role="navigation" aria-label="Zero search terms">
+          <% if @term_page > 1 %>
+            <div class="govuk-pagination__prev">
+              <%= link_to "Previous",
+                          search_analytics_path(period: @period, view: @view, term_filter: @term_filter, term_page: @term_page - 1),
+                          class: "govuk-link govuk-pagination__link" %>
+            </div>
+          <% end %>
+          <% if @term_page < @term_total_pages %>
+            <div class="govuk-pagination__next">
+              <%= link_to "Next",
+                          search_analytics_path(period: @period, view: @view, term_filter: @term_filter, term_page: @term_page + 1),
+                          class: "govuk-link govuk-pagination__link" %>
+            </div>
+          <% end %>
+        </nav>
+      <% end %>
+    </section>
+  </div>
+</div>

--- a/app/webpacker/packs/application.scss
+++ b/app/webpacker/packs/application.scss
@@ -177,6 +177,69 @@ $govuk-image-url-function: frontend-image-url;
   }
 }
 
+.search-analytics-filters {
+  display: flex;
+  flex-wrap: wrap;
+  gap: govuk-spacing(6);
+}
+
+.search-analytics-metrics {
+  display: grid;
+  gap: govuk-spacing(3);
+  grid-template-columns: repeat(auto-fit, minmax(11rem, 1fr));
+}
+
+.search-analytics-metric {
+  border-top: 4px solid govuk-colour("blue");
+  padding-top: govuk-spacing(3);
+}
+
+.search-analytics-metric__value {
+  @include govuk-font($size: 36, $weight: bold);
+  margin: 0 0 govuk-spacing(2);
+}
+
+.search-analytics-charts {
+  display: grid;
+  gap: govuk-spacing(6);
+  grid-template-columns: repeat(auto-fit, minmax(20rem, 1fr));
+}
+
+.search-analytics-chart-container {
+  height: 18rem;
+  max-width: 100%;
+  position: relative;
+  width: 100%;
+}
+
+.search-analytics-chart {
+  display: block;
+  height: 100%;
+  width: 100%;
+}
+
+.search-analytics-term-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: govuk-spacing(3);
+}
+
+.search-analytics-view-summary {
+  max-width: 36rem;
+}
+
+.search-analytics-view-summary__table {
+  margin-bottom: 0;
+}
+
+.search-analytics-metric-definitions {
+  margin-bottom: 0;
+
+  .govuk-summary-list__key {
+    width: 9rem;
+  }
+}
+
 .scored-tag-pill {
   display: inline-flex;
   align-items: center;

--- a/app/webpacker/packs/search-analytics-dashboard.js
+++ b/app/webpacker/packs/search-analytics-dashboard.js
@@ -9,6 +9,14 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
+    payload.datasets = payload.datasets.filter((dataset) => (
+      dataset.data || []
+    ).some((value) => Number(value) !== 0));
+
+    if (payload.datasets.length === 0) {
+      return;
+    }
+
     new Chart(canvas, {
       type: requestedType === 'line' && payload.labels.length < 2 ? 'bar' : requestedType,
       data: payload,

--- a/app/webpacker/packs/search-analytics-dashboard.js
+++ b/app/webpacker/packs/search-analytics-dashboard.js
@@ -1,0 +1,55 @@
+import Chart from 'chart.js/auto';
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.querySelectorAll('.search-analytics-chart').forEach((canvas) => {
+    const payload = JSON.parse(canvas.dataset.chart || '{}');
+    const requestedType = canvas.dataset.chartType || 'line';
+
+    if (!payload.labels || !payload.datasets) {
+      return;
+    }
+
+    new Chart(canvas, {
+      type: requestedType === 'line' && payload.labels.length < 2 ? 'bar' : requestedType,
+      data: payload,
+      options: {
+        animation: false,
+        interaction: {
+          intersect: false,
+          mode: 'index',
+        },
+        responsive: true,
+        maintainAspectRatio: false,
+        elements: {
+          line: {
+            tension: 0,
+          },
+          point: {
+            hoverRadius: 5,
+            radius: 3,
+          },
+        },
+        scales: {
+          x: {
+            ticks: {
+              autoSkip: true,
+              maxRotation: 0,
+              maxTicksLimit: 8,
+            },
+          },
+          y: {
+            beginAtZero: true,
+            ticks: {
+              precision: 0,
+            },
+          },
+        },
+        plugins: {
+          legend: {
+            position: 'bottom',
+          },
+        },
+      },
+    });
+  });
+});

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -144,6 +144,7 @@ Rails.application.routes.draw do
       post :bulk_import
     end
   end
+  resources :search_analytics, only: %i[index]
   resources :search_diagnostics, only: %i[index show], param: :request_id, constraints: { request_id: /[^\/.]+/ }
   resources :goods_nomenclature_autocomplete_results, only: %i[index]
 

--- a/spec/features/search_analytics_dashboard_spec.rb
+++ b/spec/features/search_analytics_dashboard_spec.rb
@@ -29,14 +29,24 @@ RSpec.describe "Search analytics dashboard" do
     expect_view_link("Internal", content: "internal term", value: "530")
   end
 
-  it "filters improvement terms to non-numeric searches", :aggregate_failures do
+  it "filters zero search terms to search terms", :aggregate_failures do
     visit search_analytics_path
 
-    click_link "Non-numeric"
+    click_link "Search terms"
 
-    expect(current_url).to include("term_filter=non_numeric")
+    expect(current_url).to include("term_filter=search_terms")
     expect(improvement_term_queries).to include("yoga ball", "phone case")
     expect(improvement_term_queries).not_to include("3926909090")
+  end
+
+  it "filters zero search terms to item IDs", :aggregate_failures do
+    visit search_analytics_path
+
+    click_link "Item IDs"
+
+    expect(current_url).to include("term_filter=item_ids")
+    expect(improvement_term_queries).to include("3926909090")
+    expect(improvement_term_queries).not_to include("yoga ball", "phone case")
   end
 
   it "paginates improvement terms", :aggregate_failures do
@@ -122,7 +132,8 @@ RSpec.describe "Search analytics dashboard" do
     expect(page).to have_css(".search-analytics-view-summary__table")
     expect(page).to have_content("Classic")
     expect(page).to have_content("Internal")
-    expect(page).to have_link("Non-numeric")
+    expect(page).to have_link("Search terms")
+    expect(page).to have_link("Item IDs")
     expect(page).to have_link("Next")
     expect(chart_datasets).to all(include("borderColor"))
     expect(non_empty_chart_payloads.size).to eq(2)

--- a/spec/features/search_analytics_dashboard_spec.rb
+++ b/spec/features/search_analytics_dashboard_spec.rb
@@ -85,13 +85,13 @@ RSpec.describe "Search analytics dashboard" do
   end
 
   def expect_first_improvement_term_page
-    expect(improvement_term_queries).to include("3926909090")
-    expect(improvement_term_queries).not_to include("ceramic mug")
+    expect(improvement_term_queries).to include("bike seat", "yoga ball")
+    expect(improvement_term_queries).not_to include("3926909090", "storage box")
   end
 
   def expect_second_improvement_term_page
-    expect(improvement_term_queries).to include("ceramic mug")
-    expect(improvement_term_queries).not_to include("3926909090")
+    expect(improvement_term_queries).to include("storage box")
+    expect(improvement_term_queries).not_to include("3926909090", "bike seat")
   end
 
   def expect_search_term_pagination
@@ -126,7 +126,8 @@ RSpec.describe "Search analytics dashboard" do
     expect(page).not_to have_css("section[aria-labelledby='zero-search-terms-heading']", text: "Searches")
     expect(page).to have_css("section[aria-labelledby='zero-search-terms-heading']", text: "Zero-result searches")
     expect(page).to have_content("Searches by view")
-    expect(page).to have_content("3926909090")
+    expect(page).to have_content("bike seat")
+    expect(page).not_to have_css("section[aria-labelledby='zero-search-terms-heading']", text: "3926909090")
     expect(page).to have_css(".search-analytics-chart-container", count: 2)
     expect(page).to have_css(".search-analytics-view-summary")
     expect(page).to have_css(".search-analytics-view-summary__table")
@@ -134,6 +135,7 @@ RSpec.describe "Search analytics dashboard" do
     expect(page).to have_content("Internal")
     expect(page).to have_link("Search terms")
     expect(page).to have_link("Item IDs")
+    expect(page).not_to have_link("All", href: /term_filter/)
     expect(page).to have_link("Next")
     expect(chart_datasets).to all(include("borderColor"))
     expect(non_empty_chart_payloads.size).to eq(2)

--- a/spec/features/search_analytics_dashboard_spec.rb
+++ b/spec/features/search_analytics_dashboard_spec.rb
@@ -43,11 +43,8 @@ RSpec.describe "Search analytics dashboard" do
     visit search_analytics_path
 
     expect_first_improvement_term_page
-
-    click_link "Next"
-
-    expect(current_url).to include("term_page=2")
-    expect_second_improvement_term_page
+    expect_search_term_pagination
+    expect_second_improvement_term_page_after_next
   end
 
   def stub_search_analytics(period, view)
@@ -87,6 +84,19 @@ RSpec.describe "Search analytics dashboard" do
     expect(improvement_term_queries).not_to include("3926909090")
   end
 
+  def expect_search_term_pagination
+    expect(page).to have_css(".govuk-pagination__list")
+    expect(page).to have_link("1", class: "govuk-pagination__link")
+    expect(page).to have_link("2", class: "govuk-pagination__link")
+  end
+
+  def expect_second_improvement_term_page_after_next
+    click_link "Next"
+    expect(current_url).to include("page=2")
+    expect(current_url).not_to include("term_page")
+    expect_second_improvement_term_page
+  end
+
   def expect_default_dashboard_content
     expect(page).to have_content("Search dashboard")
     expect(page).to have_content("Searches")
@@ -94,10 +104,12 @@ RSpec.describe "Search analytics dashboard" do
     expect(page).to have_content("Failure rate")
     expect(page).to have_content("1.2%")
     expect(page).to have_content("Generated 10 June 2026 at 09:55")
-    expect(page).to have_content("data through 10 June 2026 at 09:50")
+    expect(page).not_to have_content("Query window ended")
     expect(page).to have_css(".govuk-details", text: "How these metrics are calculated")
-    expect(page).to have_content("Zero-result rate Completed searches with no results divided by completed searches.")
-    expect(page).to have_content("Selection rate Result selections divided by eligible searches.")
+    expect(page).to have_css(".govuk-summary-list__row", text: "Zero-result rate", visible: :all)
+    expect(page).to have_css(".govuk-summary-list__row", text: "Completed searches with no results divided by completed searches.", visible: :all)
+    expect(page).to have_css(".govuk-summary-list__row", text: "Selection rate", visible: :all)
+    expect(page).to have_css(".govuk-summary-list__row", text: "Result selections divided by eligible searches.", visible: :all)
     expect(page).to have_content("Can exceed 100% when users open more than one result.")
     expect(page).to have_content("Zero search terms")
     expect(page).not_to have_css("section[aria-labelledby='zero-search-terms-heading']", text: "Selection rate")

--- a/spec/features/search_analytics_dashboard_spec.rb
+++ b/spec/features/search_analytics_dashboard_spec.rb
@@ -1,0 +1,130 @@
+RSpec.describe "Search analytics dashboard" do
+  include_context "with UK service"
+
+  before do
+    stub_search_analytics("24h", "all")
+    stub_search_analytics("7d", "all")
+    stub_search_analytics("30d", "all")
+    stub_search_analytics("24h", "classic")
+    stub_search_analytics("24h", "internal")
+  end
+
+  it "renders the default dashboard from the backend contract fixture", :aggregate_failures do
+    visit search_analytics_path
+
+    expect_default_dashboard_content
+  end
+
+  it "renders each period link from fixture-backed data", :aggregate_failures do
+    visit search_analytics_path
+
+    expect_period_link("7 days", content: "8,420", query: "period=7d")
+    expect_period_link("30 days", content: "36,100", query: "period=30d")
+  end
+
+  it "renders each view link from fixture-backed data", :aggregate_failures do
+    visit search_analytics_path
+
+    expect_view_link("Classic", content: "classic term", value: "710")
+    expect_view_link("Internal", content: "internal term", value: "530")
+  end
+
+  it "filters improvement terms to non-numeric searches", :aggregate_failures do
+    visit search_analytics_path
+
+    click_link "Non-numeric"
+
+    expect(current_url).to include("term_filter=non_numeric")
+    expect(improvement_term_queries).to include("yoga ball", "phone case")
+    expect(improvement_term_queries).not_to include("3926909090")
+  end
+
+  it "paginates improvement terms", :aggregate_failures do
+    visit search_analytics_path
+
+    expect_first_improvement_term_page
+
+    click_link "Next"
+
+    expect(current_url).to include("term_page=2")
+    expect_second_improvement_term_page
+  end
+
+  def stub_search_analytics(period, view)
+    stub_api_request("/search_analytics")
+      .with(query: { period:, view: })
+      .to_return(
+        status: 200,
+        headers: { "content-type" => "application/json; charset=utf-8" },
+        body: Rails.root.join("spec/fixtures/search_analytics/#{period}_#{view}.json").read,
+      )
+  end
+
+  def non_empty_chart_payloads
+    page.all("canvas.search-analytics-chart").filter_map do |canvas|
+      payload = JSON.parse(canvas["data-chart"])
+      payload if payload.fetch("labels").any? && payload.fetch("datasets").all? { |dataset| dataset.fetch("data").any? }
+    end
+  end
+
+  def chart_datasets
+    page.all("canvas.search-analytics-chart").flat_map do |canvas|
+      JSON.parse(canvas["data-chart"]).fetch("datasets")
+    end
+  end
+
+  def improvement_term_queries
+    page.all("[data-improvement-term-query]").map(&:text)
+  end
+
+  def expect_first_improvement_term_page
+    expect(improvement_term_queries).to include("3926909090")
+    expect(improvement_term_queries).not_to include("ceramic mug")
+  end
+
+  def expect_second_improvement_term_page
+    expect(improvement_term_queries).to include("ceramic mug")
+    expect(improvement_term_queries).not_to include("3926909090")
+  end
+
+  def expect_default_dashboard_content
+    expect(page).to have_content("Search dashboard")
+    expect(page).to have_content("Searches")
+    expect(page).to have_content("1,240")
+    expect(page).to have_content("Failure rate")
+    expect(page).to have_content("1.2%")
+    expect(page).to have_content("Generated 10 June 2026 at 09:55")
+    expect(page).to have_content("data through 10 June 2026 at 09:50")
+    expect(page).to have_css(".govuk-details", text: "How these metrics are calculated")
+    expect(page).to have_content("Zero-result rate Completed searches with no results divided by completed searches.")
+    expect(page).to have_content("Selection rate Result selections divided by eligible searches.")
+    expect(page).to have_content("Can exceed 100% when users open more than one result.")
+    expect(page).to have_content("Zero search terms")
+    expect(page).not_to have_css("section[aria-labelledby='zero-search-terms-heading']", text: "Selection rate")
+    expect(page).not_to have_css("section[aria-labelledby='zero-search-terms-heading']", text: "Searches")
+    expect(page).to have_css("section[aria-labelledby='zero-search-terms-heading']", text: "Zero-result searches")
+    expect(page).to have_content("Searches by view")
+    expect(page).to have_content("3926909090")
+    expect(page).to have_css(".search-analytics-chart-container", count: 2)
+    expect(page).to have_css(".search-analytics-view-summary")
+    expect(page).to have_css(".search-analytics-view-summary__table")
+    expect(page).to have_content("Classic")
+    expect(page).to have_content("Internal")
+    expect(page).to have_link("Non-numeric")
+    expect(page).to have_link("Next")
+    expect(chart_datasets).to all(include("borderColor"))
+    expect(non_empty_chart_payloads.size).to eq(2)
+  end
+
+  def expect_period_link(label, content:, query:)
+    click_link label
+    expect(page).to have_content(content)
+    expect(current_url).to include(query)
+  end
+
+  def expect_view_link(label, content:, value:)
+    click_link label
+    expect(page).to have_content(content)
+    expect(page).to have_content(value)
+  end
+end

--- a/spec/fixtures/search_analytics/24h_all.json
+++ b/spec/fixtures/search_analytics/24h_all.json
@@ -38,18 +38,22 @@
         "internal": { "searches": 530, "zero_result_rate": 0.1, "selection_rate": 0.38, "p90_latency_ms": 2400 }
       },
       "improvement_terms": [
-        { "query": "3926909090", "searches": 40, "zero_results": 18, "selection_rate": 0.12 },
-        { "query": "4202129000", "searches": 28, "zero_results": 14, "selection_rate": 0.21 },
-        { "query": "9031809090", "searches": 24, "zero_results": 13, "selection_rate": 0.18 },
-        { "query": "9603909090", "searches": 21, "zero_results": 12, "selection_rate": 0.1 },
-        { "query": "3304990039", "searches": 20, "zero_results": 11, "selection_rate": 0.3 },
-        { "query": "3304990099", "searches": 19, "zero_results": 10, "selection_rate": 0.16 },
-        { "query": "0000000000", "searches": 18, "zero_results": 9, "selection_rate": 0.0 },
-        { "query": "bike seat", "searches": 17, "zero_results": 8, "selection_rate": 0.12 },
-        { "query": "yoga ball", "searches": 16, "zero_results": 7, "selection_rate": 0.19 },
-        { "query": "phone case", "searches": 15, "zero_results": 6, "selection_rate": 0.21 },
-        { "query": "ceramic mug", "searches": 14, "zero_results": 5, "selection_rate": 0.14 },
-        { "query": "garden lights", "searches": 13, "zero_results": 4, "selection_rate": 0.08 }
+        { "query": "bike seat", "zero_results": 18, "term_type": "search_terms" },
+        { "query": "yoga ball", "zero_results": 17, "term_type": "search_terms" },
+        { "query": "phone case", "zero_results": 16, "term_type": "search_terms" },
+        { "query": "garden lights", "zero_results": 15, "term_type": "search_terms" },
+        { "query": "ceramic mug", "zero_results": 14, "term_type": "search_terms" },
+        { "query": "running shoes", "zero_results": 13, "term_type": "search_terms" },
+        { "query": "cotton scarf", "zero_results": 12, "term_type": "search_terms" },
+        { "query": "phone charger", "zero_results": 11, "term_type": "search_terms" },
+        { "query": "laptop stand", "zero_results": 10, "term_type": "search_terms" },
+        { "query": "desk lamp", "zero_results": 9, "term_type": "search_terms" },
+        { "query": "storage box", "zero_results": 8, "term_type": "search_terms" },
+        { "query": "3926909090", "zero_results": 18, "term_type": "item_ids" },
+        { "query": "4202129000", "zero_results": 14, "term_type": "item_ids" },
+        { "query": "9031809090", "zero_results": 13, "term_type": "item_ids" },
+        { "query": "9603909090", "zero_results": 12, "term_type": "item_ids" },
+        { "query": "3304990039", "zero_results": 11, "term_type": "item_ids" }
       ]
     }
   }

--- a/spec/fixtures/search_analytics/24h_all.json
+++ b/spec/fixtures/search_analytics/24h_all.json
@@ -1,0 +1,56 @@
+{
+  "data": {
+    "id": "uk-24h-all",
+    "type": "search_analytics",
+    "attributes": {
+      "service": "uk",
+      "period": "24h",
+      "view": "all",
+      "bucket_size": "hour",
+      "generated_at": "2026-06-10T09:55:00Z",
+      "data_through": "2026-06-10T09:50:00Z",
+      "summary": {
+        "searches": 1240,
+        "failure_rate": 0.012,
+        "zero_result_rate": 0.084,
+        "selection_rate": 0.41,
+        "p90_latency_ms": 1800
+      },
+      "summary_statuses": {
+        "searches": { "level": "neutral", "message": "Search volume is available for this period" },
+        "failure_rate": { "level": "good", "message": "Failures are low" },
+        "zero_result_rate": { "level": "watch", "message": "Zero-result searches are slightly higher than usual" },
+        "selection_rate": { "level": "good", "message": "Selections are tracking search volume" },
+        "p90_latency_ms": { "level": "watch", "message": "Some searches are taking longer than usual" }
+      },
+      "trends": {
+        "volume": [
+          { "bucket": "2026-06-10T08:00:00Z", "all": 48, "classic": 28, "internal": 20 },
+          { "bucket": "2026-06-10T09:00:00Z", "all": 52, "classic": 31, "internal": 21 }
+        ],
+        "outcomes": [
+          { "bucket": "2026-06-10T08:00:00Z", "completed": 47, "failed": 1, "zero_result": 3, "selected": 18 },
+          { "bucket": "2026-06-10T09:00:00Z", "completed": 50, "failed": 2, "zero_result": 4, "selected": 19 }
+        ]
+      },
+      "comparisons": {
+        "classic": { "searches": 710, "zero_result_rate": 0.07, "selection_rate": 0.43, "p90_latency_ms": 620 },
+        "internal": { "searches": 530, "zero_result_rate": 0.1, "selection_rate": 0.38, "p90_latency_ms": 2400 }
+      },
+      "improvement_terms": [
+        { "query": "3926909090", "searches": 40, "zero_results": 18, "selection_rate": 0.12 },
+        { "query": "4202129000", "searches": 28, "zero_results": 14, "selection_rate": 0.21 },
+        { "query": "9031809090", "searches": 24, "zero_results": 13, "selection_rate": 0.18 },
+        { "query": "9603909090", "searches": 21, "zero_results": 12, "selection_rate": 0.1 },
+        { "query": "3304990039", "searches": 20, "zero_results": 11, "selection_rate": 0.3 },
+        { "query": "3304990099", "searches": 19, "zero_results": 10, "selection_rate": 0.16 },
+        { "query": "0000000000", "searches": 18, "zero_results": 9, "selection_rate": 0.0 },
+        { "query": "bike seat", "searches": 17, "zero_results": 8, "selection_rate": 0.12 },
+        { "query": "yoga ball", "searches": 16, "zero_results": 7, "selection_rate": 0.19 },
+        { "query": "phone case", "searches": 15, "zero_results": 6, "selection_rate": 0.21 },
+        { "query": "ceramic mug", "searches": 14, "zero_results": 5, "selection_rate": 0.14 },
+        { "query": "garden lights", "searches": 13, "zero_results": 4, "selection_rate": 0.08 }
+      ]
+    }
+  }
+}

--- a/spec/fixtures/search_analytics/24h_classic.json
+++ b/spec/fixtures/search_analytics/24h_classic.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "id": "uk-24h-classic",
+    "type": "search_analytics",
+    "attributes": {
+      "service": "uk",
+      "period": "24h",
+      "view": "classic",
+      "bucket_size": "hour",
+      "generated_at": "2026-06-10T09:55:00Z",
+      "data_through": "2026-06-10T09:50:00Z",
+      "summary": { "searches": 710, "failure_rate": 0.006, "zero_result_rate": 0.07, "selection_rate": 0.43, "p90_latency_ms": 620 },
+      "summary_statuses": {
+        "searches": { "level": "neutral", "message": "Search volume is available for this period" },
+        "failure_rate": { "level": "good", "message": "Failures are low" },
+        "zero_result_rate": { "level": "good", "message": "Most searches are returning results" },
+        "selection_rate": { "level": "good", "message": "Selections are tracking search volume" },
+        "p90_latency_ms": { "level": "good", "message": "Most searches are completing quickly" }
+      },
+      "trends": { "volume": [{ "bucket": "2026-06-10T09:00:00Z", "all": 31, "classic": 31, "internal": 0 }], "outcomes": [{ "bucket": "2026-06-10T09:00:00Z", "completed": 31, "failed": 0, "zero_result": 2, "selected": 13 }] },
+      "comparisons": { "classic": { "searches": 710, "zero_result_rate": 0.07, "selection_rate": 0.43, "p90_latency_ms": 620 }, "internal": { "searches": 530, "zero_result_rate": 0.1, "selection_rate": 0.38, "p90_latency_ms": 2400 } },
+      "improvement_terms": [{ "query": "classic term", "searches": 18, "zero_results": 5, "selection_rate": 0.22 }]
+    }
+  }
+}

--- a/spec/fixtures/search_analytics/24h_internal.json
+++ b/spec/fixtures/search_analytics/24h_internal.json
@@ -1,0 +1,25 @@
+{
+  "data": {
+    "id": "uk-24h-internal",
+    "type": "search_analytics",
+    "attributes": {
+      "service": "uk",
+      "period": "24h",
+      "view": "internal",
+      "bucket_size": "hour",
+      "generated_at": "2026-06-10T09:55:00Z",
+      "data_through": "2026-06-10T09:50:00Z",
+      "summary": { "searches": 530, "failure_rate": 0.02, "zero_result_rate": 0.1, "selection_rate": 0.38, "p90_latency_ms": 2400 },
+      "summary_statuses": {
+        "searches": { "level": "neutral", "message": "Search volume is available for this period" },
+        "failure_rate": { "level": "watch", "message": "Failures are slightly higher than usual" },
+        "zero_result_rate": { "level": "watch", "message": "Zero-result searches are slightly higher than usual" },
+        "selection_rate": { "level": "good", "message": "Selections are tracking search volume" },
+        "p90_latency_ms": { "level": "watch", "message": "Some searches are taking longer than usual" }
+      },
+      "trends": { "volume": [{ "bucket": "2026-06-10T09:00:00Z", "all": 21, "classic": 0, "internal": 21 }], "outcomes": [{ "bucket": "2026-06-10T09:00:00Z", "completed": 20, "failed": 1, "zero_result": 2, "selected": 8 }] },
+      "comparisons": { "classic": { "searches": 710, "zero_result_rate": 0.07, "selection_rate": 0.43, "p90_latency_ms": 620 }, "internal": { "searches": 530, "zero_result_rate": 0.1, "selection_rate": 0.38, "p90_latency_ms": 2400 } },
+      "improvement_terms": [{ "query": "internal term", "searches": 15, "zero_results": 6, "selection_rate": 0.13 }]
+    }
+  }
+}

--- a/spec/fixtures/search_analytics/30d_all.json
+++ b/spec/fixtures/search_analytics/30d_all.json
@@ -1,0 +1,37 @@
+{
+  "data": {
+    "id": "uk-30d-all",
+    "type": "search_analytics",
+    "attributes": {
+      "service": "uk",
+      "period": "30d",
+      "view": "all",
+      "bucket_size": "day",
+      "generated_at": "2026-06-10T09:55:00Z",
+      "data_through": "2026-06-10T09:50:00Z",
+      "summary": { "searches": 36100, "failure_rate": 0.011, "zero_result_rate": 0.079, "selection_rate": 0.42, "p90_latency_ms": 1720 },
+      "summary_statuses": {
+        "searches": { "level": "neutral", "message": "Search volume is available for this period" },
+        "failure_rate": { "level": "good", "message": "Failures are low" },
+        "zero_result_rate": { "level": "good", "message": "Most searches are returning results" },
+        "selection_rate": { "level": "good", "message": "Selections are tracking search volume" },
+        "p90_latency_ms": { "level": "watch", "message": "Some searches are taking longer than usual" }
+      },
+      "trends": {
+        "volume": [
+          { "bucket": "2026-05-12T00:00:00Z", "all": 1110, "classic": 650, "internal": 460 },
+          { "bucket": "2026-06-10T00:00:00Z", "all": 1240, "classic": 710, "internal": 530 }
+        ],
+        "outcomes": [
+          { "bucket": "2026-05-12T00:00:00Z", "completed": 1100, "failed": 10, "zero_result": 86, "selected": 462 },
+          { "bucket": "2026-06-10T00:00:00Z", "completed": 1226, "failed": 14, "zero_result": 91, "selected": 521 }
+        ]
+      },
+      "comparisons": {
+        "classic": { "searches": 21400, "zero_result_rate": 0.07, "selection_rate": 0.44, "p90_latency_ms": 640 },
+        "internal": { "searches": 14700, "zero_result_rate": 0.1, "selection_rate": 0.39, "p90_latency_ms": 2300 }
+      },
+      "improvement_terms": [{ "query": "trainers", "searches": 990, "zero_results": 290, "selection_rate": 0.16 }]
+    }
+  }
+}

--- a/spec/fixtures/search_analytics/7d_all.json
+++ b/spec/fixtures/search_analytics/7d_all.json
@@ -1,0 +1,37 @@
+{
+  "data": {
+    "id": "uk-7d-all",
+    "type": "search_analytics",
+    "attributes": {
+      "service": "uk",
+      "period": "7d",
+      "view": "all",
+      "bucket_size": "day",
+      "generated_at": "2026-06-10T09:55:00Z",
+      "data_through": "2026-06-10T09:50:00Z",
+      "summary": { "searches": 8420, "failure_rate": 0.009, "zero_result_rate": 0.071, "selection_rate": 0.44, "p90_latency_ms": 1650 },
+      "summary_statuses": {
+        "searches": { "level": "neutral", "message": "Search volume is available for this period" },
+        "failure_rate": { "level": "good", "message": "Failures are low" },
+        "zero_result_rate": { "level": "good", "message": "Most searches are returning results" },
+        "selection_rate": { "level": "good", "message": "Selections are tracking search volume" },
+        "p90_latency_ms": { "level": "watch", "message": "Some searches are taking longer than usual" }
+      },
+      "trends": {
+        "volume": [
+          { "bucket": "2026-06-04T00:00:00Z", "all": 1170, "classic": 690, "internal": 480 },
+          { "bucket": "2026-06-10T00:00:00Z", "all": 1240, "classic": 710, "internal": 530 }
+        ],
+        "outcomes": [
+          { "bucket": "2026-06-04T00:00:00Z", "completed": 1160, "failed": 10, "zero_result": 82, "selected": 512 },
+          { "bucket": "2026-06-10T00:00:00Z", "completed": 1228, "failed": 12, "zero_result": 88, "selected": 546 }
+        ]
+      },
+      "comparisons": {
+        "classic": { "searches": 4890, "zero_result_rate": 0.06, "selection_rate": 0.46, "p90_latency_ms": 610 },
+        "internal": { "searches": 3530, "zero_result_rate": 0.09, "selection_rate": 0.4, "p90_latency_ms": 2200 }
+      },
+      "improvement_terms": [{ "query": "chargers", "searches": 220, "zero_results": 65, "selection_rate": 0.18 }]
+    }
+  }
+}

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe NavigationHelper, type: :helper do
       )
     end
 
-    it "defines Classification with 6 items" do
+    it "defines Classification with 7 items" do
       section = helper.navigation_sections.find { |s| s.key == :classification }
-      expect(section.items.map(&:text)).to eq(["Search References", "Descriptions", "Configuration", "Intercepts", "Diagnostics", "Recent changes"])
+      expect(section.items.map(&:text)).to eq(["Search References", "Descriptions", "Configuration", "Intercepts", "Search dashboard", "Search diagnostics", "Recent changes"])
     end
 
     it "defines SPIMM with xi service restriction" do
@@ -81,7 +81,7 @@ RSpec.describe NavigationHelper, type: :helper do
                          "Reports",
                          "Rollbacks",
                        ],
-                       classification: ["Search References", "Descriptions", "Configuration", "Intercepts", "Diagnostics", "Recent changes"],
+                       classification: ["Search References", "Descriptions", "Configuration", "Intercepts", "Search dashboard", "Search diagnostics", "Recent changes"],
                        manage_users: nil
     end
 
@@ -92,7 +92,7 @@ RSpec.describe NavigationHelper, type: :helper do
 
       include_examples "visible sections and items",
                        ott_admin: ["News", "Live Issues"],
-                       classification: ["Search References", "Diagnostics"]
+                       classification: ["Search References", "Search dashboard", "Search diagnostics"]
     end
 
     context "with UK service and auditor role" do
@@ -109,7 +109,7 @@ RSpec.describe NavigationHelper, type: :helper do
                          "Updates",
                          "Rollbacks",
                        ],
-                       classification: ["Search References", "Configuration", "Diagnostics"]
+                       classification: ["Search References", "Configuration", "Search dashboard", "Search diagnostics"]
     end
 
     context "with UK service and guest role" do
@@ -129,7 +129,7 @@ RSpec.describe NavigationHelper, type: :helper do
 
       include_examples "visible sections and items",
                        ott_admin: ["Section & chapter notes", "Updates", "Reports", "Rollbacks"],
-                       classification: ["Search References", "Descriptions", "Diagnostics", "Recent changes"],
+                       classification: ["Search References", "Descriptions", "Search dashboard", "Search diagnostics", "Recent changes"],
                        spimm: [
                          "Category Assessments",
                          "Exemptions",
@@ -147,7 +147,7 @@ RSpec.describe NavigationHelper, type: :helper do
       let(:user) { build(:user, :hmrc_admin) }
 
       include_examples "visible sections and items",
-                       classification: ["Search References", "Diagnostics"]
+                       classification: ["Search References", "Search dashboard", "Search diagnostics"]
     end
 
     context "with XI service and auditor role" do
@@ -157,7 +157,7 @@ RSpec.describe NavigationHelper, type: :helper do
 
       include_examples "visible sections and items",
                        ott_admin: ["Section & chapter notes", "Updates", "Rollbacks"],
-                       classification: ["Search References", "Diagnostics"],
+                       classification: ["Search References", "Search dashboard", "Search diagnostics"],
                        spimm: [
                          "Category Assessments",
                          "Exemptions",

--- a/spec/helpers/search_analytics_helper_spec.rb
+++ b/spec/helpers/search_analytics_helper_spec.rb
@@ -59,10 +59,21 @@ RSpec.describe SearchAnalyticsHelper do
     let(:payload_with_zero_series) do
       helper.search_analytics_chart_payload(
         [
-          { bucket: "2026-06-10T09:00:00Z", completed: 52, failed: 0 },
-          { bucket: "2026-06-10T10:00:00Z", completed: 48, failed: 0 },
+          { bucket: "2026-06-10T09:00:00Z", completed: 52, failed: "0" },
+          { bucket: "2026-06-10T10:00:00Z", completed: 48, failed: "0" },
         ],
         series: { completed: "Completed", failed: "Failed" },
+      )
+    end
+
+    let(:payload_with_negligible_series) do
+      helper.search_analytics_chart_payload(
+        [
+          { bucket: "2026-06-10T09:00:00Z", all: 140_000, classic: 139_990, internal: 10 },
+          { bucket: "2026-06-10T10:00:00Z", all: 140_000, classic: 139_990, internal: 10 },
+        ],
+        series: { all: "All", classic: "Classic", internal: "Internal" },
+        minimum_series_share: 1,
       )
     end
 
@@ -76,6 +87,10 @@ RSpec.describe SearchAnalyticsHelper do
 
     it "omits chart series that are zero for every bucket" do
       expect(JSON.parse(payload_with_zero_series).fetch("datasets").pluck("label")).to eq(%w[Completed])
+    end
+
+    it "omits chart series below the configured share of the largest series" do
+      expect(JSON.parse(payload_with_negligible_series).fetch("datasets").pluck("label")).to eq(%w[All Classic])
     end
   end
 

--- a/spec/helpers/search_analytics_helper_spec.rb
+++ b/spec/helpers/search_analytics_helper_spec.rb
@@ -1,0 +1,145 @@
+RSpec.describe SearchAnalyticsHelper do
+  describe "#search_analytics_number" do
+    it "formats large numbers with delimiters" do
+      expect(helper.search_analytics_number(12_400)).to eq("12,400")
+    end
+  end
+
+  describe "#search_analytics_percentage" do
+    it "formats rates as percentages" do
+      expect(helper.search_analytics_percentage(0.084)).to eq("8.4%")
+    end
+  end
+
+  describe "#search_analytics_latency" do
+    it "formats millisecond latency as seconds" do
+      expect(helper.search_analytics_latency(1_800)).to eq("1.8s")
+    end
+  end
+
+  describe "#search_analytics_status_tag_class" do
+    it "maps status levels to GOV.UK tag classes", :aggregate_failures do
+      expect(helper.search_analytics_status_tag_class("good")).to eq("govuk-tag govuk-tag--green")
+      expect(helper.search_analytics_status_tag_class("watch")).to eq("govuk-tag govuk-tag--yellow")
+      expect(helper.search_analytics_status_tag_class("problem")).to eq("govuk-tag govuk-tag--red")
+      expect(helper.search_analytics_status_tag_class("neutral")).to eq("govuk-tag govuk-tag--blue")
+    end
+  end
+
+  describe "#search_analytics_chart_payload" do
+    let(:trend_payload) do
+      helper.search_analytics_chart_payload(
+        [
+          { bucket: "2026-06-10T09:00:00Z", all: 52, classic: 31 },
+          { bucket: "2026-06-10T10:00:00Z", all: 48, classic: 29 },
+        ],
+        series: { all: "All", classic: "Classic" },
+      )
+    end
+
+    let(:daily_payload) do
+      helper.search_analytics_chart_payload(
+        [
+          { bucket: "2026-06-10T00:00:00Z", all: 52 },
+        ],
+        series: { all: "All" },
+      )
+    end
+
+    let(:expected_trend_payload) do
+      {
+        "labels" => ["09:00", "10:00"],
+        "datasets" => [
+          include("label" => "All", "data" => [52, 48], "borderColor" => "#144e81", "backgroundColor" => "#144e81"),
+          include("label" => "Classic", "data" => [31, 29], "borderColor" => "#005a30", "backgroundColor" => "#005a30"),
+        ],
+      }
+    end
+
+    it "builds chart JSON from trend rows" do
+      expect(JSON.parse(trend_payload)).to match(expected_trend_payload)
+    end
+
+    it "labels daily buckets as dates" do
+      expect(JSON.parse(daily_payload).fetch("labels")).to eq(["10 Jun"])
+    end
+  end
+
+  describe "#search_analytics_comparison_chart_payload" do
+    let(:comparison_payload) do
+      helper.search_analytics_comparison_chart_payload(
+        {
+          classic: { searches: 710 },
+          internal: { searches: 530 },
+        },
+      )
+    end
+
+    let(:expected_comparison_payload) do
+      {
+        "labels" => %w[Classic Internal],
+        "datasets" => [
+          include("label" => "Searches", "data" => [710, 530], "borderColor" => "#144e81", "backgroundColor" => "#144e81"),
+        ],
+      }
+    end
+
+    it "builds chart JSON from comparison rows" do
+      expect(JSON.parse(comparison_payload)).to match(expected_comparison_payload)
+    end
+  end
+
+  describe "#search_analytics_view_summary_rows" do
+    let(:rows) do
+      helper.search_analytics_view_summary_rows(
+        {
+          classic: { searches: 710 },
+          internal: { searches: 530 },
+        },
+      )
+    end
+
+    it "builds proportional rows for the comparison summary" do
+      expect(rows).to contain_exactly(
+        include(label: "Classic", searches: 710, percentage: "57.3%", width: 57.3),
+        include(label: "Internal", searches: 530, percentage: "42.7%", width: 42.7),
+      )
+    end
+  end
+
+  describe "#search_analytics_show_view_summary?" do
+    subject(:show_view_summary) { helper.search_analytics_show_view_summary?(comparisons) }
+
+    context "when internal searches have meaningful volume" do
+      let(:comparisons) do
+        {
+          classic: { searches: 9_900 },
+          internal: { searches: 100 },
+        }
+      end
+
+      it "shows the summary" do
+        expect(show_view_summary).to be(true)
+      end
+    end
+
+    context "when internal searches are negligible" do
+      let(:comparisons) do
+        {
+          classic: { searches: 131_468 },
+          internal: { searches: 0 },
+        }
+      end
+
+      it "hides the summary" do
+        expect(show_view_summary).to be(false)
+      end
+    end
+  end
+
+  describe "#search_analytics_timestamp" do
+    it "formats ISO timestamps for the dashboard" do
+      expect(helper.search_analytics_timestamp("2026-06-10T09:55:00Z")).to eq("10 June 2026 at 09:55")
+    end
+  end
+end

--- a/spec/helpers/search_analytics_helper_spec.rb
+++ b/spec/helpers/search_analytics_helper_spec.rb
@@ -56,12 +56,26 @@ RSpec.describe SearchAnalyticsHelper do
       }
     end
 
+    let(:payload_with_zero_series) do
+      helper.search_analytics_chart_payload(
+        [
+          { bucket: "2026-06-10T09:00:00Z", completed: 52, failed: 0 },
+          { bucket: "2026-06-10T10:00:00Z", completed: 48, failed: 0 },
+        ],
+        series: { completed: "Completed", failed: "Failed" },
+      )
+    end
+
     it "builds chart JSON from trend rows" do
       expect(JSON.parse(trend_payload)).to match(expected_trend_payload)
     end
 
     it "labels daily buckets as dates" do
       expect(JSON.parse(daily_payload).fetch("labels")).to eq(["10 Jun"])
+    end
+
+    it "omits chart series that are zero for every bucket" do
+      expect(JSON.parse(payload_with_zero_series).fetch("datasets").pluck("label")).to eq(%w[Completed])
     end
   end
 

--- a/spec/models/search_analytics_spec.rb
+++ b/spec/models/search_analytics_spec.rb
@@ -1,0 +1,53 @@
+RSpec.describe SearchAnalytics do
+  describe ".fetch" do
+    subject(:analytics) { described_class.fetch(period: "24h", view: "all") }
+
+    let(:expected_attributes) do
+      {
+        resource_id: "uk-24h-all",
+        service: "uk",
+        period: "24h",
+        view: "all",
+        bucket_size: "hour",
+      }
+    end
+
+    before do
+      stub_api_request("/search_analytics")
+        .with(query: { period: "24h", view: "all" })
+        .to_return jsonapi_response(
+          :search_analytics,
+          {
+            resource_id: "uk-24h-all",
+            service: "uk",
+            period: "24h",
+            view: "all",
+            bucket_size: "hour",
+            generated_at: "2026-06-10T09:55:00Z",
+            data_through: "2026-06-10T09:50:00Z",
+            summary: {
+              searches: 1_240,
+              failure_rate: 0.012,
+            },
+            trends: {
+              volume: [
+                { bucket: "2026-06-10T09:00:00Z", all: 52 },
+              ],
+            },
+          },
+        )
+    end
+
+    it "fetches the dashboard attributes from the backend" do
+      expect(analytics).to have_attributes(expected_attributes)
+    end
+
+    it "parses the summary payload" do
+      expect(analytics.summary[:searches]).to eq(1_240)
+    end
+
+    it "parses the trend payload" do
+      expect(analytics.trends.dig(:volume, 0, :all)).to eq(52)
+    end
+  end
+end

--- a/spec/policies/search_analytics_policy_spec.rb
+++ b/spec/policies/search_analytics_policy_spec.rb
@@ -1,0 +1,23 @@
+RSpec.describe SearchAnalyticsPolicy do
+  subject(:policy) { described_class }
+
+  let(:analytics) { SearchAnalytics.new(period: "24h", view: "all") }
+
+  permissions :index? do
+    it "grants access to technical operator" do
+      expect(policy).to permit(create(:user, :technical_operator), analytics)
+    end
+
+    it "grants access to hmrc admin" do
+      expect(policy).to permit(create(:user, :hmrc_admin), analytics)
+    end
+
+    it "grants access to auditor" do
+      expect(policy).to permit(create(:user, :auditor), analytics)
+    end
+
+    it "denies access to guest user" do
+      expect(policy).not_to permit(create(:user, :guest), analytics)
+    end
+  end
+end

--- a/spec/requests/search_analytics_controller_spec.rb
+++ b/spec/requests/search_analytics_controller_spec.rb
@@ -98,7 +98,8 @@ RSpec.describe SearchAnalyticsController do
     expect(response.body).to include("Zero-result rate", "8.4%")
     expect(response.body).to include("Selection rate", "41%")
     expect(response.body).to include("P90 latency", "1.8s")
-    expect(response.body).to include("Generated 10 June 2026 at 09:55", "data through 10 June 2026 at 09:50")
+    expect(response.body).to include("Generated 10 June 2026 at 09:55")
+    expect(response.body).not_to include("Query window ended")
     expect(response.body).to include("Zero search terms")
   end
 end

--- a/spec/requests/search_analytics_controller_spec.rb
+++ b/spec/requests/search_analytics_controller_spec.rb
@@ -1,0 +1,104 @@
+RSpec.describe SearchAnalyticsController do
+  subject(:rendered_page) { make_request && response }
+
+  include_context "with authenticated user"
+
+  let(:analytics) do
+    SearchAnalytics.new(
+      period: "24h",
+      view: "all",
+      generated_at: "2026-06-10T09:55:00Z",
+      data_through: "2026-06-10T09:50:00Z",
+      summary: {
+        searches: 1_240,
+        failure_rate: 0.012,
+        zero_result_rate: 0.084,
+        selection_rate: 0.41,
+        p90_latency_ms: 1_800,
+      },
+      summary_statuses: {
+        failure_rate: { level: "good", message: "Failures are low" },
+      },
+      trends: {
+        volume: [
+          { bucket: "2026-06-10T09:00:00Z", all: 52, classic: 31, internal: 21 },
+        ],
+        outcomes: [
+          { bucket: "2026-06-10T09:00:00Z", completed: 50, failed: 2, zero_result: 4, selected: 19 },
+        ],
+      },
+      comparisons: {
+        classic: { searches: 710, zero_result_rate: 0.07, selection_rate: 0.43, p90_latency_ms: 620 },
+      },
+      improvement_terms: [
+        { query: "trainers", searches: 40, zero_results: 18, selection_rate: 0.12 },
+      ],
+    )
+  end
+
+  before do
+    allow(SearchAnalytics).to receive(:fetch).and_return(analytics)
+  end
+
+  describe "GET #index" do
+    let(:make_request) { get search_analytics_path }
+
+    it { is_expected.to have_http_status :success }
+
+    it "fetches the default dashboard" do
+      rendered_page
+
+      expect(SearchAnalytics).to have_received(:fetch).with(period: "24h", view: "all")
+    end
+
+    it "renders filters and the five top metrics" do
+      rendered_page
+
+      expect_dashboard_content
+    end
+
+    context "with filters" do
+      let(:make_request) { get search_analytics_path, params: { period: "7d", view: "classic" } }
+
+      it "passes period and view through" do
+        rendered_page
+
+        expect(SearchAnalytics).to have_received(:fetch).with(period: "7d", view: "classic")
+      end
+    end
+
+    context "when analytics are not available yet" do
+      before do
+        allow(SearchAnalytics).to receive(:fetch).and_raise(Faraday::ResourceNotFound.new("missing snapshots"))
+      end
+
+      it "renders the dashboard instead of redirecting back to itself" do
+        expect(rendered_page).to have_http_status(:success)
+      end
+
+      it "shows that analytics are unavailable" do
+        rendered_page
+
+        expect(response.body).to include("Search analytics are not available yet.")
+      end
+    end
+
+    context "when unauthorised" do
+      let(:current_user) { create(:user, :guest) }
+
+      it { is_expected.to have_http_status :forbidden }
+    end
+  end
+
+  def expect_dashboard_content
+    expect(response.body).to include("24 hours", "7 days", "30 days", "All", "Classic", "Internal")
+    expect(response.body).not_to include("Suggestions")
+    expect(response.body).to include("Searches", "1,240")
+    expect(response.body).to include("Failure rate", "1.2%")
+    expect(response.body).to include("Zero-result rate", "8.4%")
+    expect(response.body).to include("Selection rate", "41%")
+    expect(response.body).to include("P90 latency", "1.8s")
+    expect(response.body).to include("Generated 10 June 2026 at 09:55", "data through 10 June 2026 at 09:50")
+    expect(response.body).to include("Zero search terms")
+  end
+end


### PR DESCRIPTION
### Jira link

[AI-521](https://transformuk.atlassian.net/browse/AI-521)

<img width="905" height="1229" alt="image" src="https://github.com/user-attachments/assets/08230291-0abb-4405-81f3-786bd5f72372" />


### What?

- [x] Add a `SearchAnalytics` API entity, controller, route, and Pundit policy.
- [x] Add Search dashboard navigation next to Search diagnostics.
- [x] Render fixed period and view filters for All, Classic, and Internal search traffic.
- [x] Render five top metrics, freshness text, trend charts, comparison chart, and improvement terms.
- [x] Remove suggestion analytics from the dashboard contract and fixtures because suggestion activity is high-volume.
- [x] Add fixture-backed feature coverage for default, period, and view states.

### Why?

Admin users need a non-technical Search dashboard that explains search health and search improvement opportunities without needing CloudWatch access or request-level diagnostics knowledge.

### Risk

**Risk level:** 🟠

**Reason for rating:** Adds a new admin UI that consumes a new backend API endpoint. The surface is admin-only, read-only, and covered by model, request, policy, helper, navigation, and fixture-backed feature specs plus a browser smoke check.

