### PR TITLE
AI-904 Add Chapter Ranges to Customs Tariff Updates Show View

### DIFF
--- a/app/controllers/customs_tariff/updates_controller.rb
+++ b/app/controllers/customs_tariff/updates_controller.rb
@@ -10,6 +10,7 @@ module CustomsTariff
       authorize @update, :show?
       @updates = CustomsTariff::Update.all
       @section_summaries = CustomsTariff::SectionSummary.all(customs_tariff_update_version: params[:version])
+      @sections_by_id = Section.all.index_by { |s| s.position.to_i }
       @baseline_version = @updates
         .reject { |u| u.version == @update.version || u.status == "failed" }
         .select { |u| u.validity_start_date.present? && u.validity_start_date < @update.validity_start_date }

--- a/app/views/customs_tariff/updates/show.html.erb
+++ b/app/views/customs_tariff/updates/show.html.erb
@@ -36,6 +36,7 @@
   table.with_head do |head|
     head.with_row do |row|
       row.with_cell(text: 'Section')
+      row.with_cell(text: 'Chapters')
       row.with_cell(text: 'Section Note')
       row.with_cell(text: 'Actions')
       row.with_cell(text: 'Chapter Notes')
@@ -49,6 +50,7 @@
 
       body.with_row do |row|
         row.with_cell(text: "Section #{summary.section_id}")
+        row.with_cell(text: @sections_by_id[summary.section_id]&.chapters_range)
         row.with_cell do
           if summary.section_note_status_symbol == :absent
             "—"

--- a/spec/requests/customs_tariff/updates_controller_spec.rb
+++ b/spec/requests/customs_tariff/updates_controller_spec.rb
@@ -137,6 +137,11 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
           body: { data: [] }.to_json,
         )
       stub_api_request("/customs_tariff_updates").and_return(updates_list_response)
+      stub_api_request("/sections").and_return(
+        status: 200,
+        headers: { "content-type" => "application/json; charset=utf-8" },
+        body: { data: [] }.to_json,
+      )
     end
 
     it { is_expected.to have_http_status(:ok) }
@@ -184,6 +189,11 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
             ],
           }.to_json,
         )
+        stub_api_request("/sections").and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: { data: [] }.to_json,
+        )
         get customs_tariff_update_path(update_version)
       end
 
@@ -225,6 +235,11 @@ RSpec.describe CustomsTariff::UpdatesController, type: :request do
           }.to_json,
         )
         stub_api_request("/customs_tariff_updates").and_return(updates_list_response)
+        stub_api_request("/sections").and_return(
+          status: 200,
+          headers: { "content-type" => "application/json; charset=utf-8" },
+          body: { data: [] }.to_json,
+        )
         get customs_tariff_update_path(update_version)
       end
 


### PR DESCRIPTION
## What:
Add a Chapters column to the customs tariff update show view

## Why:
It makes it easier for users to see which chapters belong to each section before drilling down

## Ticket:
[AI-904](https://transformuk.atlassian.net/browse/AI-904)

## Risk:

**Risk level:** 🟢 

**Reason for rating:**
Minor cosmetic change.

<img width="540" height="774" alt="image" src="https://github.com/user-attachments/assets/8598be62-90b5-43c1-af12-be0fdf0de30c" />