### PR TITLE
AI-1062: Separate journey and note evidence

### DIFF
--- a/app/helpers/search_diagnostics_helper.rb
+++ b/app/helpers/search_diagnostics_helper.rb
@@ -26,7 +26,7 @@ module SearchDiagnosticsHelper
     "description_intercept_checked" => %i[matched term excluded filtering filter_prefix_count guidance_level guidance_location escalate_to_webchat],
     "question_returned" => %i[question_count attempt_number iteration effective_query],
     "answer_returned" => %i[answer_count confidence_levels attempt_number iteration effective_query],
-    "note_evidence_evaluated" => %i[query effective_query iteration attempt_number operation note_evidence_enabled note_evidence_status considered_note_count considered_evidence_count selected_note_count selected_evidence_count omitted_evidence_count logged_omitted_evidence_count omitted_evidence_truncated],
+    "note_evidence_evaluated" => %i[query effective_query iteration attempt_number operation note_evidence_enabled note_evidence_status considered_note_count considered_evidence_count considered_association_count considered_distinct_source_count selected_note_count selected_evidence_count selected_distinct_source_count omitted_evidence_count logged_omitted_evidence_count omitted_evidence_truncated],
     "evaluation_trace_returned" => %i[trace_version query effective_query iteration answer_count retrieval_method results_type candidate_count logged_candidate_count candidates_truncated final_result_type ranked_answer_count logged_ranked_answer_count ranked_answers_truncated question_count logged_question_count questions_truncated confidence_levels ranking_source model result_limit error_message error_message_truncated],
     "search_completed" => %i[query search_type results_type final_result_type total_attempts total_questions result_count max_score total_duration_ms description_intercept_matched description_intercept_term description_intercept_excluded description_intercept_filtering description_intercept_filter_prefix_count description_intercept_guidance_level description_intercept_guidance_location description_intercept_escalate_to_webchat error_message error_message_truncated],
     "retrieval_leg_completed" => %i[leg status result_count duration_ms error_message error_message_truncated],
@@ -278,7 +278,7 @@ module SearchDiagnosticsHelper
   end
 
   def search_diagnostic_note_evidence(events)
-    Array(events).filter_map do |raw_event|
+    note_events = Array(events).filter_map do |raw_event|
       event = normalise_search_diagnostic_hash(raw_event)
       next unless event.is_a?(Hash) && event[:event].to_s == "note_evidence_evaluated"
 
@@ -289,6 +289,16 @@ module SearchDiagnosticsHelper
       limits = {}.with_indifferent_access unless limits.is_a?(Hash)
       selected_contexts = diagnostic_result_rows(details[:selected_contexts]).map do |context|
         context.merge(evidence: diagnostic_result_rows(context[:evidence]))
+      end
+      selected_evidence = selected_contexts.flat_map do |context|
+        context[:evidence].map do |item|
+          item.merge(
+            context_hash: context[:context_hash],
+            context_hashes: Array(item[:context_hashes]).presence || [context[:context_hash]].compact,
+            commodity_codes: Array(item[:commodity_codes]).presence || Array(context[:commodity_codes]),
+            note_ref: context[:note_ref],
+          )
+        end
       end
 
       {
@@ -302,16 +312,22 @@ module SearchDiagnosticsHelper
         status: fields[:note_evidence_status],
         considered_note_count: fields[:considered_note_count],
         considered_evidence_count: fields[:considered_evidence_count],
+        considered_association_count: fields[:considered_association_count],
+        considered_distinct_source_count: fields[:considered_distinct_source_count],
         selected_note_count: fields[:selected_note_count],
         selected_evidence_count: fields[:selected_evidence_count],
+        selected_distinct_source_count: fields[:selected_distinct_source_count],
         omitted_evidence_count: fields[:omitted_evidence_count],
         logged_omitted_evidence_count: fields[:logged_omitted_evidence_count],
         omitted_evidence_truncated: truthy?(fields[:omitted_evidence_truncated]),
         limits:,
         selected_contexts:,
+        selected_evidence:,
         omitted_evidence: diagnostic_result_rows(details[:omitted_evidence]),
       }
     end
