### PR TITLE
Promote configuration to standalone navigation

### DIFF
--- a/app/controllers/configurations_controller.rb
+++ b/app/controllers/configurations_controller.rb
@@ -1,11 +1,11 @@
-class ClassificationConfigurationsController < AuthenticatedController
+class ConfigurationsController < AuthenticatedController
   before_action :set_current_configuration, only: %i[edit update]
 
   def index
     authorize AdminConfiguration, :index?
     @configurations = AdminConfiguration.all.sort_by { |c| [c.config_type, c.name] }
   rescue Faraday::Error => e
-    Rails.logger.error("Failed to fetch classification configurations: #{e.message}")
+    Rails.logger.error("Failed to fetch configurations: #{e.message}")
     @configurations = []
     flash.now[:alert] = "Unable to load configurations. Please try again."
   end
@@ -15,13 +15,13 @@ class ClassificationConfigurationsController < AuthenticatedController
     @configuration = find_configuration
     @versions = fetch_versions
   rescue Faraday::ResourceNotFound
-    redirect_to classification_configurations_path, alert: "Configuration not found."
+    redirect_to configurations_path, alert: "Configuration not found."
   end
 
   def edit
     authorize AdminConfiguration, :update?
   rescue Faraday::ResourceNotFound
-    redirect_to classification_configurations_path, alert: "Configuration not found."
+    redirect_to configurations_path, alert: "Configuration not found."
   end
 
   def update
@@ -30,13 +30,13 @@ class ClassificationConfigurationsController < AuthenticatedController
     @configuration.assign_attributes(configuration_params)
 
     if @configuration.save && @configuration.errors.empty?
-      redirect_to classification_configuration_path(@configuration),
+      redirect_to configuration_path(@configuration),
                   notice: "Configuration updated."
     else
       render :edit
     end
   rescue Faraday::ResourceNotFound
-    redirect_to classification_configurations_path, alert: "Configuration not found."
+    redirect_to configurations_path, alert: "Configuration not found."
   end
 
 private
@@ -46,7 +46,7 @@ private
 
     return if @configuration.current?
 
-    redirect_to classification_configuration_path(@configuration),
+    redirect_to configuration_path(@configuration),
                 alert: "Cannot edit historical versions."
   end
 
@@ -65,7 +65,7 @@ private
   end
 
   def configuration_params
-    permitted = params.require(:classification_configuration).permit(:value).to_h
+    permitted = params.require(:configuration).permit(:value).to_h
 
     if permitted[:value].is_a?(String) && permitted[:value].match?(/\A\s*[\[{]/)
       begin

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -90,13 +90,6 @@ module NavigationHelper
             service: nil,
           ),
           NavigationItem.new(
-            text: "Configuration",
-            href: classification_configurations_path,
-            policy_class: AdminConfiguration,
-            active_when: /\/classification_configurations/,
-            service: :uk,
-          ),
-          NavigationItem.new(
             text: "Intercepts",
             href: description_intercepts_path,
             policy_class: DescriptionIntercept,
@@ -183,6 +176,13 @@ module NavigationHelper
         service: nil,
         items: [],
       ),
+      NavigationSection.new(
+        key: :configuration,
+        label: "Configuration",
+        href: configurations_path,
+        items: [],
+        service: :uk,
+      ),
     ]
   end
 
@@ -243,6 +243,8 @@ private
     case section.key
     when :manage_users
       policy(User).index?
+    when :configuration
+      policy(AdminConfiguration).index?
     else
       true
     end

--- a/app/helpers/versions_helper.rb
+++ b/app/helpers/versions_helper.rb
@@ -16,7 +16,7 @@ module VersionsHelper
       tariff_knowledge_compressed_note_path(version.item_id, **opts) if version.item_id.present?
     when "AdminConfiguration"
       name = version.object&.dig("name")
-      classification_configuration_path(name, **opts) if name.present?
+      configuration_path(name, **opts) if name.present?
     end
   end
 

