### PR TITLE
AI-889: Simplify customs tariff update review

### DIFF
--- a/app/controllers/customs_tariff/updates_controller.rb
+++ b/app/controllers/customs_tariff/updates_controller.rb
@@ -2,7 +2,7 @@ module CustomsTariff
   class UpdatesController < AuthenticatedController
     def index
       authorize CustomsTariff::Update, :index?
-      @updates = CustomsTariff::Update.all
+      @updates = CustomsTariff::Update.all(page: current_page)
     end
 
     def show
@@ -15,22 +15,6 @@ module CustomsTariff
         .select { |u| u.validity_start_date.present? && u.validity_start_date < @update.validity_start_date }
         .max_by(&:validity_start_date)
         &.version
-    end
-
-    def update_status
-      @update = CustomsTariff::Update.find(params[:version])
-      authorize @update, :update?
-
-      CustomsTariff::Update.api.patch(
-        "admin/customs_tariff_updates/#{params[:version]}/status",
-        { data: { attributes: { status: params.require(:status) } } },
-      )
-
-      redirect_to customs_tariff_updates_path,
-                  notice: "Status updated to #{params[:status]}."
-    rescue Faraday::UnprocessableEntityError => e
-      redirect_to customs_tariff_update_path(params[:version]),
-                  alert: "Could not update status: #{e.response[:body].dig('errors', 0, 'detail')}"
     end
 
     def reimport

--- a/app/views/customs_tariff/updates/chapter_notes/edit.html.erb
+++ b/app/views/customs_tariff/updates/chapter_notes/edit.html.erb
@@ -8,42 +8,36 @@
         class: 'govuk-link' %>
 </p>
 
-<% if @update.rejected? %>
-  <%= govuk_inset_text do %>
-    This file has been rejected. To edit individual notes, set it back to pending.
-  <% end %>
-<% else %>
-  <div class="govuk-grid-row"
-       data-controller="tariff-note-preview"
-       data-tariff-note-preview-url-value="<%= customs_tariff_chapter_note_preview_path %>">
-    <div class="govuk-grid-column-one-half">
-      <%= form_with model: @chapter_note,
-                    url: customs_tariff_update_chapter_note_path(@update.version, @chapter_note.chapter_id),
-                    method: :patch do |f| %>
-        <%= hidden_field_tag :section_id, @section_id %>
-        <div class="govuk-form-group">
-          <%= f.label :content, 'Content', class: 'govuk-label govuk-label--m' %>
-          <%= f.text_area :content, rows: 20, class: 'govuk-textarea',
-                          data: { tariff_note_preview_target: 'content',
-                                  action: 'input->tariff-note-preview#update' } %>
-        </div>
-        <div class="govuk-button-group">
-          <%= f.submit 'Save', class: 'govuk-button' %>
-          <%= link_to 'Cancel',
-                customs_tariff_update_section_chapter_notes_path(@update.version, @section_id),
-                class: 'govuk-link' %>
-        </div>
-      <% end %>
-    </div>
-
-    <div class="govuk-grid-column-one-half">
-      <h2 class="govuk-heading-m">Preview</h2>
-      <div class="govuk-body tariff-note-preview" data-tariff-note-preview-target="preview">
-        <%= @chapter_note.preview %>
+<div class="govuk-grid-row"
+     data-controller="tariff-note-preview"
+     data-tariff-note-preview-url-value="<%= customs_tariff_chapter_note_preview_path %>">
+  <div class="govuk-grid-column-one-half">
+    <%= form_with model: @chapter_note,
+                  url: customs_tariff_update_chapter_note_path(@update.version, @chapter_note.chapter_id),
+                  method: :patch do |f| %>
+      <%= hidden_field_tag :section_id, @section_id %>
+      <div class="govuk-form-group">
+        <%= f.label :content, 'Content', class: 'govuk-label govuk-label--m' %>
+        <%= f.text_area :content, rows: 20, class: 'govuk-textarea',
+                        data: { tariff_note_preview_target: 'content',
+                                action: 'input->tariff-note-preview#update' } %>
       </div>
