### PR TITLE
Show search diagnostics estimated AI cost and elapsed time

### DIFF
--- a/app/helpers/search_diagnostics_helper.rb
+++ b/app/helpers/search_diagnostics_helper.rb
@@ -4,7 +4,25 @@ module SearchDiagnosticsHelper
     "query_expanded" => %i[original_query expanded_query reason duration_ms],
     "query_refined" => %i[base_query original_query refined_query effective_query added_answers answer_count iteration],
     "query_expansion_decided" => %i[query expand reason result_count max_score],
-    "api_call_completed" => %i[model response_type attempt_number iteration effective_query duration_ms error_message error_message_truncated],
+    "api_call_completed" => %i[
+      model
+      response_type
+      attempt_number
+      iteration
+      effective_query
+      duration_ms
+      provider
+      event_kind
+      input_tokens
+      output_tokens
+      total_tokens
+      input_cost_usd
+      output_cost_usd
+      total_cost_usd
+      pricing_known
+      error_message
+      error_message_truncated
+    ],
     "description_intercept_checked" => %i[matched term excluded filtering filter_prefix_count guidance_level guidance_location escalate_to_webchat],
     "question_returned" => %i[question_count attempt_number iteration effective_query],
     "answer_returned" => %i[answer_count confidence_levels attempt_number iteration effective_query],
@@ -15,12 +33,32 @@ module SearchDiagnosticsHelper
     "search_failed" => %i[search_type error_type error_message error_message_truncated],
   }.freeze
 
+  AI_USAGE_FIELD_KEYS = %i[
+    provider
+    event_kind
+    input_tokens
+    output_tokens
+    total_tokens
+    input_cost_usd
+    output_cost_usd
+    total_cost_usd
+    pricing_known
+  ].freeze
+
   FIELD_LABELS = {
     attempt_number: "Attempt",
     duration_ms: "Duration",
     total_duration_ms: "Total duration",
     final_result_type: "Final result",
     expand: "Expand query",
+    input_tokens: "Input tokens",
+    output_tokens: "Output tokens",
+    total_tokens: "Total tokens",
+    input_cost_usd: "Input cost (USD)",
+    output_cost_usd: "Output cost (USD)",
+    total_cost_usd: "Total cost (USD)",
+    pricing_known: "Pricing known",
+    event_kind: "Event kind",
   }.freeze
 
   SIGNIFICANT_TIMELINE_EVENTS = %w[
@@ -132,6 +170,8 @@ module SearchDiagnosticsHelper
       route_tags: overview_route_tags(events),
       results: overview_results(events),
       selected_results: overview_selected_results(events),
+      elapsed_time: overview_elapsed_time(events),
+      total_cost: overview_total_cost(events),
     }
   end
 
@@ -470,6 +510,11 @@ private
     return value.map { |item| readable_value(item) }.join(", ") if value.is_a?(Array)
     return value.map { |key, item| "#{readable_value(key)}: #{readable_value(item)}" }.join(", ") if value.is_a?(Hash)
     return "#{number_with_delimiter(value)} ms" if key.to_s.end_with?("_ms")
+
+    if key.to_s.end_with?("_usd")
+      amount = Float(value, exception: false)
+      return format_search_diagnostic_cost_usd(amount) if amount
+    end
     return value if key.to_sym == :description_intercept
 
     readable_value(value)
@@ -575,6 +620,56 @@ private
 
       { id:, href: }
     end
+  end
+
+  def overview_elapsed_time(events)
+    duration_ms = events.reverse_each.filter_map { |event|
+      next unless event[:event].to_s == "search_completed"
+
+      value = search_diagnostic_fields(event)[:total_duration_ms]
+      next unless logged_value?(value)
+
+      Float(value, exception: false)
+    }.first
+
+    format_search_diagnostic_duration_ms(duration_ms) if duration_ms
+  end
+
+  def overview_total_cost(events)
+    api_calls = events.select { |event| event[:event].to_s == "api_call_completed" }
+    return if api_calls.blank?
+
+    field_sets = api_calls.map { |event| search_diagnostic_fields(event) }
+    return unless field_sets.any? { |fields| ai_usage_fields?(fields) }
+
+    costs = field_sets.map { |fields| Float(fields[:total_cost_usd], exception: false) }
+    known_costs = costs.compact
+    return "Unavailable (pricing unknown)" if known_costs.blank?
+
+    label = format_search_diagnostic_cost_usd(known_costs.sum)
+    return label if known_costs.size == costs.size
+
+    "#{label} (partial — some calls missing pricing)"
+  end
+
+  def ai_usage_fields?(fields)
+    AI_USAGE_FIELD_KEYS.any? { |key| fields.key?(key) && !fields[key].nil? }
+  end
+
+  def format_search_diagnostic_duration_ms(duration_ms)
+    return if duration_ms.nil?
+
+    if duration_ms < 1000
+      "#{duration_ms.round} ms"
+    else
+      sprintf("%.2f s", duration_ms / 1000.0)
+    end
+  end
+
+  def format_search_diagnostic_cost_usd(amount)
+    rounded = amount.round(6)
+    formatted = sprintf("%.6f", rounded).sub(/0+\z/, "").sub(/\.\z/, "")
+    "$#{formatted}"
   end
 
   def endpoint_for_class(goods_nomenclature_class)

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -5,7 +5,7 @@
     <h1 class="govuk-heading-l">Search diagnostics</h1>
 
     <% contextual_events = @search_diagnostic.events? ? search_diagnostic_events_with_context(@search_diagnostic.events) : [] %>
