### PR TITLE
Implement lazy load to description tabs

### DIFF
--- a/app/javascript/controllers/generated_content_table_controller.js
+++ b/app/javascript/controllers/generated_content_table_controller.js
@@ -26,28 +26,17 @@ export default class extends Controller {
   }
 
   connect() {
+    this.loaded = false;
+
     if (this.visible()) {
-      this.fetchData();
-      return;
-    }
-
-    this.visibilityObserver = new MutationObserver(this.fetchDataOnceVisible.bind(this));
-    this.visibilityObserver.observe(this.element, {
-      attributes: true,
-      attributeFilter: ['class', 'hidden', 'style'],
-    });
-  }
-
-  disconnect() {
-    if (this.visibilityObserver) {
-      this.visibilityObserver.disconnect();
+      this.loadOnce();
     }
   }
 
-  fetchDataOnceVisible() {
-    if (!this.visible()) return;
+  loadOnce() {
+    if (this.loaded || !this.visible()) return;
 
-    this.visibilityObserver.disconnect();
+    this.loaded = true;
     this.fetchData();
   }
 

--- a/app/javascript/controllers/generated_content_table_controller.js
+++ b/app/javascript/controllers/generated_content_table_controller.js
@@ -26,6 +26,28 @@ export default class extends Controller {
   }
 
   connect() {
+    if (this.visible()) {
+      this.fetchData();
+      return;
+    }
+
+    this.visibilityObserver = new MutationObserver(this.fetchDataOnceVisible.bind(this));
+    this.visibilityObserver.observe(this.element, {
+      attributes: true,
+      attributeFilter: ['class', 'hidden', 'style'],
+    });
+  }
+
+  disconnect() {
+    if (this.visibilityObserver) {
+      this.visibilityObserver.disconnect();
+    }
+  }
+
+  fetchDataOnceVisible() {
+    if (!this.visible()) return;
+
+    this.visibilityObserver.disconnect();
     this.fetchData();
   }
 
@@ -77,6 +99,10 @@ export default class extends Controller {
       this.pageValue = page;
       this.fetchData();
     }
+  }
+
+  visible() {
+    return !this.element.closest('.govuk-tabs__panel--hidden') && !this.element.hidden;
   }
 
   fetchData() {

--- a/app/javascript/controllers/generated_content_tabs_controller.js
+++ b/app/javascript/controllers/generated_content_tabs_controller.js
@@ -1,0 +1,31 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  loadSelectedTab(event) {
+    const tab = event.target.closest('.govuk-tabs__tab');
+    if (!tab || !this.element.contains(tab)) return;
+
+    const panelId = tab.hash.slice(1);
+    if (!panelId) return;
+
+    window.setTimeout(() => {
+      const panel = document.getElementById(panelId);
+      if (!panel || !this.element.contains(panel)) return;
+
+      const tableElement = this.tableElementForPanel(panel);
+      if (!tableElement) return;
+
+      const controller = this.application.getControllerForElementAndIdentifier(
+        tableElement,
+        'generated-content-table',
+      );
+      if (controller) controller.loadOnce();
+    }, 0);
+  }
+
+  tableElementForPanel(panel) {
+    if (panel.matches('[data-controller~="generated-content-table"]')) return panel;
+
+    return panel.querySelector('[data-controller~="generated-content-table"]');
+  }
+}

--- a/app/views/goods_nomenclature_self_texts/index.html.erb
+++ b/app/views/goods_nomenclature_self_texts/index.html.erb
@@ -1,9 +1,9 @@
 <h1 class="govuk-heading-l">Descriptions</h1>
 
-<div class="govuk-tabs" data-module="govuk-tabs">
+<div class="govuk-tabs" data-module="govuk-tabs" data-controller="generated-content-tabs">
   <h2 class="govuk-tabs__title">Contents</h2>
 
-  <ul class="govuk-tabs__list">
+  <ul class="govuk-tabs__list" data-action="click->generated-content-tabs#loadSelectedTab">
     <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
       <a class="govuk-tabs__tab" href="#self-texts">Self-texts</a>
     </li>

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -121,6 +121,18 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
       end
       # rubocop:enable RSpec/ExampleLength
 
+      # rubocop:disable RSpec/ExampleLength
+      it "defers initial data loading for hidden generated content tab panels" do
+        controller = Rails.root.join("app/javascript/controllers/generated_content_table_controller.js").read
+
+        expect(rendered_page.body).to include('govuk-tabs__panel govuk-tabs__panel--hidden" id="labels"')
+        expect(rendered_page.body).to include('govuk-tabs__panel govuk-tabs__panel--hidden" id="compressed-notes"')
+        expect(controller).to include("if (this.visible()) {")
+        expect(controller).to include("this.visibilityObserver = new MutationObserver")
+        expect(controller).to include("this.fetchDataOnceVisible")
+      end
+      # rubocop:enable RSpec/ExampleLength
+
       stylesheet = Rails.root.join("app/assets/stylesheets/application.sass.scss").read
 
       it "defines a fixed layout for the self-text table styles" do

--- a/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
+++ b/spec/requests/goods_nomenclature_self_texts_controller_spec.rb
@@ -123,13 +123,16 @@ RSpec.describe GoodsNomenclatureSelfTextsController, type: :request do
 
       # rubocop:disable RSpec/ExampleLength
       it "defers initial data loading for hidden generated content tab panels" do
-        controller = Rails.root.join("app/javascript/controllers/generated_content_table_controller.js").read
+        table_controller = Rails.root.join("app/javascript/controllers/generated_content_table_controller.js").read
+        tabs_controller = Rails.root.join("app/javascript/controllers/generated_content_tabs_controller.js").read
 
         expect(rendered_page.body).to include('govuk-tabs__panel govuk-tabs__panel--hidden" id="labels"')
         expect(rendered_page.body).to include('govuk-tabs__panel govuk-tabs__panel--hidden" id="compressed-notes"')
-        expect(controller).to include("if (this.visible()) {")
-        expect(controller).to include("this.visibilityObserver = new MutationObserver")
-        expect(controller).to include("this.fetchDataOnceVisible")
+        expect(rendered_page.body).to include('govuk-tabs__list" data-action="click->generated-content-tabs#loadSelectedTab"')
+        expect(table_controller).to include("if (this.loaded || !this.visible()) return;")
+        expect(tabs_controller).to include("event.target.closest('.govuk-tabs__tab')")
+        expect(tabs_controller).to include("window.setTimeout")
+        expect(tabs_controller).to include("controller.loadOnce();")
       end
       # rubocop:enable RSpec/ExampleLength
 


### PR DESCRIPTION
# Pull Request

## What:
Lazy-load the hidden tables on the Descriptions page

## Why:
Previously, all three tab tables fetched data immediately, even though two were hidden. This caused unnecessary backend/API requests and client-side rendering work on first load. The change reduces initial table data requests from 3 to 1, deferring the other 2 until needed.

## Ticket:
[HMRC-2415](https://transformuk.atlassian.net/browse/HMRC-2415)

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
The change is narrowly scoped to the shared generated-content table controller’s initial load behaviour