+      <div class="govuk-button-group">
+        <%= f.submit 'Save', class: 'govuk-button' %>
+        <%= link_to 'Cancel',
+              customs_tariff_update_section_chapter_notes_path(@update.version, @section_id),
+              class: 'govuk-link' %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="govuk-grid-column-one-half">
+    <h2 class="govuk-heading-m">Preview</h2>
+    <div class="hott-markdown-preview" data-tariff-note-preview-target="preview">
+      <%= @chapter_note.preview %>
     </div>
   </div>
-<% end %>
+</div>
 
 <% if policy(@chapter_note).destroy? %>
   <h3>Remove chapter note</h3>

--- a/app/views/customs_tariff/updates/chapter_notes/index.html.erb
+++ b/app/views/customs_tariff/updates/chapter_notes/index.html.erb
@@ -8,12 +8,6 @@
 <h2>Chapter Notes &mdash; <%= @section.title %></h2>
 <p class="govuk-body">Update version: <%= @update.version %></p>
 
-<% if @update.rejected? %>
-  <%= govuk_inset_text do %>
-    This file has been rejected. To edit individual notes, set it back to pending.
-  <% end %>
-<% end %>
-
 <%= govuk_table do |table|
   table.with_head do |head|
     head.with_row do |row|
@@ -39,7 +33,7 @@
             tag.strong(note.file_diff_status.to_s.capitalize, class: "govuk-tag govuk-tag--#{chip_colour}")
           end
           row.with_cell do