-    <% overview = search_diagnostic_overview(contextual_events) if contextual_events.any? %>
+    <% overview = contextual_events.any? ? search_diagnostic_overview(contextual_events) : nil %>
 
     <dl class="govuk-summary-list">
       <div class="govuk-summary-list__row">

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -52,6 +52,18 @@
           <dd class="govuk-summary-list__value"><%= safe_join(overview[:selected_results].map { |result| search_diagnostic_overview_selected_result_link(result) }, ", ") %></dd>
         </div>
       <% end %>
+      <% if overview&.dig(:elapsed_time).present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Elapsed time</dt>
+          <dd class="govuk-summary-list__value"><%= overview[:elapsed_time] %></dd>
+        </div>
+      <% end %>
+      <% if overview&.dig(:total_cost).present? %>
+        <div class="govuk-summary-list__row">
+          <dt class="govuk-summary-list__key">Estimated AI cost</dt>
+          <dd class="govuk-summary-list__value"><%= overview[:total_cost] %></dd>
+        </div>
+      <% end %>
     </dl>
 
     <% if @search_diagnostic.events? %>

--- a/spec/helpers/search_diagnostics_helper_spec.rb
+++ b/spec/helpers/search_diagnostics_helper_spec.rb
@@ -109,6 +109,38 @@ RSpec.describe SearchDiagnosticsHelper do
     it "summarises a zero-result search as needing attention" do
       expect(overview_summary(zero_result_events)).to eq(zero_result_overview_summary)
     end
+
+    it "includes elapsed time from the last completed search total duration" do
+      expect(overview_summary(interactive_cost_events)[:elapsed_time]).to eq("1.50 s")
+    end
+
+    it "sums request-linked model call costs for the estimated AI cost" do
+      expect(overview_summary(interactive_cost_events)[:total_cost]).to eq("$0.0051")
+    end
+
+    it "marks the cost as partial when some model calls lack pricing" do
+      expect(overview_summary(partial_cost_events)[:total_cost]).to eq("$0.0036 (partial — some calls missing pricing)")
+    end
+
+    it "shows unavailable when AI usage is present but no costs can be priced" do
+      expect(overview_summary(unpriced_cost_events)[:total_cost]).to eq("Unavailable (pricing unknown)")
+    end
+
+    it "omits cost when no AI usage telemetry is present" do
+      expect(overview_summary(classic_overview_events)[:total_cost]).to be_nil
+    end
+
+    it "omits elapsed time when search_completed has no total duration" do
+      expect(overview_summary(classic_overview_events)[:elapsed_time]).to be_nil
+    end
+
+    it "formats sub-second elapsed times in milliseconds" do
+      events = [
+        { event: "search_completed", fields: { total_duration_ms: 450.1 } },
+      ]
+
+      expect(helper.search_diagnostic_overview(events)[:elapsed_time]).to eq("450 ms")
+    end
   end
 
   describe "#search_diagnostic_event_time" do
@@ -385,6 +417,8 @@ RSpec.describe SearchDiagnosticsHelper do
       route_tags: overview[:route_tags].pluck(:label, :colour),
       results: overview[:results],
       selected_results: overview[:selected_results],
+      elapsed_time: overview[:elapsed_time],
+      total_cost: overview[:total_cost],
     }
   end
 
@@ -398,6 +432,8 @@ RSpec.describe SearchDiagnosticsHelper do
         { id: "6110", href: "#{TradeTariffAdmin.frontend_host}/headings/6110" },
         { id: "6110309900", href: "#{TradeTariffAdmin.frontend_host}/commodities/6110309900" },
       ],
+      elapsed_time: nil,
+      total_cost: nil,
     }
   end
 
@@ -408,6 +444,8 @@ RSpec.describe SearchDiagnosticsHelper do
       route_tags: [%w[Classic blue], %w[Fuzzy purple]],
       results: "0 fuzzy results",
       selected_results: [],
+      elapsed_time: nil,
+      total_cost: nil,
     }
   end
 
@@ -478,6 +516,87 @@ RSpec.describe SearchDiagnosticsHelper do
       { timestamp: "2026-06-05 09:33:44.079", event: "search_started", search_type: "classic", fields: { query: "women's breif" } },
       { timestamp: "2026-06-05 09:33:44.114", event: "fuzzy_results_returned", search_type: "classic", fields: { result_count: 0 } },
       { timestamp: "2026-06-05 09:33:44.114", event: "search_completed", search_type: "classic", fields: { query: "women's breif", result_count: 0, results_type: "fuzzy_search" } },
