### PR TITLE
Fix basic session password toggle labels

### DIFF
--- a/app/views/basic_sessions/new.html.erb
+++ b/app/views/basic_sessions/new.html.erb
@@ -24,7 +24,9 @@
 
           <%= form.govuk_password_field :password,
                                         label: { text: 'Password' },
-                                        class: 'govuk-input--width-10' %>
+                                        class: 'govuk-input--width-10',
+                                        show_password_text: 'Show',
+                                        hide_password_text: 'Hide' %>
 
 
 	  <%= form.hidden_field :return_url, value: @basic_session.return_url %>

--- a/spec/requests/basic_sessions_controller_spec.rb
+++ b/spec/requests/basic_sessions_controller_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe "BasicSessionsController", type: :request do
       get "/basic_sessions/new"
       expect(assigns(:basic_session).return_url).to eq("/customs_tariff/updates")
     end
+
+    it "renders the show password toggle with visible label text" do
+      get "/basic_sessions/new"
+
+      page = Capybara.string(response.body)
+      toggle = "button.govuk-password-input__toggle[hidden]"
+      expect(page).to have_css(toggle, text: "Show", visible: :hidden)
+    end
   end
 
   describe "POST /basic_sessions" do


### PR DESCRIPTION
# Pull Request

## What:

Restores the visible Show and Hide labels on the Basic Session password toggle.

Adds a request spec covering the rendered toggle text.

## Why:

The form builder no longer supplies default toggle labels. Once GOV.UK JavaScript revealed the empty button, it appeared as a thin grey bar.

This matches the existing fix in the frontend application.

## Ticket:

N/A

## Risk:

Risk level: 🟢 Green

Reason for rating:

This only changes the password control's display text for development and other non-production Basic Session authentication. Password validation, authorisation, production authentication and secrets are unchanged.

## Verification:

- `bundle exec rspec spec/requests/basic_sessions_controller_spec.rb` (4 examples, 0 failures)
- `bin/rubocop spec/requests/basic_sessions_controller_spec.rb` (no offenses)
- Repository commit and push hooks passed