### PR TITLE
Show Restore button for the original version

### DIFF
--- a/app/views/versions/_history_table.html.erb
+++ b/app/views/versions/_history_table.html.erb
@@ -43,13 +43,11 @@
         <td class="govuk-table__cell" style="<%= cell_style %>"><%= version.created_at_formatted %></td>
         <% if defined?(can_restore) && can_restore %>
           <td class="govuk-table__cell" style="<%= cell_style %>">
-            <% unless version.event == 'create' %>
-              <%= button_to "Restore",
-                            restore_path_helper.call(version),
-                            method: :post,
-                            class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-0",
-                            data: { module: "govuk-button", confirm: "Restore to this version? The current values will be overwritten." } %>
-            <% end %>
+            <%= button_to "Restore",
+                          restore_path_helper.call(version),
+                          method: :post,
+                          class: "govuk-button govuk-button--secondary govuk-!-margin-bottom-0",
+                          data: { module: "govuk-button", confirm: "Restore to this version? The current values will be overwritten." } %>
           </td>
         <% end %>
         <% if defined?(view_path_helper) && view_path_helper %>

--- a/spec/views/versions/_history_table.html.erb_spec.rb
+++ b/spec/views/versions/_history_table.html.erb_spec.rb
@@ -1,0 +1,39 @@
+RSpec.describe "versions/_history_table" do
+  subject(:rendered_page) { render_page && rendered }
+
+  let(:render_page) do
+    render "versions/history_table",
+           versions:,
+           can_restore: true,
+           restore_path_helper: ->(version) { "/versions/#{version.resource_id}/restore" },
+           view_path_helper: nil,
+           current_oid: nil
+  end
+
+  let(:create_version) { Version.new(resource_id: 1, event: "create", whodunnit: nil, created_at: "2025-06-14T09:00:00Z", object: {}) }
+  let(:update_version) { Version.new(resource_id: 2, event: "update", whodunnit: nil, created_at: "2025-06-15T10:00:00Z", object: {}, changeset: { "changed_fields" => %w[term], "changes" => {} }) }
+  let(:versions) { [update_version, create_version] }
+
+  it "renders a Restore button for the original (create) version, same as later versions" do
+    expect(rendered_page).to have_css "form[action='/versions/1/restore'] button", text: "Restore"
+  end
+
+  it "renders a Restore button for later (update) versions" do
+    expect(rendered_page).to have_css "form[action='/versions/2/restore'] button", text: "Restore"
+  end
+
+  context "when can_restore is false" do
+    let(:render_page) do
+      render "versions/history_table",
+             versions:,
+             can_restore: false,
+             restore_path_helper: nil,
+             view_path_helper: nil,
+             current_oid: nil
+    end
+
+    it "renders no Restore buttons at all" do
+      expect(rendered_page).to have_no_button "Restore"
+    end
+  end
+end


### PR DESCRIPTION
# Pull Request

## What:
Removes a guard in the shared version-history partial (`app/views/versions/_history_table.html.erb`) that was hiding the Restore button on a record's original ("create") version row. Every later ("update") version already had a working Restore button - only the very first one was missing it.

## Why:
The guard assumed the real PaperTrail gem's behaviour, where a create event doesn't store a full snapshot and so can't be restored to. This codebase actually uses a custom Sequel plugin that stores a full snapshot on every event, including create, so the original version was restorable all along - it just had no button to trigger it. The backend restore endpoint already handles this correctly; this was purely a missing button in the UI.

Since the fix lives in the one shared partial, it applies uniformly everywhere version history is shown: chapter and section notes, labels, self-texts, admin configuration, and description intercepts - none of those pages re-implement the restore logic themselves.

Added a view spec covering the partial directly: Restore now renders for both create and update events, and still renders nothing when the user isn't authorised to restore.

## Ticket:
AI-1084

## Risk:

**Risk level:** 🟢

**Reason for rating:** One line removed from an existing UI partial, restoring a button that calls the same restore endpoint and authorisation check already used (and already working) for every other version row. No new API calls, no auth changes, and full test coverage added.

<img width="557" height="784" alt="image" src="https://github.com/user-attachments/assets/b20bf281-ee3d-4773-b24a-8445e37d2e75" />
