### PR TITLE
Correctly detect risk level rating from descriptions

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -30,6 +30,7 @@ Rate the overall risk of deploying this change:
 
 🟢 GREEN – things that are typically low risk:
 ───────────────────────────────────────────────────
+
 - New tests or improved test coverage with no production code changes
 - Dependency bumps with no API changes (minor/patch gems, npm packages)
 - Copy or content changes to admin UI labels, hint text, or page titles
@@ -41,6 +42,7 @@ Rate the overall risk of deploying this change:
 
 🟠 AMBER – things that need a team conversation first:
 ───────────────────────────────────────────────────
+
 - Changes to how tariff data is displayed, edited, or validated in the admin UI
 - New or modified API calls to the backend service
 - Changes to authentication or authorisation logic (AUTH_STRATEGY, identity integration)
@@ -53,6 +55,7 @@ Rate the overall risk of deploying this change:
 
 🔴 RED – requires explicit approval from Thor or Neil:
 ───────────────────────────────────────────────────
+
 - Changes to how measures, conditions, footnotes, or quotas are created or modified through the admin UI
 - Modifications to the authentication mechanism or identity service integration
 - Changes to admin user roles, permissions, or access control rules

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,60 @@
-### Jira link
+## What:
+<!-- A brief description of what this PR does -->
 
-HMRC-<TODO>
+## Why:
+<!-- The reasoning or context behind this change -->
 
-### What?
+## Ticket:
+<!-- Link to the relevant Jira/ticket, or 'N/A' if not applicable -->
 
-I have added/removed/altered:
+## Risk:
 
-- [ ] Added foo in bar
-- [ ] Removed baz
+**Risk level:** 🟢 / 🟠 / 🔴 <!-- delete as appropriate -->
 
-### Why?
+**Reason for rating:**
+<!-- One or two sentences explaining your assessment, especially for Amber or Red -->
 
-I am doing this because:
+───────────────────────────────────────────────────
 
--
--
--
+Rate the overall risk of deploying this change:
 
-### Have you? (optional)
+🟢 Green  – Low risk. Good to go, standard review applies.
 
-- [ ] Reviewed view changes with stake holders
-- [ ] Validated mobile responsive behaviour of view changes
+🟠 Amber  – Medium risk. Socialise with the team before merging.
 
-### Deployment risks (optional)
+🔴 Red    – High risk. Requires explicit approval from Thor or Neil before merging.
 
-- Validated any auth changes don't break the apps integration with the backend
+───────────────────────────────────────────────────
+
+🟢 GREEN – things that are typically low risk:
+───────────────────────────────────────────────────
+- New tests or improved test coverage with no production code changes
+- Dependency bumps with no API changes (minor/patch gems, npm packages)
+- Copy or content changes to admin UI labels, hint text, or page titles
+- Config/env var additions that are purely additive and have safe defaults
+- Refactors with full test coverage and no behaviour change
+- Adding or updating CloudWatch alarms or dashboards (read-only observability)
+- Terraform formatting or variable renaming with no resource recreation
+- Logging improvements or additional audit trail entries (additive only)
+
+🟠 AMBER – things that need a team conversation first:
+───────────────────────────────────────────────────
+- Changes to how tariff data is displayed, edited, or validated in the admin UI
+- New or modified API calls to the backend service
+- Changes to authentication or authorisation logic (AUTH_STRATEGY, identity integration)
+- Modifications to admin-only actions (section notes, measure management, quota controls)
+- Adding or changing feature flags that affect live admin journeys
+- Infrastructure changes that alter networking, security groups, or IAM permissions in non-production first
+- Terraform changes that will cause a resource replacement (check plan output carefully)
+- Changes to CI/CD pipeline steps or deployment order dependencies
+- Removing or deprecating a route, controller action, or view still in use
+
+🔴 RED – requires explicit approval from Thor or Neil:
+───────────────────────────────────────────────────
+- Changes to how measures, conditions, footnotes, or quotas are created or modified through the admin UI
+- Modifications to the authentication mechanism or identity service integration
+- Changes to admin user roles, permissions, or access control rules
+- Any change to production AWS infrastructure that cannot be easily rolled back
+- Secrets rotation or changes to how credentials are stored, scoped, or accessed
+- Database migrations that are destructive (dropping columns/tables, removing indexes)
+- Significant architectural shifts (e.g. new service boundaries or authentication providers)

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+# Pull Request
+
 ## What:
 <!-- A brief description of what this PR does -->
 

--- a/.github/workflows/risk-label.yml
+++ b/.github/workflows/risk-label.yml
@@ -1,0 +1,12 @@
+name: "Risk Label"
+
+on:
+  pull_request_target:
+    types: [opened, edited, synchronize]
+
+jobs:
+  risk-label:
+    uses: trade-tariff/trade-tariff-tools/.github/workflows/risk-label-reusable.yml@main
+    permissions:
+      contents: read
+      pull-requests: write


### PR DESCRIPTION
## What:
Adds the standardised risk rating section to the PR template with criteria tailored to this repository, and adds the risk-label workflow which delegates to [trade-tariff-tools](https://github.com/trade-tariff/trade-tariff-tools).

## Why:
Consistent risk rating across all tariff repos. The workflow auto-applies `low-risk`, `medium-risk`, or `high-risk` labels and fails the check for high-risk PRs so an admin must bypass branch protection to merge.

## Ticket:
N/A

## Risk:
**Risk level:** 🟢

**Reason for rating:**
Template and workflow file changes only — no application code affected.