--- a/app/views/configurations/_form.html.erb
+++ b/app/views/configurations/_form.html.erb
@@ -1,8 +1,8 @@
 <% form_data = %w[options multi_options nested_options].include?(configuration.config_type) ? { controller: 'config-form' } : {} %>
 
 <%= govuk_form_for configuration,
-                   as: :classification_configuration,
-                   url: classification_configuration_path(configuration),
+                   as: :configuration,
+                   url: configuration_path(configuration),
                    html: { data: form_data } do |f| %>
 
   <% case configuration.config_type %>
@@ -22,7 +22,7 @@
     <% selected = configuration.value.is_a?(Hash) ? configuration.value["selected"] : "" %>
 
     <input type="hidden"
-           name="classification_configuration[value]"
+           name="configuration[value]"
            value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>"
            data-config-form-target="hiddenField">
 
@@ -43,7 +43,7 @@
     <% selected_values = configuration.value.is_a?(Hash) ? Array(configuration.value["selected"]) : [] %>
 
     <input type="hidden"
-           name="classification_configuration[value]"
+           name="configuration[value]"
            value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>"
            data-config-form-target="hiddenField">
 
@@ -76,7 +76,7 @@
     <% sub_values = configuration.value.is_a?(Hash) ? (configuration.value["sub_values"] || {}) : {} %>
 
     <input type="hidden"
-           name="classification_configuration[value]"
+           name="configuration[value]"
            value="<%= configuration.value.is_a?(Hash) ? configuration.value.to_json : configuration.value %>"
            data-config-form-target="hiddenField">
 
@@ -109,5 +109,5 @@
                           rows: 6 %>
   <% end %>
 
-  <%= submit_and_back_buttons f, classification_configurations_path %>
+  <%= submit_and_back_buttons f, configurations_path %>
 <% end %>

--- a/app/views/configurations/edit.html.erb
+++ b/app/views/configurations/edit.html.erb
@@ -1,4 +1,4 @@
-<%= govuk_breadcrumbs "Configurations": classification_configurations_path %>
+<%= govuk_breadcrumbs "Configurations": configurations_path %>
 
 <h1 class="govuk-heading-l">Edit Configuration: <%= @configuration.display_name %></h1>
 

--- a/app/views/configurations/index.html.erb
+++ b/app/views/configurations/index.html.erb
@@ -1,4 +1,4 @@
-<h1 class="govuk-heading-l">Classification Configurations</h1>
+<h1 class="govuk-heading-l">Configurations</h1>
 
 <% if @configurations.any? %>
   <div data-controller="config-table">
@@ -114,7 +114,7 @@
                 </td>
                 <td class="govuk-table__cell"><%= config.description %></td>
                 <td class="govuk-table__cell">
-                  <%= link_to "View", classification_configuration_path(config), class: "govuk-link" %>
+                  <%= link_to "View", configuration_path(config), class: "govuk-link" %>
                 </td>
               </tr>
             <% end %>

--- a/app/views/configurations/show.html.erb
+++ b/app/views/configurations/show.html.erb
@@ -1,8 +1,8 @@
-<%= govuk_breadcrumbs "Configurations": classification_configurations_path %>
+<%= govuk_breadcrumbs "Configurations": configurations_path %>
 
 <%= render "versions/version_banner",
            record: @configuration,
-           current_path: classification_configuration_path(@configuration),
+           current_path: configuration_path(@configuration),
            type_name: "configuration" %>
 
 <h1 class="govuk-heading-l">Configuration: <%= @configuration.display_name %></h1>
@@ -216,14 +216,14 @@
 
 <% if @configuration.current? && policy(@configuration).update? %>
   <div class="govuk-button-group">
-    <%= link_to "Edit", edit_classification_configuration_path(@configuration), class: "govuk-button" %>
+    <%= link_to "Edit", edit_configuration_path(@configuration), class: "govuk-button" %>
   </div>
 <% end %>
 
 <% if @versions.present? %>
   <%= render "versions/history_section",
              versions: @versions,