+
+    annotate_note_evidence_changes(note_events)
   end
 
   def search_diagnostic_note_evidence_status(status)
@@ -367,6 +383,43 @@ module SearchDiagnosticsHelper
   end
 
 private
+
+  def annotate_note_evidence_changes(note_events)
+    previous = []
+
+    note_events.each_with_index.map do |note_event, index|
+      current = note_event[:selected_evidence]
+      previous_by_identity = previous.index_by { |evidence| note_evidence_identity(evidence) }
+      current_by_identity = current.index_by { |evidence| note_evidence_identity(evidence) }
+      annotated = current.map do |evidence|
+        change = previous_by_identity.key?(note_evidence_identity(evidence)) ? :retained : :added
+        evidence.merge(change:)
+      end
+      removed = previous.filter_map do |evidence|
+        evidence.merge(change: :removed) unless current_by_identity.key?(note_evidence_identity(evidence))
+      end
+      changes = annotated + removed
+
+      previous = current
+      note_event.merge(
+        dom_id: note_evidence_dom_id(note_event, index),
+        selected_evidence: annotated,
+        removed_evidence: removed,
+        change_counts: changes.map { |evidence| evidence[:change] }.tally.reverse_merge(added: 0, retained: 0, removed: 0),
+      )
+    end
+  end
+
+  def note_evidence_identity(evidence)
+    evidence[:source_node_key].presence || Digest::SHA256.hexdigest(
+      [evidence[:source_ref], evidence[:evidence_kind], evidence[:text].to_s.squish.downcase].join("|"),
+    )
+  end
+
+  def note_evidence_dom_id(note_event, index)
+    suffix = note_event[:iteration].presence || "evaluation-#{index + 1}"
+    "note-evidence-iteration-#{suffix}"
+  end
 
   def diagnostic_datetime(timestamp)
     parsed = diagnostic_timestamp(timestamp)

--- a/app/helpers/search_diagnostics_helper.rb
+++ b/app/helpers/search_diagnostics_helper.rb
@@ -379,7 +379,8 @@ module SearchDiagnosticsHelper
   end
 
   def search_diagnostic_fields(event)
-    normalise_search_diagnostic_hash(event[:fields] || {})
+    fields = normalise_search_diagnostic_hash(event[:fields] || {})
+    fields.is_a?(Hash) ? fields : {}.with_indifferent_access
   end
 
 private

--- a/app/views/search_diagnostics/_note_evidence.html.erb
+++ b/app/views/search_diagnostics/_note_evidence.html.erb
@@ -1,95 +1,118 @@
 <section class="search-diagnostics-note-evidence" aria-labelledby="search-diagnostics-note-evidence-title">
   <h2 class="govuk-heading-m" id="search-diagnostics-note-evidence-title">Compressed note evidence</h2>
-  <p class="govuk-body">Evidence recorded immediately before each model call. It explains which note blocks or fragments entered the prompt and why other evidence was omitted.</p>
+  <p class="govuk-body">Evidence recorded immediately before each model call. Each model call is stateless, so retained passages are sent again on later iterations.</p>
 
   <% if note_evidence_events.empty? %>
     <div class="govuk-inset-text">No compressed note evidence event was logged for this request. Older requests may pre-date this diagnostic.</div>
   <% else %>
     <% note_evidence_events.each do |note_event| %>
       <% status = search_diagnostic_note_evidence_status(note_event[:status]) %>