-            if !@update.rejected? && policy(note).edit?
+            if policy(note).edit?
               if @compare_version.present? && note.file_diff_status == :changed
                 link_to 'View diff',
                         customs_tariff_update_comparison_chapter_note_path(
@@ -62,7 +56,7 @@
         else
           row.with_cell
           row.with_cell do
-            if !@update.rejected? && policy(CustomsTariff::ChapterNote.new(customs_tariff_update_version: @update.version, chapter_id: chapter_code)).create?
+            if policy(CustomsTariff::ChapterNote.new(customs_tariff_update_version: @update.version, chapter_id: chapter_code)).create?
               link_to "Add",
                       new_customs_tariff_update_chapter_note_path(
                         @update.version,

--- a/app/views/customs_tariff/updates/chapter_notes/new.html.erb
+++ b/app/views/customs_tariff/updates/chapter_notes/new.html.erb
@@ -30,7 +30,7 @@
 
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-m">Preview</h2>
-    <div class="govuk-body" data-tariff-note-preview-target="preview">
+    <div class="hott-markdown-preview" data-tariff-note-preview-target="preview">
     </div>
   </div>
 </div>

--- a/app/views/customs_tariff/updates/comparisons/show.html.erb
+++ b/app/views/customs_tariff/updates/comparisons/show.html.erb
@@ -14,7 +14,7 @@
   <% end %>
 <% end %>
 
-<% if !@update.rejected? && policy(@section_note).edit? %>
+<% if policy(@section_note).edit? %>
   <p class="govuk-body">
     <%= link_to "Edit this note",
           edit_customs_tariff_update_section_note_path(@update.version, @section_note.section_id),

--- a/app/views/customs_tariff/updates/comparisons/show_chapter_note.html.erb
+++ b/app/views/customs_tariff/updates/comparisons/show_chapter_note.html.erb
@@ -17,7 +17,7 @@
   <% end %>
 <% end %>
 
-<% if !@update.rejected? && policy(@chapter_note).edit? %>
+<% if policy(@chapter_note).edit? %>
   <p class="govuk-body">
     <%= link_to "Edit this note",
           edit_customs_tariff_update_chapter_note_path(@update.version, @chapter_note.chapter_id,

--- a/app/views/customs_tariff/updates/index.html.erb
+++ b/app/views/customs_tariff/updates/index.html.erb
@@ -6,7 +6,6 @@
       row.with_cell(text: 'Version')
       row.with_cell(text: 'Valid from')
       row.with_cell(text: 'Valid to')
-      row.with_cell(text: 'Status')
       row.with_cell(text: 'Actions')
       row.with_cell(text: '')
     end
@@ -18,9 +17,6 @@
         row.with_cell(text: update.version)
         row.with_cell(text: update.validity_start_date)
         row.with_cell(text: update.validity_end_date || '—')
-        row.with_cell do
-          tag.strong(update.status.capitalize, class: "govuk-tag govuk-tag--#{update.status_tag_colour}")
-        end
         row.with_cell do
           link_to('Review', customs_tariff_update_path(update.version), class: 'govuk-link')
         end
@@ -37,3 +33,5 @@
     end
   end
 end %>
+
+<%= paginate @updates %>

--- a/app/views/customs_tariff/updates/section_notes/edit.html.erb
+++ b/app/views/customs_tariff/updates/section_notes/edit.html.erb
@@ -28,7 +28,7 @@
 
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-m">Preview</h2>
-    <div class="govuk-body tariff-note-preview" data-tariff-note-preview-target="preview">
+    <div class="hott-markdown-preview" data-tariff-note-preview-target="preview">
       <%= @section_note.preview %>
     </div>
   </div>

--- a/app/views/customs_tariff/updates/section_notes/new.html.erb
+++ b/app/views/customs_tariff/updates/section_notes/new.html.erb
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-column-one-half">
     <h2 class="govuk-heading-m">Preview</h2>
-    <div class="govuk-body" data-tariff-note-preview-target="preview">
+    <div class="hott-markdown-preview" data-tariff-note-preview-target="preview">
     </div>
   </div>
 </div>

--- a/app/views/customs_tariff/updates/show.html.erb
+++ b/app/views/customs_tariff/updates/show.html.erb
@@ -7,50 +7,15 @@
 
 <h2>Customs Tariff Update <%= @update.version %></h2>
 
-<p class="govuk-body">
-  Status:
-  <strong class="govuk-tag govuk-tag--<%= @update.status_tag_colour %>">
-    <%= @update.status.capitalize %>
-  </strong>
-</p>
-
-<% if policy(@update).update? %>
-  <div class="govuk-button-group">
-    <% if @update.pending? %>
-      <%= button_to 'Approve', update_status_customs_tariff_update_path(@update.version),
-            params: { status: 'approved' }, method: :patch, class: 'govuk-button' %>
-      <%= button_to 'Reject', update_status_customs_tariff_update_path(@update.version),
-            params: { status: 'rejected' }, method: :patch,
-            class: 'govuk-button govuk-button--warning',
-            data: { confirm: 'Are you sure you want to reject this update?' } %>
-    <% elsif @update.approved? %>
-      <%= button_to 'Set to Pending', update_status_customs_tariff_update_path(@update.version),
-            params: { status: 'pending' }, method: :patch, class: 'govuk-button govuk-button--secondary' %>
-      <%= button_to 'Reject', update_status_customs_tariff_update_path(@update.version),
-            params: { status: 'rejected' }, method: :patch,
-            class: 'govuk-button govuk-button--warning',
-            data: { confirm: 'This will take the current live section notes offline. Are you sure?' } %>
-    <% elsif @update.rejected? %>
-      <%= button_to 'Approve', update_status_customs_tariff_update_path(@update.version),
-            params: { status: 'approved' }, method: :patch, class: 'govuk-button' %>
-      <%= button_to 'Set to Pending', update_status_customs_tariff_update_path(@update.version),
-            params: { status: 'pending' }, method: :patch, class: 'govuk-button govuk-button--secondary' %>
-    <% end %>
-  </div>
-<% end %>
-
-<% if @update.rejected? %>
-  <%= govuk_inset_text do %>
-    This file has been rejected. To edit individual notes, set it back to pending.
-  <% end %>
-<% end %>
-
-<h2 class="govuk-heading-m">Compare with another version</h2>
+<h2 class="govuk-heading-m govuk-!-margin-top-6">Compare with another version</h2>
 
 <%= form_with url: customs_tariff_update_comparison_path(@update.version), method: :get do |f| %>
   <%= f.select :compare_version,
-        @updates.reject { |u| u.version == @update.version }
-                .map { |u| ["#{u.version} (#{u.status})", u.version] },
+        options_for_select(
+          @updates.reject { |u| u.version == @update.version }
+                  .map { |u| [u.version, u.version] },
+          params[:compare_version].presence || @baseline_version,
+        ),
         { include_blank: "Select a version..." },
         { class: "govuk-select" } %>
   <%= f.submit "Compare", class: "govuk-button govuk-button--secondary" %>
@@ -92,7 +57,7 @@
           end
         end
         row.with_cell do
-          if !@update.rejected? && summary.section_note_id.present?
+          if summary.section_note_id.present?
             note_stub = CustomsTariff::SectionNote.new(
               id: summary.section_note_id,
               section_id: summary.section_id,
@@ -112,7 +77,7 @@
                         class: 'govuk-link'
               end
             end
-          elsif !@update.rejected? && summary.section_note_status_symbol == :absent
+          elsif summary.section_note_status_symbol == :absent
             if policy(CustomsTariff::SectionNote.new(customs_tariff_update_version: @update.version, section_id: summary.section_id)).create?
               link_to 'Add',
                       new_customs_tariff_update_section_note_path(

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -202,7 +202,6 @@ Rails.application.routes.draw do
 
     constraints(version: /[^\/]+/) do
       get   "updates/:version",               to: "updates#show",          as: :customs_tariff_update
-      patch "updates/:version/update_status", to: "updates#update_status", as: :update_status_customs_tariff_update
       get   "updates/:version/compare",       to: "updates/comparisons#index", as: :customs_tariff_update_comparison
       post  "updates/:version/reimport",      to: "updates#reimport",      as: :reimport_customs_tariff_update
     end

--- a/spec/requests/customs_tariff/updates_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates_controller_spec.rb
@@ -53,17 +53,75 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
 
     before do
       stub_api_request("/customs_tariff_updates")
+        .with(query: { "page" => "1" })
         .and_return(
           status: 200,
           headers: { "content-type" => "application/json; charset=utf-8" },
           body: {
             data: [{ type: "customs_tariff_update", id: update_version, attributes: update_attributes }],
+            meta: {
+              pagination: {
+                page: 1,
+                per_page: 20,
+                total_count: 1,
+              },
+            },
           }.to_json,
         )
     end
 
     it { is_expected.to have_http_status(:ok) }
     it { is_expected.to render_template(:index) }
+
+    it "does not render file-level status" do
+      make_request
+
+      expect(response.body).not_to include("Pending")
+    end
+
+    context "when more updates exist than fit on one page" do
+      let(:make_request) { get customs_tariff_updates_path, params: { page: 2 } }
+
+      before do
+        stub_api_request("/customs_tariff_updates")
+          .with(query: { "page" => "2" })
+          .and_return(
+            status: 200,
+            headers: { "content-type" => "application/json; charset=utf-8" },
+            body: {
+              data: [
+                {
+                  type: "customs_tariff_update",
+                  id: "9.26",
+                  attributes: update_attributes.merge("version" => "9.26"),
+                },
+              ],
+              meta: {
+                pagination: {
+                  page: 2,
+                  per_page: 25,
+                  total_count: 26,
+                },
+              },
+            }.to_json,
+          )
+      end
+
+      it "paginates the updates table", :aggregate_failures do
+        make_request
+
+        expect(response.body).to include("9.26")
+        expect(response.body).not_to include("9.01")
+        expect(response.body).to include("govuk-pagination")
+      end
+
+      it "requests the selected page from the backend" do
+        make_request
+
+        expect(a_request(:get, %r{/admin/customs_tariff_updates}).with(query: { "page" => "2" }))
+          .to have_been_made
+      end
+    end
   end
 
   describe "GET #show" do
@@ -87,6 +145,21 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
     it "renders the compare form" do
       make_request
       expect(response.body).to include(customs_tariff_update_comparison_path(update_version))
+    end
+
+    it "does not render whole-file approval controls", :aggregate_failures do
+      make_request
+
+      expect(response.body).not_to include("Approve")
+      expect(response.body).not_to include("Reject")
+      expect(response.body).not_to include("Set to Pending")
+      expect(response.body).not_to include("update_status")
+    end
+
+    it "does not render file-level status" do
+      make_request
+
+      expect(response.body).not_to include("Status:")
     end
 
     context "when a previous version exists in the updates list" do
@@ -116,6 +189,14 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
 
       it "displays the baseline version in explanatory text" do
         expect(response.body).to include("Comparing notes against version 1.30")
+      end
+
+      it "selects the baseline version in the compare dropdown" do
+        expect(response.body).to include('<option selected="selected" value="1.30">1.30</option>')
+      end
+
+      it "does not show file-level status in compare options" do
+        expect(response.body).not_to include("1.30 (pending)")
       end
     end
 
@@ -157,52 +238,15 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
   end
 
   describe "PATCH #update_status" do
-    context "when the backend accepts the status change" do
-      let(:make_request) do
-        patch update_status_customs_tariff_update_path(update_version), params: { status: "approved" }
-      end
-
-      before do
-        stub_api_request("/customs_tariff_updates/#{update_version}")
-          .and_return(update_response)
-        stub_api_request("/customs_tariff_updates/#{update_version}/status", :patch)
-          .and_return(
-            status: 200,
-            headers: { "content-type" => "application/json; charset=utf-8" },
-            body: {}.to_json,
-          )
-      end
-
-      it { is_expected.to redirect_to(customs_tariff_updates_path) }
-
-      it "sets a success flash notice" do
-        make_request
-        expect(session.dig("flash", "flashes", "notice")).to eq("Status updated to approved.")
-      end
+    let(:recognize_status_update_path) do
+      Rails.application.routes.recognize_path(
+        "/customs_tariff/updates/#{update_version}/update_status",
+        method: :patch,
+      )
     end
 
-    context "when the backend rejects the status change" do
-      let(:make_request) do
-        patch update_status_customs_tariff_update_path(update_version), params: { status: "approved" }
-      end
-
-      before do
-        stub_api_request("/customs_tariff_updates/#{update_version}")
-          .and_return(update_response)
-        stub_api_request("/customs_tariff_updates/#{update_version}/status", :patch)
-          .and_return(
-            status: 422,
-            headers: { "content-type" => "application/json; charset=utf-8" },
-            body: { errors: [{ detail: "Version is already approved" }] }.to_json,
-          )
-      end
-
-      it { is_expected.to redirect_to(customs_tariff_update_path(update_version)) }
-
-      it "sets a flash alert containing the backend error detail" do
-        make_request
-        expect(session.dig("flash", "flashes", "alert")).to eq("Could not update status: Version is already approved")
-      end
+    it "is not routed" do
+      expect { recognize_status_update_path }.to raise_error(ActionController::RoutingError)
     end
   end
 


### PR DESCRIPTION
### Jira link
[AI-889](https://transformuk.atlassian.net/browse/AI-889)

### What?
- Remove whole-file approval/reject/pending controls and the status update route from customs tariff update review
- Remove file-level status display from the updates table, update header and compare dropdown options
- Keep re-import actions intact
- Default the compare dropdown to the same previous version shown in the explanatory text
- Paginate the customs tariff updates table using backend pagination metadata
- Allow note edit/add links to render regardless of rejected file status, subject to normal policies
- Render customs tariff note previews with the existing markdown preview wrapper

### Why?
This aligns the admin review flow with Appendix 5a precedence by removing approval-state mechanics while keeping review, comparison and note editing workflows available.

### Risk
**Risk level:** 🟢

**Reason for rating:** This changes non-live admin review UI for customs tariff notes. The re-import flow remains, and focused request specs cover the removed route, removed controls, removed file-level status display, compare default and pagination.