+    ]
+  end
+
+  def interactive_cost_events
+    [
+      { event: "search_started", search_type: "interactive", fields: { query: "red shoes" } },
+      {
+        event: "api_call_completed",
+        search_type: "interactive",
+        fields: {
+          model: "gpt-4.1-mini",
+          response_type: "questions",
+          input_tokens: 1_000,
+          output_tokens: 200,
+          total_tokens: 1_200,
+          total_cost_usd: 0.0036,
+          pricing_known: true,
+        },
+      },
+      {
+        event: "api_call_completed",
+        search_type: "interactive",
+        fields: {
+          model: "gpt-4.1-mini",
+          response_type: "answers",
+          input_tokens: 500,
+          output_tokens: 100,
+          total_tokens: 600,
+          total_cost_usd: 0.0015,
+          pricing_known: true,
+        },
+      },
+      {
+        event: "search_completed",
+        search_type: "interactive",
+        fields: {
+          query: "red shoes",
+          result_count: 2,
+          results_type: "hybrid",
+          total_duration_ms: 1500.25,
+        },
+      },
+    ]
+  end
+
+  def partial_cost_events
+    [
+      {
+        event: "api_call_completed",
+        search_type: "interactive",
+        fields: {
+          model: "gpt-4.1-mini",
+          total_cost_usd: 0.0036,
+          pricing_known: true,
+        },
+      },
+      {
+        event: "api_call_completed",
+        search_type: "interactive",
+        fields: {
+          model: "gpt-4.1-mini",
+          input_tokens: 75,
+          total_cost_usd: nil,
+          pricing_known: false,
+        },
+      },
+    ]
+  end
+
+  def unpriced_cost_events
+    [
+      {
+        event: "api_call_completed",
+        search_type: "interactive",
+        fields: {
+          model: "gpt-4.1-mini",
+          input_tokens: 75,
+          total_cost_usd: nil,
+          pricing_known: false,
+        },
+      },
     ]
   end
 end

--- a/spec/requests/search_diagnostics_controller_spec.rb
+++ b/spec/requests/search_diagnostics_controller_spec.rb
@@ -73,6 +73,7 @@ RSpec.describe SearchDiagnosticsController do
                 fields: {
                   request_id: "request-123",
                   query: "horse",
+                  total_duration_ms: 85.4,
                 },
               },
               {
@@ -199,6 +200,44 @@ RSpec.describe SearchDiagnosticsController do
                   response_type: "questions",
                   attempt_number: 1,
                   duration_ms: 450.1,
+                  provider: "openai",
+                  event_kind: "interactive_search",
+                  input_tokens: 1_000,
+                  output_tokens: 200,
+                  total_tokens: 1_200,
+                  input_cost_usd: 0.002,
+                  output_cost_usd: 0.0016,
+                  total_cost_usd: 0.0036,
+                  pricing_known: true,
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:04.600",
+                event: "api_call_completed",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  model: "gpt-4.1-mini",
+                  response_type: "answers",
+                  attempt_number: 2,
+                  duration_ms: 320.0,
+                  provider: "openai",
+                  event_kind: "interactive_search_final_answer",
+                  input_tokens: 500,
+                  output_tokens: 100,
+                  total_tokens: 600,
+                  total_cost_usd: 0.0015,
+                  pricing_known: true,
+                },
+              },
+              {
+                timestamp: "2026-06-05 09:59:04.700",
+                event: "search_completed",
+                search_type: "interactive",
+                fields: {
+                  request_id: "request-123",
+                  query: "red leather shoes",
+                  total_duration_ms: 1500.25,
                 },
               },
               {
@@ -424,6 +463,10 @@ RSpec.describe SearchDiagnosticsController do
       "Description intercept",
       "1 fuzzy result",
       "#{TradeTariffAdmin.frontend_host}/commodities/6403990000",
+      "Elapsed time",
+      "1.50 s",
+      "Estimated AI cost",
+      "$0.0051",
     ]
   end
 end


### PR DESCRIPTION

<img width="1834" height="1533" alt="search-diagnostics-overview-cost" src="https://github.com/user-attachments/assets/1667f65e-89dc-4135-a2c3-758a888e2738" />


## What

- [x] Show **Elapsed time** on the search diagnostics overview summary list from `search_completed.total_duration_ms`
- [x] Show **Estimated AI cost** by summing request-linked `api_call_completed.total_cost_usd` values
- [x] Handle partial/unknown pricing and omit rows when telemetry is absent
- [x] Surface token/cost fields on individual API call diagnostic details
- [x] Cover helper and request behaviour with specs

## Why

Operators reviewing a search journey need a quick sense of how long the search took and roughly how much the model calls cost, without digging through every event.

## Ticket

N/A

## Risk

**Risk level:** 🟢

**Reason for rating:** Admin-only presentation change over existing diagnostic events. No backend API or auth changes; covered by helper and request specs.