-      <article class="govuk-!-margin-bottom-7">
-        <h3 class="govuk-heading-s govuk-!-margin-bottom-2">
-          <%= note_event[:iteration] ? "Iteration #{note_event[:iteration]}" : "Prompt evaluation" %>
-          <% if note_event[:attempt_number] %>(attempt <%= note_event[:attempt_number] %>)<% end %>
-        </h3>
-        <p class="govuk-body-s">
-          <strong class="govuk-tag govuk-tag--<%= status[:colour] %>"><%= status[:label] %></strong>
-          <% if note_event[:operation].present? %><span class="govuk-!-margin-left-2"><%= note_event[:operation].to_s.humanize %></span><% end %>
-        </p>
+      <% changes = note_event[:change_counts] %>
+      <details class="govuk-details" id="<%= note_event[:dom_id] %>">
+        <summary class="govuk-details__summary">
+          <span class="govuk-details__summary-text">
+            <%= note_event[:iteration] ? "Iteration #{note_event[:iteration]}" : "Prompt evaluation" %> —
+            <%= note_event[:selected_distinct_source_count].presence || note_event[:selected_evidence_count].presence || note_event[:selected_evidence].size %> selected;
+            <%= changes[:added] %> added, <%= changes[:retained] %> retained, <%= changes[:removed] %> removed
+          </span>
+        </summary>
+        <div class="govuk-details__text">
+          <p class="govuk-body-s">
+            <strong class="govuk-tag govuk-tag--<%= status[:colour] %>"><%= status[:label] %></strong>
+            <% if note_event[:attempt_number] %><span class="govuk-!-margin-left-2">attempt <%= note_event[:attempt_number] %></span><% end %>
+            <% if note_event[:operation].present? %><span class="govuk-!-margin-left-2"><%= note_event[:operation].to_s.humanize %></span><% end %>
+          </p>
 
-        <% if note_event[:query].present? %>
-          <p class="govuk-body"><strong>Search query:</strong> <%= note_event[:query] %></p>
-        <% end %>
-        <% if note_event[:effective_query].present? %>
-          <p class="govuk-body"><strong>Effective query:</strong> <%= note_event[:effective_query] %></p>
-        <% end %>
+          <% if note_event[:query].present? %><p class="govuk-body"><strong>Search query:</strong> <%= note_event[:query] %></p><% end %>
+          <% if note_event[:effective_query].present? %><p class="govuk-body"><strong>Effective query:</strong> <%= note_event[:effective_query] %></p><% end %>
 
-        <dl class="govuk-summary-list govuk-summary-list--no-border">
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Considered</dt>
-            <dd class="govuk-summary-list__value"><%= note_event[:considered_note_count].presence || "-" %> notes; <%= note_event[:considered_evidence_count].presence || "-" %> evidence records</dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Selected</dt>
-            <dd class="govuk-summary-list__value"><%= note_event[:selected_note_count].presence || "-" %> notes; <%= note_event[:selected_evidence_count].presence || "-" %> evidence records</dd>
-          </div>
-          <div class="govuk-summary-list__row">
-            <dt class="govuk-summary-list__key">Selection limits</dt>
-            <dd class="govuk-summary-list__value">Minimum score <%= note_event.dig(:limits, :minimum_score) || "-" %>; per note <%= note_event.dig(:limits, :per_note) || "-" %>; total <%= note_event.dig(:limits, :total) || "-" %></dd>
-          </div>
-        </dl>
+          <dl class="govuk-summary-list govuk-summary-list--no-border">
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Considered</dt>
+              <dd class="govuk-summary-list__value">
+                <% if note_event[:considered_distinct_source_count].present? %>
+                  <%= note_event[:considered_note_count].presence || "unavailable" %> contexts;
+                  <%= note_event[:considered_association_count].presence || "unavailable" %> associations;
+                  <%= note_event[:considered_distinct_source_count] %> distinct source passages
+                <% else %>
+                  <%= note_event[:considered_note_count].presence || "unavailable" %> contexts;
+                  <%= note_event[:considered_evidence_count].presence || "unavailable" %> reported evidence records
+                <% end %>
+              </dd>
+            </div>
+            <div class="govuk-summary-list__row">
+              <dt class="govuk-summary-list__key">Selected</dt>
+              <dd class="govuk-summary-list__value">
+                <%= note_event[:selected_note_count].presence || "unavailable" %> contexts;
+                <%= note_event[:selected_distinct_source_count].presence || note_event[:selected_evidence_count].presence || "unavailable" %>
+                <%= note_event[:selected_distinct_source_count].present? ? "distinct source passages" : "reported evidence records" %>
+              </dd>
+            </div>
+          </dl>
 
