### PR TITLE
AI-1056: Remove status concept from customs tariff update model

### DIFF
--- a/app/controllers/customs_tariff/updates_controller.rb
+++ b/app/controllers/customs_tariff/updates_controller.rb
@@ -12,7 +12,7 @@ module CustomsTariff
       @section_summaries = CustomsTariff::SectionSummary.all(customs_tariff_update_version: params[:version])
       @sections_by_id = Section.all.index_by { |s| s.position.to_i }
       @baseline_version = @updates
-        .reject { |u| u.version == @update.version || u.status == "failed" }
+        .reject { |u| u.version == @update.version || u.failed? }
         .select { |u| u.validity_start_date.present? && u.validity_start_date < @update.validity_start_date }
         .max_by(&:validity_start_date)
         &.version

--- a/app/models/customs_tariff/update.rb
+++ b/app/models/customs_tariff/update.rb
@@ -2,14 +2,12 @@ module CustomsTariff
   class Update
     include ApiEntity
 
-    attributes :version, :status, :validity_start_date, :validity_end_date,
+    attributes :version, :import_error, :validity_start_date, :validity_end_date,
                :source_url, :document_created_on, :created_at, :updated_at
 
     set_collection_path "admin/customs_tariff_updates"
     set_singular_path   "admin/customs_tariff_updates/:version"
 
-    def pending?  = status == "pending"
-    def approved? = status == "approved"
-    def rejected? = status == "rejected"
+    def failed? = import_error.present?
   end
 end

--- a/spec/models/customs_tariff/update_spec.rb
+++ b/spec/models/customs_tariff/update_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe CustomsTariff::Update do
   let(:attributes) do
     {
       version: "1.31",
-      status: "pending",
+      import_error: nil,
       validity_start_date: "2026-01-01",
       validity_end_date: nil,
       source_url: "https://example.com/document.pdf",
@@ -14,34 +14,14 @@ RSpec.describe CustomsTariff::Update do
     }
   end
 
-  describe "#pending?" do
-    it { is_expected.to be_pending }
-
-    it "is false when status is approved" do
-      update.status = "approved"
-      expect(update).not_to be_pending
-    end
-  end
-
-  describe "#approved?" do
-    it "is false when status is pending" do
-      expect(update).not_to be_approved
+  describe "#failed?" do
+    it "is false when import_error is nil" do
+      expect(update).not_to be_failed
     end
 
-    it "is true when status is approved" do
-      update.status = "approved"
-      expect(update).to be_approved
-    end
-  end
-
-  describe "#rejected?" do
-    it "is false when status is pending" do
-      expect(update).not_to be_rejected
-    end
-
-    it "is true when status is rejected" do
-      update.status = "rejected"
-      expect(update).to be_rejected
+    it "is true when import_error is present" do
+      update.import_error = "Something went wrong"
+      expect(update).to be_failed
     end
   end
 end


### PR DESCRIPTION
### Jira link

AI-1056

### What?

Companion change to backend PR [#3520](https://github.com/trade-tariff/trade-tariff-backend/pull/3520). Updates the admin app's `CustomsTariff::Update` model to reflect the backend's removal of the `status` concept.

Here's what's changed:

- **`CustomsTariff::Update`** — swaps the `status` attribute for `import_error`, removes `pending?`, `approved?`, and `rejected?` predicates, and adds `failed?` (returns true when `import_error` is present)
- **`CustomsTariff::UpdatesController`** — updates the baseline version filter to use `failed?` instead of checking `status == "failed"`
- **`spec/models/customs_tariff/update_spec.rb`** — replaces stale status predicate specs with coverage for `failed?`

### Why?

The backend no longer exposes a `status` field on the `CustomsTariff::Update` serializer — it now exposes `import_error` instead. This PR keeps the admin app in sync so it doesn't break when the backend is deployed.

### Risk

**Risk level:** 🟢

**Reason for rating:** The customs tariff notes feature has never been deployed to production. This is a straight model attribute swap with no view changes.

### Have you?

- [ ] Reviewed view changes with stakeholders
- [ ] Validated mobile responsive behaviour of view changes

### Deployment risks

- Must be merged and deployed alongside the backend PR [#3520](https://github.com/trade-tariff/trade-tariff-backend/pull/3520) — deploying the backend alone will break the admin app's customs tariff updates page.