-             view_path_helper: ->(v) { classification_configuration_path(@configuration, oid: v.resource_id) },
+             view_path_helper: ->(v) { configuration_path(@configuration, oid: v.resource_id) },
              restore_path_helper: ->(v) { restore_version_path(v.resource_id) },
              can_restore: policy(@configuration).update?,
              current_oid: @configuration.version_oid %>
@@ -231,4 +231,4 @@
 
 <%= render "versions/version_navigation",
            record: @configuration,
-           version_path_helper: ->(oid) { classification_configuration_path(@configuration, oid: oid) } %>
+           version_path_helper: ->(oid) { configuration_path(@configuration, oid: oid) } %>

--- a/app/views/description_intercepts/index.html.erb
+++ b/app/views/description_intercepts/index.html.erb
@@ -76,7 +76,7 @@
           </div>
           <p class="govuk-body">
             Add templates in
-            <%= link_to "Classification configurations", classification_configuration_path("description_intercept_templates"), class: "govuk-link" %>
+            <%= link_to "Configurations", configuration_path("description_intercept_templates"), class: "govuk-link" %>
             before importing description intercepts.
           </p>
         <% end %>

--- a/config/debride.whitelist
+++ b/config/debride.whitelist
@@ -42,8 +42,8 @@ ChapterNotePolicy#create?
 ChapterNotePolicy#destroy?
 ChapterNotePolicy#show?
 ChapterNotePolicy#update?
-ClassificationConfigurationsController#edit
-ClassificationConfigurationsController#show
+ConfigurationsController#edit
+ConfigurationsController#show
 Commodity#declarable?
 Commodity#reference_title
 CustomsTariff::ChapterNote#version_objects

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -162,7 +162,7 @@ Rails.application.routes.draw do
     end
   end
 
-  resources :classification_configurations, param: :name, only: %i[index show edit update]
+  resources :configurations, param: :name, only: %i[index show edit update]
 
   resources :description_intercepts, only: %i[index new create show edit update destroy] do
     member do

--- a/spec/helpers/navigation_helper_spec.rb
+++ b/spec/helpers/navigation_helper_spec.rb
@@ -13,8 +13,8 @@ RSpec.describe NavigationHelper, type: :helper do
   end
 
   describe "#navigation_sections" do
-    it "returns all four sections" do
-      expect(helper.navigation_sections.map(&:key)).to eq(%i[ott_admin classification spimm manage_users])
+    it "returns all five sections" do
+      expect(helper.navigation_sections.map(&:key)).to eq(%i[ott_admin classification spimm manage_users configuration])
     end
 
     it "defines OTT Admin with 8 items" do
@@ -24,9 +24,9 @@ RSpec.describe NavigationHelper, type: :helper do
       )
     end
 
-    it "defines Classification with 7 items" do
+    it "defines Classification with 6 items" do
       section = helper.navigation_sections.find { |s| s.key == :classification }
-      expect(section.items.map(&:text)).to eq(["Search References", "Descriptions", "Configuration", "Intercepts", "Search dashboard", "Search diagnostics", "Recent changes"])
+      expect(section.items.map(&:text)).to eq(["Search References", "Descriptions", "Intercepts", "Search dashboard", "Search diagnostics", "Recent changes"])
     end
 
     it "defines SPIMM with xi service restriction" do
@@ -47,6 +47,13 @@ RSpec.describe NavigationHelper, type: :helper do
     it "defines Manage Users with users_path href" do
       section = helper.navigation_sections.find { |s| s.key == :manage_users }
       expect(section.href).to eq(helper.users_path)
+    end
+
+    it "defines Configuration as standalone with configurations_path href", :aggregate_failures do
+      section = helper.navigation_sections.find { |s| s.key == :configuration }
+
+      expect(section.items).to be_empty
+      expect(section.href).to eq(helper.configurations_path)
     end
   end
 