-        <% note_event[:selected_contexts].each do |context| %>
-          <div class="govuk-!-margin-bottom-5">
-            <h4 class="govuk-heading-s govuk-!-margin-bottom-1"><%= context[:note_ref].presence || "Compressed note context" %></h4>
-            <p class="govuk-body-s govuk-!-margin-bottom-1"><strong>Context hash:</strong> <%= context[:context_hash].presence || "-" %></p>
-            <p class="govuk-body-s"><strong>Commodity codes:</strong> <%= Array(context[:commodity_codes]).join(", ").presence || "-" %></p>
+          <% if note_event[:selected_evidence].empty? %>
+            <p class="govuk-inset-text">No compressed note passage was added to this model prompt.</p>
+          <% end %>
 
-            <% Array(context[:evidence]).each do |evidence| %>
-              <details class="govuk-details" open>
-                <summary class="govuk-details__summary">
-                  <span class="govuk-details__summary-text"><%= evidence[:source].presence || evidence[:source_ref].presence || evidence[:source_node_key].presence || "Selected evidence" %></span>
-                </summary>
+          <% note_event[:selected_evidence].each do |evidence| %>
+            <article class="govuk-!-margin-bottom-5">
+              <h3 class="govuk-heading-s govuk-!-margin-bottom-1"><%= evidence[:source].presence || evidence[:source_ref].presence || evidence[:source_node_key].presence || "Selected evidence" %></h3>
+              <p class="govuk-body-s govuk-!-margin-bottom-1"><strong><%= evidence[:change].to_s.humanize %></strong><% if evidence[:change] == :retained %> and sent again on this stateless model call<% end %></p>
+              <p class="govuk-body"><%= evidence[:text] %></p>
+
+              <details class="govuk-details">
+                <summary class="govuk-details__summary"><span class="govuk-details__summary-text">Technical selection details</span></summary>
                 <div class="govuk-details__text">
-                  <p class="govuk-body-s"><strong>Source:</strong> <%= [evidence[:source_ref], evidence[:source_type], evidence[:source_version]].compact_blank.join("; ").presence || "-" %></p>
-                  <p class="govuk-body-s"><strong>Source node:</strong> <%= evidence[:source_node_key].presence || "-" %></p>
+                  <% if evidence[:note_ref].present? %><p class="govuk-body-s"><strong>Compressed note:</strong> <%= evidence[:note_ref] %></p><% end %>
+                  <p class="govuk-body-s"><strong>Source:</strong> <%= [evidence[:source_ref], evidence[:source_type], evidence[:source_version]].compact_blank.join("; ").presence || "unavailable" %></p>
+                  <p class="govuk-body-s"><strong>Source node:</strong> <%= evidence[:source_node_key].presence || "unavailable" %></p>
                   <% if evidence[:source_id].present? %><p class="govuk-body-s"><strong>Source ID:</strong> <%= evidence[:source_id] %></p><% end %>
-                  <% if evidence[:parent_source_node_key].present? || evidence[:parent_source_title].present? %><p class="govuk-body-s"><strong>Parent source:</strong> <%= evidence[:parent_source_title].presence || "-" %> (<%= evidence[:parent_source_node_key].presence || "-" %>)</p><% end %>
-                  <% if evidence[:range_node_key].present? || evidence[:range_code].present? %><p class="govuk-body-s"><strong>Range:</strong> <%= [evidence[:range_type], evidence[:range_code]].compact_blank.join(" ") %> (<%= evidence[:range_node_key].presence || "-" %>)</p><% end %>
+                  <% if evidence[:parent_source_node_key].present? || evidence[:parent_source_title].present? %><p class="govuk-body-s"><strong>Parent source:</strong> <%= evidence[:parent_source_title].presence || "unavailable" %> (<%= evidence[:parent_source_node_key].presence || "unavailable" %>)</p><% end %>
+                  <% if evidence[:range_node_key].present? || evidence[:range_code].present? %><p class="govuk-body-s"><strong>Range:</strong> <%= [evidence[:range_type], evidence[:range_code]].compact_blank.join(" ") %> (<%= evidence[:range_node_key].presence || "unavailable" %>)</p><% end %>
                   <% if Array(evidence[:fragment_node_keys]).any? %><p class="govuk-body-s"><strong>Contained fragments:</strong> <%= Array(evidence[:fragment_node_keys]).join(", ") %><%= " (truncated)" if evidence[:fragment_node_keys_truncated] %></p><% end %>
