### PR TITLE
Disable automatic commodity code links on description intercepts

### DIFF
--- a/app/views/description_intercepts/_form.html.erb
+++ b/app/views/description_intercepts/_form.html.erb
@@ -159,16 +159,11 @@
                             :message,
                             label: { text: "Guidance message" },
                             hint: { text: "Shown to the trader-facing frontend when this intercept matches." },
-                            rows: 5,
-                            linkify_code_references: true do %>
-      <%= govuk_details(summary_text: "Markdown and automatic short code links") do %>
+                            rows: 5 do %>
+      <%= govuk_details(summary_text: "Markdown formatting") do %>
         <p class="govuk-body">
-          Short codes are automatically rendered as links in the frontend. You do not need to add markdown links for
-          chapters, headings, subheadings or commodities.
-        </p>
-        <p class="govuk-body">
-          For example, <code>01</code>, <code>0101</code>, <code>010121</code> and <code>0101210000</code> will be linked
-          automatically.
+          Commodity codes are not linked automatically. Add markdown links yourself when a chapter, heading,
+          subheading or commodity should be clickable.
         </p>
         <p class="govuk-body">
           Use the

--- a/app/views/description_intercepts/show.html.erb
+++ b/app/views/description_intercepts/show.html.erb
@@ -41,7 +41,7 @@
       <dt class="govuk-summary-list__key">Guidance</dt>
       <dd class="govuk-summary-list__value">
         <div class="hott-markdown-preview">
-          <%= @description_intercept.preview(linkify_code_references: true) %>
+          <%= @description_intercept.preview %>
         </div>
       </dd>
     </div>

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -412,18 +412,15 @@ RSpec.describe DescriptionInterceptsController, type: :request do
 
       expect(page).to have_css ".govuk-grid-row .govuk-grid-column-one-half", count: 2
       expect(page).to have_css 'textarea.govuk-textarea[name="description_intercept[message]"]'
-      expect(page).to have_css '.hott-markdown-preview[data-preview="govspeak"][data-preview-for="#description-intercept-message-field"][data-preview-linkify-code-references="true"]'
+      expect(page).to have_css '.hott-markdown-preview[data-preview="govspeak"][data-preview-for="#description-intercept-message-field"]'
+      expect(page).not_to have_css '.hott-markdown-preview[data-preview-linkify-code-references="true"]'
     end
 
-    it "explains markdown and automatic short code links in a details component" do
+    it "explains markdown formatting in a details component" do
       page = Capybara.string(rendered_page.body)
 
-      expect(page).to have_css ".govuk-details__summary-text", text: "Markdown and automatic short code links"
-      expect(page).to have_css ".govuk-details__text", text: "Short codes are automatically rendered as links", visible: :all
-      expect(page).to have_css ".govuk-details__text", text: "01", visible: :all
-      expect(page).to have_css ".govuk-details__text", text: "0101", visible: :all
-      expect(page).to have_css ".govuk-details__text", text: "010121", visible: :all
-      expect(page).to have_css ".govuk-details__text", text: "0101210000", visible: :all
+      expect(page).to have_css ".govuk-details__summary-text", text: "Markdown formatting"
+      expect(page).to have_css ".govuk-details__text", text: "Commodity codes are not linked automatically", visible: :all
       expect(page).to have_link "Markdown guide", href: "https://govspeak-preview.publishing.service.gov.uk/guide", visible: :all
     end
 

--- a/spec/requests/description_intercepts_controller_spec.rb
+++ b/spec/requests/description_intercepts_controller_spec.rb
@@ -413,7 +413,7 @@ RSpec.describe DescriptionInterceptsController, type: :request do
       expect(page).to have_css ".govuk-grid-row .govuk-grid-column-one-half", count: 2
       expect(page).to have_css 'textarea.govuk-textarea[name="description_intercept[message]"]'
       expect(page).to have_css '.hott-markdown-preview[data-preview="govspeak"][data-preview-for="#description-intercept-message-field"]'
-      expect(page).not_to have_css '.hott-markdown-preview[data-preview-linkify-code-references="true"]'
+      expect(page).not_to have_css '.hott-markdown-preview[data-preview-for="#description-intercept-message-field"][data-preview-linkify-code-references="true"]'
     end
 
     it "explains markdown formatting in a details component" do


### PR DESCRIPTION
## What:
- [x] Turn off goods nomenclature code autolinking for description intercept guidance preview and editor
- [x] Update the form guidance so editors know codes are not linked automatically
- [x] Keep chapter/section note autolinking unchanged

## Why:
Description intercept guidance should not auto-link commodity codes. Editors need to add explicit markdown links when a code should be clickable, matching the frontend rendering behaviour.

## Ticket:
N/A

## Risk:

**Risk level:** 🟢

**Reason for rating:** Admin-only copy and preview behaviour for description intercepts. Chapter/section note linkification is unchanged, and request specs cover the form guidance.