@@ -81,8 +88,9 @@ RSpec.describe NavigationHelper, type: :helper do
                          "Reports",
                          "Rollbacks",
                        ],
-                       classification: ["Search References", "Descriptions", "Configuration", "Intercepts", "Search dashboard", "Search diagnostics", "Recent changes"],
-                       manage_users: nil
+                       classification: ["Search References", "Descriptions", "Intercepts", "Search dashboard", "Search diagnostics", "Recent changes"],
+                       manage_users: nil,
+                       configuration: []
     end
 
     context "with UK service and hmrc_admin role" do
@@ -109,7 +117,8 @@ RSpec.describe NavigationHelper, type: :helper do
                          "Updates",
                          "Rollbacks",
                        ],
-                       classification: ["Search References", "Configuration", "Search dashboard", "Search diagnostics"]
+                       classification: ["Search References", "Search dashboard", "Search diagnostics"],
+                       configuration: []
     end
 
     context "with UK service and guest role" do
@@ -205,6 +214,14 @@ RSpec.describe NavigationHelper, type: :helper do
 
       it "returns Manage Users section" do
         expect(helper.current_navigation_section.key).to eq(:manage_users)
+      end
+    end
+
+    context "when on the configurations page" do
+      let(:request_path) { "/configurations" }
+
+      it "returns Configuration section" do
+        expect(helper.current_navigation_section.key).to eq(:configuration)
       end
     end
 

--- a/spec/requests/configurations_controller_spec.rb
+++ b/spec/requests/configurations_controller_spec.rb
@@ -1,5 +1,5 @@
 # rubocop:disable RSpec/MultipleMemoizedHelpers, RSpec/MultipleExpectations, RSpec/ExampleLength
-RSpec.describe ClassificationConfigurationsController, type: :request do
+RSpec.describe ConfigurationsController, type: :request do
   subject(:rendered_page) { make_request && response }
 
   include_context "with authenticated user"
@@ -142,13 +142,13 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         .and_return(collection_response)
     end
 
-    let(:make_request) { get classification_configurations_path }
+    let(:make_request) { get configurations_path }
 
     it { is_expected.to have_http_status :success }
     it { is_expected.to render_template(:index) }
 
     it "displays configurations with humanised names" do
-      expect(rendered_page.body).to include("Classification Configurations")
+      expect(rendered_page.body).to include("Configurations")
       expect(rendered_page.body).to include("Expansion Prompt")
       expect(rendered_page.body).to include("Qa Enabled")
       expect(rendered_page.body).to include("Object template")
@@ -206,7 +206,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         .and_return(status: 200, headers: { "content-type" => "application/json; charset=utf-8" }, body: { data: [] }.to_json)
     end
 
-    let(:make_request) { get classification_configuration_path(config_name) }
+    let(:make_request) { get configuration_path(config_name) }
 
     it { is_expected.to have_http_status :success }
     it { is_expected.to render_template(:show) }
@@ -382,7 +382,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(historical_config_response)
       end
 
-      let(:make_request) { get classification_configuration_path(config_name, oid: 41) }
+      let(:make_request) { get configuration_path(config_name, oid: 41) }
 
       it { is_expected.to have_http_status :success }
 
@@ -405,7 +405,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(status: 404, body: { error: "Not found" }.to_json)
       end
 
-      it { is_expected.to redirect_to(classification_configurations_path) }
+      it { is_expected.to redirect_to(configurations_path) }
 
       it "shows an error message" do
         rendered_page
@@ -442,7 +442,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         .and_return(config_response)
     end
 
-    let(:make_request) { get edit_classification_configuration_path(config_name) }
+    let(:make_request) { get edit_configuration_path(config_name) }
 
     it { is_expected.to have_http_status :success }
     it { is_expected.to render_template(:edit) }
@@ -661,9 +661,9 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
     it "does not render editable name, type, or description fields", :aggregate_failures do
       body = rendered_page.body