+                  <p class="govuk-body-s"><strong>Context hashes:</strong> <%= Array(evidence[:context_hashes]).join(", ").presence || "unavailable" %></p>
+                  <p class="govuk-body-s"><strong>Commodity codes:</strong> <%= Array(evidence[:commodity_codes]).join(", ").presence || "unavailable" %></p>
+                  <% if evidence[:best_candidate_rank].present? %><p class="govuk-body-s"><strong>Best candidate rank:</strong> <%= evidence[:best_candidate_rank] %></p><% end %>
+                  <% if evidence[:range_specificity].present? %><p class="govuk-body-s"><strong>Range specificity:</strong> <%= evidence[:range_specificity].to_s.humanize %></p><% end %>
                   <p class="govuk-body-s"><strong>Kind:</strong> <%= evidence[:evidence_kind].to_s == "note_block" ? "#{evidence[:type].to_s.humanize} block" : evidence[:evidence_kind].to_s.humanize %>; <strong>Score <%= evidence[:score] %></strong></p>
                   <% if Array(evidence[:score_reasons]).any? %><p class="govuk-body-s"><strong>Why selected:</strong> <%= Array(evidence[:score_reasons]).join("; ") %></p><% end %>
                   <% Array(evidence[:graph_paths]).each do |path| %><p class="govuk-body-s"><strong>Graph path:</strong> <%= Array(path).join(" → ") %></p><% end %>
-                  <p class="govuk-body"><%= evidence[:text] %></p>
                 </div>
               </details>
-            <% end %>
-          </div>
-        <% end %>
+            </article>
+          <% end %>
 
-        <details class="govuk-details">
-          <summary class="govuk-details__summary">
-            <span class="govuk-details__summary-text">Omitted evidence (<%= note_event[:omitted_evidence_count] || 0 %>)</span>
-          </summary>
-          <div class="govuk-details__text">
-            <% if note_event[:omitted_evidence].empty? %>
-              <% if note_event[:omitted_evidence_count].to_i.positive? %>
-                <p class="govuk-body">No omitted evidence samples were logged (<%= note_event[:omitted_evidence_count] %> omitted in total).</p>
+          <% if note_event[:removed_evidence].any? %>
+            <details class="govuk-details">
+              <summary class="govuk-details__summary"><span class="govuk-details__summary-text">Removed since the previous iteration (<%= note_event[:removed_evidence].size %>)</span></summary>
+              <div class="govuk-details__text">
+                <% note_event[:removed_evidence].each do |evidence| %><p class="govuk-body-s"><%= evidence[:source].presence || evidence[:source_ref].presence || evidence[:source_node_key] %></p><% end %>
+              </div>
+            </details>
+          <% end %>
+
+          <details class="govuk-details">
+            <summary class="govuk-details__summary"><span class="govuk-details__summary-text">Omitted evidence (<%= note_event[:omitted_evidence_count] || 0 %>)</span></summary>
+            <div class="govuk-details__text">
+              <% if note_event[:omitted_evidence].empty? %>
+                <% if note_event[:omitted_evidence_count].to_i.positive? %>
+                  <p class="govuk-body">No omitted evidence samples were logged (<%= note_event[:omitted_evidence_count] %> omitted in total).</p>
+                <% else %>
+                  <p class="govuk-body">No evidence was omitted.</p>
+                <% end %>
               <% else %>
