### PR TITLE
ci: enable rubocop annotations for pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,8 @@ jobs:
       - run: bundle exec brakeman
       - run: pip install pre-commit
       - run: pre-commit run --all-files --hook-stage pre-commit --show-diff-on-failure
+        env:
+          RUBOCOP_OPTS: --format github
       - run: pre-commit run --all-files --hook-stage pre-push --show-diff-on-failure
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What:

- Sets `RUBOCOP_OPTS=--format github` for pre-commit runs in GitHub Actions so RuboCop can emit GitHub Actions annotations while keeping local hook behavior unchanged.

## Why:

The Rails `bin/ci` setup runs with `CI=true`, and the direct RuboCop workflow path already uses GitHub formatting in similar repos. The pre-commit CI path was not passing RuboCop GitHub formatter options, so RuboCop failures from pre-commit were less visible inline in PRs.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**
Low risk. This only changes CI lint reporting configuration and does not affect application runtime or deployment behaviour.