-      expect(body).not_to include('name="classification_configuration[name]"')
-      expect(body).not_to include('name="classification_configuration[config_type]"')
-      expect(body).not_to include('name="classification_configuration[description]"')
+      expect(body).not_to include('name="configuration[name]"')
+      expect(body).not_to include('name="configuration[config_type]"')
+      expect(body).not_to include('name="configuration[description]"')
     end
 
     context "when configuration is a historical version" do
@@ -672,7 +672,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(historical_config_response)
       end
 
-      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+      it { is_expected.to redirect_to(configuration_path(config_name)) }
 
       it "shows a historical version alert" do
         rendered_page
@@ -688,9 +688,9 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
     end
 
     let(:make_request) do
-      patch classification_configuration_path(config_name),
+      patch configuration_path(config_name),
             params: {
-              classification_configuration: {
+              configuration: {
                 value: "Updated prompt text",
               },
             }
@@ -702,7 +702,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(config_response)
       end
 
-      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+      it { is_expected.to redirect_to(configuration_path(config_name)) }
 
       it "shows a success message" do
         rendered_page
@@ -736,9 +736,9 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         }
       end
       let(:make_request) do
-        patch classification_configuration_path(config_name),
+        patch configuration_path(config_name),
               params: {
-                classification_configuration: {
+                configuration: {
                   value: options_json,
                 },
               }
@@ -756,7 +756,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(config_response)
       end
 
-      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+      it { is_expected.to redirect_to(configuration_path(config_name)) }
 
       it "parses the JSON string value to a hash before sending to API" do
         rendered_page
@@ -777,9 +777,9 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         }
       end
       let(:make_request) do
-        patch classification_configuration_path(config_name),
+        patch configuration_path(config_name),
               params: {
-                classification_configuration: {
+                configuration: {
                   value: "false",
                 },
               }
@@ -790,7 +790,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(config_response)
       end
 
-      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+      it { is_expected.to redirect_to(configuration_path(config_name)) }
     end
 
     context "with a string config value" do
@@ -806,9 +806,9 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         }
       end
       let(:make_request) do
-        patch classification_configuration_path(config_name),
+        patch configuration_path(config_name),
               params: {
-                classification_configuration: {
+                configuration: {
                   value: "sk-new...key",
                 },
               }
@@ -819,7 +819,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(config_response)
       end
 
-      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+      it { is_expected.to redirect_to(configuration_path(config_name)) }
     end
 
     context "with an integer config value" do
@@ -835,9 +835,9 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         }
       end
       let(:make_request) do
-        patch classification_configuration_path(config_name),
+        patch configuration_path(config_name),
               params: {
-                classification_configuration: {
+                configuration: {
                   value: "500",
                 },
               }
@@ -848,7 +848,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(config_response)
       end
 
-      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+      it { is_expected.to redirect_to(configuration_path(config_name)) }
     end
 
     context "with a multi_options config JSON value" do
@@ -867,9 +867,9 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
         }
       end
       let(:make_request) do