-                <p class="govuk-body">No evidence was omitted.</p>
+                <% note_event[:omitted_evidence].each do |evidence| %>
+                  <div class="govuk-!-margin-bottom-4">
+                    <p class="govuk-body-s"><strong><%= evidence[:omission_reason].to_s.humanize.downcase %></strong>; score <%= evidence[:score] %>; <%= evidence[:source_ref].presence || evidence[:source_node_key] %></p>
+                    <p class="govuk-body"><%= evidence[:text] %></p>
+                  </div>
+                <% end %>
+                <% if note_event[:omitted_evidence_truncated] %><p class="govuk-body-s">Only <%= note_event[:logged_omitted_evidence_count] %> omitted records were logged.</p><% end %>
               <% end %>
-            <% else %>
-              <% note_event[:omitted_evidence].each do |evidence| %>
-                <div class="govuk-!-margin-bottom-4">
-                  <p class="govuk-body-s"><strong><%= evidence[:omission_reason].to_s.humanize.downcase %></strong>; score <%= evidence[:score] %>; <%= evidence[:source_ref].presence || evidence[:source_node_key] %></p>
-                  <p class="govuk-body"><%= evidence[:text] %></p>
-                </div>
-              <% end %>
-              <% if note_event[:omitted_evidence_truncated] %><p class="govuk-body-s">Only <%= note_event[:logged_omitted_evidence_count] %> omitted records were logged.</p><% end %>
-            <% end %>
-          </div>
-        </details>
-      </article>
+            </div>
+          </details>
+        </div>
+      </details>
     <% end %>
   <% end %>
 </section>

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -68,6 +68,20 @@
 
     <% if @search_diagnostic.events? %>
       <% timeline_events = search_diagnostic_timeline_events(contextual_events) %>
+      <% note_evidence_events = search_diagnostic_note_evidence(contextual_events) %>
+
+      <div class="govuk-tabs" data-module="govuk-tabs">
+        <h2 class="govuk-tabs__title">Contents</h2>
+        <ul class="govuk-tabs__list">
+          <li class="govuk-tabs__list-item govuk-tabs__list-item--selected">
+            <a class="govuk-tabs__tab" href="#journey">Journey</a>
+          </li>
+          <li class="govuk-tabs__list-item">
+            <a class="govuk-tabs__tab" href="#notes">Notes</a>
+          </li>
+        </ul>
+
+        <div class="govuk-tabs__panel" id="journey">
 
       <% if timeline_events.any? %>
         <% highlighted_timeline_events = search_diagnostic_significant_timeline_events(timeline_events) %>
@@ -135,8 +149,6 @@
         </section>
       <% end %>
 
-      <%= render "note_evidence", note_evidence_events: search_diagnostic_note_evidence(contextual_events) %>
-
       <table class="govuk-table search-diagnostics-events">
         <caption class="govuk-table__caption govuk-table__caption--m">Search journey events</caption>
         <thead class="govuk-table__head">
@@ -154,21 +166,33 @@
               <td class="govuk-table__cell" data-label="Time"><%= search_diagnostic_event_time(event) %></td>
               <td class="govuk-table__cell" data-label="Event"><%= search_diagnostic_event_name(event) %></td>
               <td class="govuk-table__cell" data-label="Type"><%= search_diagnostic_search_type(event) %></td>
-              <td class="govuk-table__cell" data-label="Summary"><%= search_diagnostic_event_summary(event) %></td>
+              <td class="govuk-table__cell" data-label="Summary">
+                <%= search_diagnostic_event_summary(event) %>
+              </td>
               <td class="govuk-table__cell" data-label="Diagnostics">
