### PR TITLE
fix: add CSP nonce to fix violations

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,6 @@
   <head>
     <title><%= TradeTariffAdmin::ServiceChooser.service_name.upcase %> - Trade Tariff Admin</title>
     <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
     <%= tag :meta, name: 'viewport', content: 'width=device-width, initial-scale=1' %>
     <%= tag :meta, property: 'og:image', content: image_path('/assets/images/govuk-opengraph-image.png') %>
     <%= tag :meta, name: 'theme-color', content: '#1d70b8' %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,8 +13,8 @@
     <%= favicon_link_tag image_path('govuk-icon-180.png'), rel: 'apple-touch-icon', type: 'image/png' %>
     <%= stylesheet_link_tag :application, 'data-turbo': 'reload', media: 'all' %>
 
-    <script async src="/javascripts/es-module-shims.js"></script>
-    <script type="esms-options">
+    <script async src="/javascripts/es-module-shims.js" nonce="<%= content_security_policy_nonce %>"></script>
+    <script type="esms-options" nonce="<%= content_security_policy_nonce %>">
       {
         "noLoadEventRetriggers": true
       }


### PR DESCRIPTION
## What:

- Add nonce to `es-module-shims` script tags
- Remove `csp_meta_tag` helper from layout

## Why:

- There are several CSP errors when using the admin service, the CSP nonce is missing from these script tags
- Inline script tags are using nonce attributes so we do not need the meta tag

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

- Adds an attribute to script tags in the main layout; no other changes