-        patch classification_configuration_path(config_name),
+        patch configuration_path(config_name),
               params: {
-                classification_configuration: {
+                configuration: {
                   value: multi_options_json,
                 },
               }
@@ -894,14 +894,14 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(config_response)
       end
 
-      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+      it { is_expected.to redirect_to(configuration_path(config_name)) }
     end
 
     context "when extra params are submitted" do
       let(:make_request) do
-        patch classification_configuration_path(config_name),
+        patch configuration_path(config_name),
               params: {
-                classification_configuration: {
+                configuration: {
                   value: "Updated prompt text",
                   name: "hacked_name",
                   config_type: "boolean",
@@ -940,15 +940,15 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
       end
 
       let(:make_request) do
-        patch classification_configuration_path(config_name),
+        patch configuration_path(config_name),
               params: {
-                classification_configuration: {
+                configuration: {
                   value: "Updated prompt text",
                 },
               }
       end
 
-      it { is_expected.to redirect_to(classification_configuration_path(config_name)) }
+      it { is_expected.to redirect_to(configuration_path(config_name)) }
 
       it "shows a historical version alert" do
         rendered_page
@@ -966,7 +966,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(collection_response)
       end
 
-      let(:make_request) { get classification_configurations_path }
+      let(:make_request) { get configurations_path }
 
       it { is_expected.to have_http_status :forbidden }
     end
@@ -981,7 +981,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(collection_response)
       end
 
-      let(:make_request) { get classification_configurations_path }
+      let(:make_request) { get configurations_path }
 
       it { is_expected.to have_http_status :success }
     end
@@ -992,7 +992,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(config_response)
       end
 
-      let(:make_request) { get edit_classification_configuration_path(config_name) }
+      let(:make_request) { get edit_configuration_path(config_name) }
 
       it { is_expected.to have_http_status :forbidden }
     end
@@ -1004,8 +1004,8 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
       end
 
       let(:make_request) do
-        patch classification_configuration_path(config_name),
-              params: { classification_configuration: { value: "Updated prompt text" } }
+        patch configuration_path(config_name),
+              params: { configuration: { value: "Updated prompt text" } }
       end
 
       it { is_expected.to have_http_status :forbidden }
@@ -1021,7 +1021,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(collection_response)
       end
 
-      let(:make_request) { get classification_configurations_path }
+      let(:make_request) { get configurations_path }
 
       it { is_expected.to have_http_status :success }
     end
@@ -1032,7 +1032,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
           .and_return(config_response)
       end
 
-      let(:make_request) { get edit_classification_configuration_path(config_name) }
+      let(:make_request) { get edit_configuration_path(config_name) }
 
       it { is_expected.to have_http_status :forbidden }
     end
@@ -1044,8 +1044,8 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
       end
 
       let(:make_request) do
-        patch classification_configuration_path(config_name),
-              params: { classification_configuration: { value: "Updated prompt text" } }
+        patch configuration_path(config_name),
+              params: { configuration: { value: "Updated prompt text" } }
       end
 
       it { is_expected.to have_http_status :forbidden }
@@ -1054,7 +1054,7 @@ RSpec.describe ClassificationConfigurationsController, type: :request do
 
   context "when user is guest (unauthorized)" do
     let(:current_user) { create(:user, :guest) }
-    let(:make_request) { get classification_configurations_path }
+    let(:make_request) { get configurations_path }
 
     it { is_expected.to have_http_status :forbidden }
   end

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -123,8 +123,8 @@ RSpec.describe DescriptionInterceptsController, type: :request do
         page = Capybara.string(rendered_page.body)
 
         expect(page).to have_text("No templates are currently configured.")
-        expect(rendered_page.body).to include("Classification configurations")
-        expect(rendered_page.body).to include(classification_configuration_path("description_intercept_templates"))
+        expect(rendered_page.body).to include("Configurations")
+        expect(rendered_page.body).to include(configuration_path("description_intercept_templates"))
         expect(rendered_page.body).to include('disabled="disabled"')
         expect(rendered_page.body).to include('value="Import description intercepts"')
       end


### PR DESCRIPTION
# Pull Request

## What:

- [x] Rename the classification configuration controller, routes, views and request specs to the general configuration naming
- [x] Promote Configuration from the Classification sub-navigation to a standalone top-level section
- [x] Enforce `AdminConfigurationPolicy#index?` when deciding whether the standalone section is visible
- [x] Update version and description-intercept links to use the renamed configuration route
- [x] Verify the change with the full 1,785-example RSpec suite and all pre-commit hooks

## Why:

Admin configuration is no longer specific to classification, so it should use general naming and have its own navigation section. The standalone section must retain the existing configuration policy restrictions so it is not shown to HMRC Admin or Guest users.

## Ticket:

N/A

## Risk:

**Risk level:** 🟠

**Reason for rating:** This renames an existing admin route and changes where Configuration appears in navigation. The underlying authorization policy is unchanged, and the new standalone navigation entry now applies it explicitly.