-                <details class="govuk-details">
-                  <summary class="govuk-details__summary">
-                    <span class="govuk-details__summary-text">View diagnostics</span>
-                  </summary>
-                  <div class="govuk-details__text">
-                    <%= search_diagnostic_event_details(event) %>
-                  </div>
-                </details>
+                <% if event[:event].to_s == "note_evidence_evaluated" && search_diagnostic_fields(event)[:iteration].present? %>
+                  <%= link_to "View iteration #{search_diagnostic_fields(event)[:iteration]} notes", "#notes", class: "govuk-link" %>
+                <% else %>
+                  <details class="govuk-details">
+                    <summary class="govuk-details__summary">
+                      <span class="govuk-details__summary-text">View diagnostics</span>
+                    </summary>
+                    <div class="govuk-details__text">
+                      <%= search_diagnostic_event_details(event) %>
+                    </div>
+                  </details>
+                <% end %>
               </td>
             </tr>
           <% end %>
         </tbody>
       </table>
+        </div>
+
+        <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="notes">
+          <%= render "note_evidence", note_evidence_events: %>
+        </div>
+      </div>
     <% else %>
       <p class="govuk-body">No search journey events were found for this request ID.</p>
     <% end %>

--- a/app/views/search_diagnostics/show.html.erb
+++ b/app/views/search_diagnostics/show.html.erb
@@ -190,7 +190,7 @@
         </div>
 
         <div class="govuk-tabs__panel govuk-tabs__panel--hidden" id="notes">
-          <%= render "note_evidence", note_evidence_events: %>
+          <%= render "note_evidence", note_evidence_events: note_evidence_events %>
         </div>
       </div>
     <% else %>

--- a/spec/helpers/search_diagnostics_helper_spec.rb
+++ b/spec/helpers/search_diagnostics_helper_spec.rb
@@ -132,6 +132,12 @@ RSpec.describe SearchDiagnosticsHelper do
     it { is_expected.to eq(expected_note_evidence_statuses) }
   end
 
+  describe "#search_diagnostic_fields" do
+    it "normalises malformed fields to an empty hash" do
+      expect(helper.search_diagnostic_fields(fields: "not-json")).to eq({})
+    end
+  end
+
   describe "#search_diagnostic_event_name" do
     it "humanises event names for display" do
       expect(helper.search_diagnostic_event_name(event: "query_expansion_decided")).to eq("Query expansion decided")

--- a/spec/helpers/search_diagnostics_helper_spec.rb
+++ b/spec/helpers/search_diagnostics_helper_spec.rb
@@ -88,6 +88,24 @@ RSpec.describe SearchDiagnosticsHelper do
 
     it { is_expected.to match([expected_note_evidence]) }
 
+    it "assigns stable anchors and marks the first iteration's evidence as added" do
+      expect(evidence.first).to include(
+        dom_id: "note-evidence-iteration-2",
+        change_counts: { added: 1, retained: 0, removed: 0 },
+        selected_evidence: contain_exactly(include(change: :added)),
+      )
+    end
+
+    it "marks unchanged evidence as retained on the following iteration" do
+      changes = note_evidence_changes
+
+      expect(changes.last[:change_counts]).to eq(added: 0, retained: 1, removed: 0)
+    end
+
+    it "retains the unchanged evidence payload for inspection" do
+      expect(note_evidence_changes.last[:selected_evidence]).to contain_exactly(include(change: :retained))
+    end
+
     context "with unrelated and malformed diagnostic events" do
       let(:events) do
         [
@@ -393,6 +411,11 @@ RSpec.describe SearchDiagnosticsHelper do
         },
       },
     }
+  end
+
+  def note_evidence_changes
+    following = note_evidence_event.deep_merge(fields: { iteration: 3, attempt_number: 3 })
+    helper.search_diagnostic_note_evidence([note_evidence_event, following])
   end
 
   def expected_note_evidence

--- a/spec/requests/search_diagnostics_controller_spec.rb
+++ b/spec/requests/search_diagnostics_controller_spec.rb
@@ -191,8 +191,11 @@ RSpec.describe SearchDiagnosticsController do
                   note_evidence_status: "selected",
                   considered_note_count: 4,
                   considered_evidence_count: 5,
