### PR TITLE
Remove generated timestamp from search dashboard

### DIFF
--- a/app/views/search_analytics/index.html.erb
+++ b/app/views/search_analytics/index.html.erb
@@ -11,11 +11,6 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Search dashboard</h1>
-    <% if @search_analytics.generated_at.present? %>
-      <p class="govuk-body-s govuk-!-margin-bottom-5">
-        Generated <%= search_analytics_timestamp(@search_analytics.generated_at) %>.
-      </p>
-    <% end %>
 
     <div class="search-analytics-filters govuk-!-margin-bottom-5">
       <div>

--- a/spec/features/search_analytics_dashboard_spec.rb
+++ b/spec/features/search_analytics_dashboard_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Search analytics dashboard" do
     expect(page).to have_content("1,240")
     expect(page).to have_content("Failure rate")
     expect(page).to have_content("1.2%")
-    expect(page).to have_content("Generated 10 June 2026 at 09:55")
+    expect(page).not_to have_content("Generated 10 June 2026 at 09:55")
     expect(page).not_to have_content("Query window ended")
     expect(page).to have_css(".govuk-details", text: "How these metrics are calculated")
     expect(page).to have_css(".govuk-summary-list__row", text: "Zero-result rate", visible: :all)

--- a/spec/features/search_analytics_dashboard_spec.rb
+++ b/spec/features/search_analytics_dashboard_spec.rb
@@ -122,7 +122,6 @@ RSpec.describe "Search analytics dashboard" do
     expect(page).to have_content("1,240")
     expect(page).to have_content("Failure rate")
     expect(page).to have_content("1.2%")
-    expect(page).not_to have_content(/Generated \d{1,2} \w+ \d{4} at \d{2}:\d{2}/)
     expect(page).not_to have_content("Query window ended")
     expect(page).to have_css(".govuk-details", text: "How these metrics are calculated")
     expect(page).to have_css(".govuk-summary-list__row", text: "Zero-result rate", visible: :all)

--- a/spec/features/search_analytics_dashboard_spec.rb
+++ b/spec/features/search_analytics_dashboard_spec.rb
@@ -122,7 +122,7 @@ RSpec.describe "Search analytics dashboard" do
     expect(page).to have_content("1,240")
     expect(page).to have_content("Failure rate")
     expect(page).to have_content("1.2%")
-    expect(page).not_to have_content("Generated 10 June 2026 at 09:55")
+    expect(page).not_to have_content(/Generated \d{1,2} \w+ \d{4} at \d{2}:\d{2}/)
     expect(page).not_to have_content("Query window ended")
     expect(page).to have_css(".govuk-details", text: "How these metrics are calculated")
     expect(page).to have_css(".govuk-summary-list__row", text: "Zero-result rate", visible: :all)

--- a/spec/requests/search_analytics_controller_spec.rb
+++ b/spec/requests/search_analytics_controller_spec.rb
@@ -98,7 +98,6 @@ RSpec.describe SearchAnalyticsController do
     expect(response.body).to include("Zero-result rate", "8.4%")
     expect(response.body).to include("Selection rate", "41%")
     expect(response.body).to include("P90 latency", "1.8s")
-    expect(response.body).not_to match(/Generated \d{1,2} \w+ \d{4} at \d{2}:\d{2}/)
     expect(response.body).not_to include("Query window ended")
     expect(response.body).to include("Zero search terms")
   end

--- a/spec/requests/search_analytics_controller_spec.rb
+++ b/spec/requests/search_analytics_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe SearchAnalyticsController do
     expect(response.body).to include("Zero-result rate", "8.4%")
     expect(response.body).to include("Selection rate", "41%")
     expect(response.body).to include("P90 latency", "1.8s")
-    expect(response.body).to include("Generated 10 June 2026 at 09:55")
+    expect(response.body).not_to include("Generated 10 June 2026 at 09:55")
     expect(response.body).not_to include("Query window ended")
     expect(response.body).to include("Zero search terms")
   end

--- a/spec/requests/search_analytics_controller_spec.rb
+++ b/spec/requests/search_analytics_controller_spec.rb
@@ -98,7 +98,7 @@ RSpec.describe SearchAnalyticsController do
     expect(response.body).to include("Zero-result rate", "8.4%")
     expect(response.body).to include("Selection rate", "41%")
     expect(response.body).to include("P90 latency", "1.8s")
-    expect(response.body).not_to include("Generated 10 June 2026 at 09:55")
+    expect(response.body).not_to match(/Generated \d{1,2} \w+ \d{4} at \d{2}:\d{2}/)
     expect(response.body).not_to include("Query window ended")
     expect(response.body).to include("Zero search terms")
   end


### PR DESCRIPTION
## What:

- [x] Remove the snapshot generation timestamp from the search dashboard
- [x] Remove transient timestamp assertions from the existing dashboard specs
- [x] Verify the focused search analytics suite: 38 examples, 0 failures

## Why:

The timestamp describes when the cached snapshot was generated rather than the selected analytics period. Removing it keeps the dashboard focused on the surfaced metrics and filters.

## Ticket:

N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:**

Admin UI copy removal only. No API contract, tariff data, authentication, or authorisation changes.