+                  considered_association_count: 5,
+                  considered_distinct_source_count: 3,
                   selected_note_count: 1,
                   selected_evidence_count: 2,
+                  selected_distinct_source_count: 2,
                   omitted_evidence_count: 1,
                   logged_omitted_evidence_count: 1,
                   omitted_evidence_truncated: false,
@@ -447,7 +450,32 @@ RSpec.describe SearchDiagnosticsController do
       page = Capybara.string(response.body)
       section = page.find("section.search-diagnostics-note-evidence")
 
-      expect(section.text).to include(*note_evidence_copy)
+      expect(section.text.squish).to include(*note_evidence_copy)
+    end
+
+    it "separates the journey and notes into GOV.UK tabs" do
+      rendered_page
+      page = Capybara.string(response.body)
+
+      expect(page).to have_css(".govuk-tabs__list-item--selected a[href='#journey']", text: "Journey")
+        .and have_css("a[href='#notes']", text: "Notes")
+    end
+
+    it "links journey evidence to the collapsed notes iteration" do
+      rendered_page
+      page = Capybara.string(response.body)
+
+      expect(page).to have_css("#journey a[href='#notes']", text: "View iteration 2 notes")
+        .and have_css("#notes details#note-evidence-iteration-2:not([open])")
+    end
+
+    it "keeps the note payload out of the journey panel" do
+      rendered_page
+
+      page = Capybara.string(response.body)
+      payload = "Pig iron means iron-carbon alloys"
+
+      expect([page.find("#journey").text.include?(payload), page.find("#notes").text.include?(payload)]).to eq([false, true])
     end
 
     it "renders the GOV.UK formatted log search window and event timeline chart" do
@@ -574,10 +602,9 @@ RSpec.describe SearchDiagnosticsController do
       it "renders each empty selection state without inventing omitted samples" do
         rendered_page
 
-        expect(Capybara.string(response.body).text.squish).to include(
-          "Disabled", "No compressed notes", "No eligible evidence", "No omitted evidence samples were logged (3 omitted in total).",
-          "Considered - notes; - evidence records", "Selected - notes; - evidence records"
-        )
+        copy = ["Disabled", "No compressed notes", "No eligible evidence", "No omitted evidence samples were logged (3 omitted in total).", "Considered unavailable contexts; unavailable reported evidence records", "Selected unavailable contexts; unavailable reported evidence records", "No compressed note passage was added to this model prompt."]
+
+        expect(Capybara.string(response.body).text.squish).to include(*copy)
       end
     end
 
@@ -627,6 +654,8 @@ RSpec.describe SearchDiagnosticsController do
       "Interactive search",
       "Search query: pig iron",
       "pig iron primary forms",
+      "4 contexts; 5 associations; 3 distinct source passages",
+      "1 contexts; 2 distinct source passages",
       "compressed_note_1",
       "chapter-72-hash",
       "7201101100, 7201200000",


### PR DESCRIPTION
# Pull Request

## What:

- [x] Separate search diagnostics into default Journey and Notes GOV.UK tabs
- [x] Keep the chronological note-evidence signal in Journey without repeating the full payload there
- [x] Group note evidence into collapsed iteration panels with source text ahead of technical metadata
- [x] Show added, retained, and removed passages across stateless model iterations
- [x] Label legacy evidence counts conservatively and display enriched context, association, and distinct-source counts when present
- [x] Cover helper and request rendering with 66 passing focused examples and clean RuboCop

## Why:

Displaying every compressed-note payload inline made a diagnostic journey difficult to scan and obscured why specific source passages entered each model prompt. Operators need a compact journey plus a dedicated place to judge the relevance and completeness of the actual note text.

The Notes tab keeps every payload inspectable while collapsing it by iteration and making source text the primary content.

## Ticket:

[AI-1062](https://transformuk.atlassian.net/browse/AI-1062)

## Risk:

**Risk level:** 🟢

**Reason for rating:** This is a read-only admin diagnostics presentation change. It does not modify search behaviour, tariff data, authentication, or backend requests.